### PR TITLE
feat: extend Blatt-Weisskopf to L <= 8

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -8,6 +8,15 @@
   url = {https://pdg.lbl.gov/2010/reviews/rpp2010-rev-dalitz-analysis-formalism.pdf}
 }
 
+@techreport{chungFormulasAngularMomentumBarrier2015,
+  title = {Formulas for {{Angular}}-{{Momentum Barrier Factors}} ({{Version II}})},
+  author = {Chung, Suh-Urk},
+  year = {2015},
+  month = mar,
+  institution = {{Brookhaven National Laboratory}},
+  url = {https://physique.cuso.ch/fileadmin/physique/document/2015_chung_pwaform1.pdf}
+}
+
 @article{chungPartialWaveAnalysis1995,
   title = {{Partial wave analysis in 𝐾-matrix formalism}},
   author = {Chung, Suh-Urk and Brose, J. and Hackmann, R. and Klempt, E. and Spanier, S. and Strassburger, C.},

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -134,6 +134,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-input",
      "keep_output"
@@ -143,10 +146,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle B_L\\left(q\\right)$"
+       "$\\displaystyle B_L\\left(q\\right)^{2}$"
       ],
       "text/plain": [
-       "BlattWeisskopf(q, d, L)"
+       "BlattWeisskopf(q, d, L)**2"
       ]
      },
      "metadata": {},
