### PR TITLE
docs: improve custom dynamics instructions

### DIFF
--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -43,24 +43,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "import inspect\n",
-    "from typing import Dict, Tuple\n",
-    "\n",
     "import graphviz\n",
     "import qrules as q\n",
-    "import sympy as sp\n",
-    "from ampform.dynamics.builder import (\n",
-    "    ResonanceDynamicsBuilder,\n",
-    "    TwoBodyKinematicVariableSet,\n",
-    "    create_relativistic_breit_wigner,\n",
-    ")\n",
-    "from qrules.particle import Particle"
+    "import sympy as sp"
    ]
   },
   {
@@ -126,6 +120,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import inspect\n",
+    "\n",
+    "from ampform.dynamics.builder import (\n",
+    "    ResonanceDynamicsBuilder,\n",
+    "    create_relativistic_breit_wigner,\n",
+    ")\n",
+    "\n",
     "print(inspect.getsource(ResonanceDynamicsBuilder))\n",
     "print(inspect.getsource(create_relativistic_breit_wigner))"
    ]
@@ -180,6 +181,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import Dict, Tuple\n",
+    "\n",
+    "from ampform.dynamics.builder import TwoBodyKinematicVariableSet\n",
+    "from qrules.particle import Particle\n",
+    "\n",
+    "\n",
     "def create_my_dynamics(\n",
     "    particle: Particle, variable_pool: TwoBodyKinematicVariableSet\n",
     ") -> Tuple[sp.Expr, Dict[sp.Symbol, float]]:\n",

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -185,14 +185,16 @@
     ") -> Tuple[sp.Expr, Dict[sp.Symbol, float]]:\n",
     "    res_mass = sp.Symbol(f\"m_{particle.name}\")\n",
     "    res_width = sp.Symbol(f\"sigma_{particle.name}\")\n",
-    "    return (\n",
-    "        my_dynamics(\n",
-    "            x=variable_pool.in_edge_inv_mass,\n",
-    "            mu=res_mass,\n",
-    "            sigma=res_width,\n",
-    "        ),\n",
-    "        {res_mass: particle.mass, res_width: particle.width},\n",
-    "    )"
+    "    expression = my_dynamics(\n",
+    "        x=variable_pool.in_edge_inv_mass,\n",
+    "        mu=res_mass,\n",
+    "        sigma=res_width,\n",
+    "    )\n",
+    "    parameter_defaults = {\n",
+    "        res_mass: particle.mass,\n",
+    "        res_width: particle.width,\n",
+    "    }\n",
+    "    return expression, parameter_defaults"
    ]
   },
   {

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -64,14 +64,12 @@ def create_relativistic_breit_wigner(
     inv_mass = variable_pool.in_edge_inv_mass
     res_mass = sp.Symbol(f"m_{particle.name}")
     res_width = sp.Symbol(f"Gamma_{particle.name}")
-    return (
-        relativistic_breit_wigner(
-            inv_mass,
-            res_mass,
-            res_width,
-        ),
-        {res_mass: particle.mass, res_width: particle.width},
-    )
+    expression = relativistic_breit_wigner(inv_mass, res_mass, res_width)
+    parameter_defaults = {
+        res_mass: particle.mass,
+        res_width: particle.width,
+    }
+    return expression, parameter_defaults
 
 
 def create_relativistic_breit_wigner_with_ff(
@@ -90,18 +88,21 @@ def create_relativistic_breit_wigner_with_ff(
     angular_momentum = variable_pool.angular_momentum
     meson_radius = sp.Symbol(f"d_{particle.name}")
 
-    return (
-        relativistic_breit_wigner_with_ff(
-            inv_mass,
-            res_mass,
-            res_width,
-            product1_inv_mass,
-            product2_inv_mass,
-            angular_momentum,
-            meson_radius,
-        ),
-        {res_mass: particle.mass, res_width: particle.width, meson_radius: 1},
+    expression = relativistic_breit_wigner_with_ff(
+        inv_mass,
+        res_mass,
+        res_width,
+        product1_inv_mass,
+        product2_inv_mass,
+        angular_momentum,
+        meson_radius,
     )
+    parameter_defaults = {
+        res_mass: particle.mass,
+        res_width: particle.width,
+        meson_radius: 1,
+    }
+    return expression, parameter_defaults
 
 
 class ResonanceDynamicsBuilder(Protocol):


### PR DESCRIPTION
Made the custom dynamics instructions a bit more user-friendly by:
- putting the `import` statements where they are used (for copy-button)
- clarifying what the output of a custom dynamics builder is by declaring an `expression` and `parameter_defaults` parameter