@@ -155,10 +158,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\begin{cases} 1 & \\text{for}\\: L = 0 \\\\\\frac{2 d^{2} q^{2}}{d^{2} q^{2} + 1} & \\text{for}\\: L = 1 \\\\\\frac{13 d^{4} q^{4}}{9 d^{2} q^{2} + \\left(d^{2} q^{2} - 3\\right)^{2}} & \\text{for}\\: L = 2 \\\\\\frac{277 d^{6} q^{6}}{d^{2} q^{2} \\left(d^{2} q^{2} - 15\\right)^{2} + \\left(2 d^{2} q^{2} - 5\\right) \\left(18 d^{2} q^{2} - 45\\right)} & \\text{for}\\: L = 3 \\\\\\frac{12746 d^{8} q^{8}}{25 d^{2} q^{2} \\left(2 d^{2} q^{2} - 21\\right)^{2} + \\left(d^{4} q^{4} - 45 d^{2} q^{2} + 105\\right)^{2}} & \\text{for}\\: L = 4 \\end{cases}$"
+       "$\\displaystyle \\begin{cases} 1 & \\text{for}\\: L = 0 \\\\\\frac{2 z}{z + 1} & \\text{for}\\: L = 1 \\\\\\frac{13 z^{2}}{9 z + \\left(z - 3\\right)^{2}} & \\text{for}\\: L = 2 \\\\\\frac{277 z^{3}}{z \\left(z - 15\\right)^{2} + \\left(2 z - 5\\right) \\left(18 z - 45\\right)} & \\text{for}\\: L = 3 \\\\\\frac{12746 z^{4}}{25 z \\left(2 z - 21\\right)^{2} + \\left(z^{2} - 45 z + 105\\right)^{2}} & \\text{for}\\: L = 4 \\\\\\frac{998881 z^{5}}{z^{5} + 15 z^{4} + 315 z^{3} + 6300 z^{2} + 99225 z + 893025} & \\text{for}\\: L = 5 \\\\\\frac{118394977 z^{6}}{z^{6} + 21 z^{5} + 630 z^{4} + 18900 z^{3} + 496125 z^{2} + 9823275 z + 108056025} & \\text{for}\\: L = 6 \\\\\\frac{19727003738 z^{7}}{z^{7} + 28 z^{6} + 1134 z^{5} + 47250 z^{4} + 1819125 z^{3} + 58939650 z^{2} + 1404728325 z + 18261468225} & \\text{for}\\: L = 7 \\\\\\frac{4392846440677 z^{8}}{z^{8} + 36 z^{7} + 1890 z^{6} + 103950 z^{5} + 5457375 z^{4} + 255405150 z^{3} + 9833098275 z^{2} + 273922023375 z + 4108830350625} & \\text{for}\\: L = 8 \\end{cases}$"
       ],
       "text/plain": [
-       "Piecewise((1, Eq(L, 0)), (2*d**2*q**2/(d**2*q**2 + 1), Eq(L, 1)), (13*d**4*q**4/(9*d**2*q**2 + (d**2*q**2 - 3)**2), Eq(L, 2)), (277*d**6*q**6/(d**2*q**2*(d**2*q**2 - 15)**2 + (2*d**2*q**2 - 5)*(18*d**2*q**2 - 45)), Eq(L, 3)), (12746*d**8*q**8/(25*d**2*q**2*(2*d**2*q**2 - 21)**2 + (d**4*q**4 - 45*d**2*q**2 + 105)**2), Eq(L, 4)))"
+       "Piecewise((1, Eq(L, 0)), (2*z/(z + 1), Eq(L, 1)), (13*z**2/(9*z + (z - 3)**2), Eq(L, 2)), (277*z**3/(z*(z - 15)**2 + (2*z - 5)*(18*z - 45)), Eq(L, 3)), (12746*z**4/(25*z*(2*z - 21)**2 + (z**2 - 45*z + 105)**2), Eq(L, 4)), (998881*z**5/(z**5 + 15*z**4 + 315*z**3 + 6300*z**2 + 99225*z + 893025), Eq(L, 5)), (118394977*z**6/(z**6 + 21*z**5 + 630*z**4 + 18900*z**3 + 496125*z**2 + 9823275*z + 108056025), Eq(L, 6)), (19727003738*z**7/(z**7 + 28*z**6 + 1134*z**5 + 47250*z**4 + 1819125*z**3 + 58939650*z**2 + 1404728325*z + 18261468225), Eq(L, 7)), (4392846440677*z**8/(z**8 + 36*z**7 + 1890*z**6 + 103950*z**5 + 5457375*z**4 + 255405150*z**3 + 9833098275*z**2 + 273922023375*z + 4108830350625), Eq(L, 8)))"
       ]
      },
      "metadata": {
@@ -171,10 +174,17 @@
     }
    ],
    "source": [
-    "q, d, L = sp.symbols(\"q, d, L\", real=True)\n",
-    "ff = BlattWeisskopf(q, d, L)\n",
-    "display(ff)\n",
-    "myst_nb.glue(\"BlattWeisskopf\", ff.doit())"
+    "z, q, d, L = sp.symbols(\"z, q, d, L\", real=True)\n",
+    "ff2 = BlattWeisskopf(q, d, L) ** 2\n",
+    "display(ff2)\n",
+    "myst_nb.glue(\"BlattWeisskopf\", ff2.doit().subs({(d * q) ** 2: z}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "with $z = (dq)^2$."
    ]
   },
   {
@@ -274,10 +284,10 @@
     {
      "data": {
       "text/latex": [
-       "$\\displaystyle \\frac{\\Gamma m_{0}^{2} \\sqrt{\\frac{\\left(m^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m^{2}}}}{m \\sqrt{\\frac{\\left(m_{0}^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m_{0}^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m_{0}^{2}}} \\left(- \\frac{i \\Gamma m_{0}^{2} \\sqrt{\\frac{\\left(m^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m^{2}}}}{m \\sqrt{\\frac{\\left(m_{0}^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m_{0}^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m_{0}^{2}}}} - m^{2} + m_{0}^{2}\\right)}$"
+       "$\\displaystyle \\frac{\\Gamma m_{0}}{- \\frac{i \\Gamma m_{0}^{2} \\sqrt{\\frac{\\left(m^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m^{2}}}}{m \\sqrt{\\frac{\\left(m_{0}^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m_{0}^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m_{0}^{2}}}} - m^{2} + m_{0}^{2}}$"
       ],
       "text/plain": [
-       "Gamma*m0**2*sqrt((m**2 - (m_a - m_b)**2)*(m**2 - (m_a + m_b)**2)/m**2)/(m*sqrt((m0**2 - (m_a - m_b)**2)*(m0**2 - (m_a + m_b)**2)/m0**2)*(-I*Gamma*m0**2*sqrt((m**2 - (m_a - m_b)**2)*(m**2 - (m_a + m_b)**2)/m**2)/(m*sqrt((m0**2 - (m_a - m_b)**2)*(m0**2 - (m_a + m_b)**2)/m0**2)) - m**2 + m0**2))"
+       "Gamma*m0/(-I*Gamma*m0**2*sqrt((m**2 - (m_a - m_b)**2)*(m**2 - (m_a + m_b)**2)/m**2)/(m*sqrt((m0**2 - (m_a - m_b)**2)*(m0**2 - (m_a + m_b)**2)/m0**2)) - m**2 + m0**2)"
       ]
      },
      "metadata": {

--- a/src/ampform/dynamics/lineshape.py
+++ b/src/ampform/dynamics/lineshape.py
@@ -63,7 +63,7 @@ def implement_expr(
 
 @implement_expr(n_args=3)
 class BlattWeisskopf(UnevaluatedExpression):
-    r"""Blatt-Weisskopf function :math:`B_L`, up to :math:`L \leq 8`.
+    r"""Blatt-Weisskopf function :math:`B_L(q)`, up to :math:`L \leq 8`.
 
     Args:
         q: Break-up momentum. Can be computed with `breakup_momentum`.
@@ -71,8 +71,13 @@ class BlattWeisskopf(UnevaluatedExpression):
             order 1 fm.
         angular_momentum: Angular momentum :math:`L` of the decaying particle.
 
+    Function :math:`B_L(q)` is defined as:
+
     .. glue:math:: BlattWeisskopf
         :label: BlattWeisskopf
+
+    with :math:`z = (d q)^2`. The impact parameter :math:`d` is usually fixed,
+    so not shown as a function argument.
 
     Each of these cases has been taken from
     :cite:`chungPartialWaveAnalysis1995`, p. 415, and

--- a/src/ampform/dynamics/lineshape.py
+++ b/src/ampform/dynamics/lineshape.py
@@ -63,7 +63,7 @@ def implement_expr(
 
 @implement_expr(n_args=3)
 class BlattWeisskopf(UnevaluatedExpression):
-    r"""Blatt-Weisskopf function :math:`B_L`, up to :math:`L \leq 4`.
+    r"""Blatt-Weisskopf function :math:`B_L`, up to :math:`L \leq 8`.
 
     Args:
         q: Break-up momentum. Can be computed with `breakup_momentum`.
@@ -75,8 +75,9 @@ class BlattWeisskopf(UnevaluatedExpression):
         :label: BlattWeisskopf
 
     Each of these cases has been taken from
-    :cite:`chungPartialWaveAnalysis1995`, p. 415. For a good overview of where
-    to use these Blatt-Weisskopf functions, see
+    :cite:`chungPartialWaveAnalysis1995`, p. 415, and
+    :cite:`chungFormulasAngularMomentumBarrier2015`. For a good overview of
+    where to use these Blatt-Weisskopf functions, see
     :cite:`asnerDalitzPlotAnalysis2006`.
 
     See also :ref:`usage/dynamics/lineshapes:Form factor`.
@@ -134,6 +135,64 @@ class BlattWeisskopf(UnevaluatedExpression):
                         )
                     ),
                     sp.Eq(angular_momentum, 4),
+                ),
+                (
+                    998881
+                    * z ** 5
+                    / (
+                        z ** 5
+                        + 15 * z ** 4
+                        + 315 * z ** 3
+                        + 6300 * z ** 2
+                        + 99225 * z
+                        + 893025
+                    ),
+                    sp.Eq(angular_momentum, 5),
+                ),
+                (
+                    118394977
+                    * z ** 6
+                    / (
+                        z ** 6
+                        + 21 * z ** 5
+                        + 630 * z ** 4
+                        + 18900 * z ** 3
+                        + 496125 * z ** 2
+                        + 9823275 * z
+                        + 108056025
+                    ),
+                    sp.Eq(angular_momentum, 6),
+                ),
+                (
+                    19727003738
+                    * z ** 7
+                    / (
+                        z ** 7
+                        + 28 * z ** 6
+                        + 1134 * z ** 5
+                        + 47250 * z ** 4
+                        + 1819125 * z ** 3
+                        + 58939650 * z ** 2
+                        + 1404728325 * z
+                        + 18261468225
+                    ),
+                    sp.Eq(angular_momentum, 7),
+                ),
+                (
+                    4392846440677
+                    * z ** 8
+                    / (
+                        z ** 8
+                        + 36 * z ** 7
+                        + 1890 * z ** 6
+                        + 103950 * z ** 5
+                        + 5457375 * z ** 4
+                        + 255405150 * z ** 3
+                        + 9833098275 * z ** 2
+                        + 273922023375 * z
+                        + 4108830350625
+                    ),
+                    sp.Eq(angular_momentum, 8),
                 ),
             )
         )


### PR DESCRIPTION
- Improved rendering of the `BlattWeisskopf` in the API and the lineshape notebook
- Extended the Blatt-Weisskopf definition to angular momentum of up to 8