### PR TITLE
ci: standardize cspell config

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
         "parmater"
     ],
     "ignorePaths": [
+        "**/.cspell.json",
         "*.bib",
         "*.ico",
         "*.root",
@@ -31,7 +32,6 @@
         ".vscode/.gitignore",
         "Makefile",
         "codecov.yml",
-        "cspell.json",
         "docs/_templates/*",
         "docs/adr/*/*",
         "docs/conf.py",

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,6 @@ indent_size = 2
 indent_size = 2
 
 # when adding words through vscode, this is the resulting output format
-[cspell.json]
+[.cspell.json]
 indent_size = 4
 insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pyvenv*/
 **.code-workspace
 
 # Exceptions
+!.cspell.json
 !.github/*.yml
 !.github/*/*.yml
 !.gitpod.yml
@@ -49,6 +50,5 @@ pyvenv*/
 !.readthedocs.yml
 !.vscode/*.json
 !codecov.yml
-!cspell.json
 !environment.yml
 !pyrightconfig.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
       - id: end-of-file-fixer
         exclude: >
           (?x)^(
-            cspell.json|
             .*\.bib|
-            .*\.svg
+            .*\.svg|
+            \.cspell\.json
           )$
       - id: mixed-line-ending
       - id: name-tests-test
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.4
+    rev: 0.0.5
     hooks:
       - id: check-dev-files
       - id: fix-first-nbcell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.3
+    rev: 0.0.4
     hooks:
       - id: check-dev-files
       - id: fix-first-nbcell

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-*.inc
-cspell.json
+.cspell.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,6 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cSpell.customFolderDictionaries": ["cspell.json"],
   "cSpell.enabled": true,
   "coverage-gutters.coverageFileNames": ["coverage.xml"],
   "coverage-gutters.coverageReportFileName": "**/htmlcov/index.html",

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -64,7 +64,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -10,7 +10,7 @@ apipkg==1.5
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
-astroid==2.5.2
+astroid==2.5.3
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.0
@@ -47,7 +47,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 idna==2.10
 imagesize==1.2.0
 immutables==0.15
@@ -89,7 +89,7 @@ mpmath==1.2.1
 mypy-extensions==0.4.3
 mypy==0.812
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclassic==0.2.7
 nbclient==0.5.3
 nbconvert==5.6.1
@@ -136,7 +136,6 @@ pytest-xdist==2.2.1
 pytest==6.2.3
 python-constraint==1.4.0
 python-dateutil==2.8.1
-pytoml==0.1.21
 pytz==2021.1
 pyyaml==5.4.1
 pyzmq==22.0.3
@@ -158,7 +157,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -169,7 +168,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
 stdlib-list==0.8.0
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 toml==0.10.2
@@ -177,7 +176,7 @@ tornado==6.1
 tox==3.23.0
 tqdm==4.60.0
 traitlets==4.3.3
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -40,7 +40,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -55,7 +55,7 @@ mdit-py-plugins==0.2.6
 mistune==0.8.4
 mpmath==1.2.1
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
@@ -99,7 +99,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -109,7 +109,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.6/requirements-extras.txt
+++ b/reqs/3.6/requirements-extras.txt
@@ -18,7 +18,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.1

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -6,7 +6,7 @@
 #
 apipkg==1.5
 appdirs==1.4.4
-astroid==2.5.2
+astroid==2.5.3
 attrs==20.3.0
 black==20.8b1
 cfgv==3.2.0
@@ -26,7 +26,7 @@ flake8-rst-docstrings==0.0.14
 flake8==3.9.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 importlib-metadata==3.10.0
 importlib-resources==3.0.0
 iniconfig==1.1.1
@@ -68,11 +68,11 @@ regex==2021.4.4
 restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 traitlets==4.3.3
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.6/requirements-test.txt
+++ b/reqs/3.6/requirements-test.txt
@@ -31,7 +31,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.6/requirements.txt
+++ b/reqs/3.6/requirements.txt
@@ -17,7 +17,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.1

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -60,7 +60,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -10,7 +10,7 @@ apipkg==1.5
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
-astroid==2.5.2
+astroid==2.5.3
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.0
@@ -45,7 +45,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.10.0
@@ -85,7 +85,7 @@ mpmath==1.2.1
 mypy-extensions==0.4.3
 mypy==0.812
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclassic==0.2.7
 nbclient==0.5.3
 nbconvert==5.6.1
@@ -132,7 +132,6 @@ pytest-xdist==2.2.1
 pytest==6.2.3
 python-constraint==1.4.0
 python-dateutil==2.8.1
-pytoml==0.1.21
 pytz==2021.1
 pyyaml==5.4.1
 pyzmq==22.0.3
@@ -154,7 +153,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -165,7 +164,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
 stdlib-list==0.8.0
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 toml==0.10.2
@@ -173,7 +172,7 @@ tornado==6.1
 tox==3.23.0
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -38,7 +38,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -53,7 +53,7 @@ mdit-py-plugins==0.2.6
 mistune==0.8.4
 mpmath==1.2.1
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
@@ -97,7 +97,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -107,7 +107,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.7/requirements-extras.txt
+++ b/reqs/3.7/requirements-extras.txt
@@ -17,7 +17,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.1

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -6,7 +6,7 @@
 #
 apipkg==1.5
 appdirs==1.4.4
-astroid==2.5.2
+astroid==2.5.3
 attrs==20.3.0
 black==20.8b1
 cfgv==3.2.0
@@ -24,7 +24,7 @@ flake8-rst-docstrings==0.0.14
 flake8==3.9.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 importlib-metadata==3.10.0
 iniconfig==1.1.1
 ipython-genutils==0.2.0
@@ -65,11 +65,11 @@ regex==2021.4.4
 restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.7/requirements-test.txt
+++ b/reqs/3.7/requirements-test.txt
@@ -30,7 +30,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.7/requirements.txt
+++ b/reqs/3.7/requirements.txt
@@ -16,7 +16,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.1

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -60,7 +60,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -10,7 +10,7 @@ apipkg==1.5
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
-astroid==2.5.2
+astroid==2.5.3
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.0
@@ -45,7 +45,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.10.0
@@ -85,7 +85,7 @@ mpmath==1.2.1
 mypy-extensions==0.4.3
 mypy==0.812
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclassic==0.2.7
 nbclient==0.5.3
 nbconvert==5.6.1
@@ -132,7 +132,6 @@ pytest-xdist==2.2.1
 pytest==6.2.3
 python-constraint==1.4.0
 python-dateutil==2.8.1
-pytoml==0.1.21
 pytz==2021.1
 pyyaml==5.4.1
 pyzmq==22.0.3
@@ -154,7 +153,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -165,7 +164,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
 stdlib-list==0.8.0
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 toml==0.10.2
@@ -173,7 +172,7 @@ tornado==6.1
 tox==3.23.0
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -38,7 +38,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -53,7 +53,7 @@ mdit-py-plugins==0.2.6
 mistune==0.8.4
 mpmath==1.2.1
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
@@ -97,7 +97,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -107,7 +107,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.8/requirements-extras.txt
+++ b/reqs/3.8/requirements-extras.txt
@@ -16,7 +16,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -6,7 +6,7 @@
 #
 apipkg==1.5
 appdirs==1.4.4
-astroid==2.5.2
+astroid==2.5.3
 attrs==20.3.0
 black==20.8b1
 cfgv==3.2.0
@@ -24,7 +24,7 @@ flake8-rst-docstrings==0.0.14
 flake8==3.9.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 isort==5.8.0
@@ -64,11 +64,11 @@ regex==2021.4.4
 restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.8/requirements-test.txt
+++ b/reqs/3.8/requirements-test.txt
@@ -29,7 +29,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 

--- a/reqs/3.8/requirements.txt
+++ b/reqs/3.8/requirements.txt
@@ -15,7 +15,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -60,7 +60,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -10,7 +10,7 @@ apipkg==1.5
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
-astroid==2.5.2
+astroid==2.5.3
 async-generator==1.10
 attrs==20.3.0
 babel==2.9.0
@@ -45,7 +45,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.10.0
@@ -85,7 +85,7 @@ mpmath==1.2.1
 mypy-extensions==0.4.3
 mypy==0.812
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclassic==0.2.7
 nbclient==0.5.3
 nbconvert==5.6.1
@@ -132,7 +132,6 @@ pytest-xdist==2.2.1
 pytest==6.2.3
 python-constraint==1.4.0
 python-dateutil==2.8.1
-pytoml==0.1.21
 pytz==2021.1
 pyyaml==5.4.1
 pyzmq==22.0.3
@@ -154,7 +153,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -165,7 +164,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
 stdlib-list==0.8.0
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 toml==0.10.2
@@ -173,7 +172,7 @@ tornado==6.1
 tox==3.23.0
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -38,7 +38,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -53,7 +53,7 @@ mdit-py-plugins==0.2.6
 mistune==0.8.4
 mpmath==1.2.1
 myst-nb==0.12.0
-myst-parser==0.13.5
+myst-parser==0.13.6
 nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
@@ -97,7 +97,7 @@ sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8
 sphinx-togglebutton==0.2.3
-sphinx==3.5.3
+sphinx==3.5.4
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-bibtex==2.2.0
 sphinxcontrib-devhelp==1.0.2
@@ -107,7 +107,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.24
-sympy==1.7.1
+sympy==1.8
 terminado==0.9.4
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.9/requirements-extras.txt
+++ b/reqs/3.9/requirements-extras.txt
@@ -16,7 +16,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/reqs/3.9/requirements-sty.txt
+++ b/reqs/3.9/requirements-sty.txt
@@ -6,7 +6,7 @@
 #
 apipkg==1.5
 appdirs==1.4.4
-astroid==2.5.2
+astroid==2.5.3
 attrs==20.3.0
 black==20.8b1
 cfgv==3.2.0
@@ -24,7 +24,7 @@ flake8-rst-docstrings==0.0.14
 flake8==3.9.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.2.2
+identify==2.2.3
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 isort==5.8.0
@@ -64,11 +64,11 @@ regex==2021.4.4
 restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.9/requirements-test.txt
+++ b/reqs/3.9/requirements-test.txt
@@ -29,7 +29,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 toml==0.10.2
 tqdm==4.60.0
 

--- a/reqs/3.9/requirements.txt
+++ b/reqs/3.9/requirements.txt
@@ -15,7 +15,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 qrules==0.8.0a1
 six==1.15.0
-sympy==1.7.1
+sympy==1.8
 tqdm==4.60.0
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Use the new `check-dev-files` hook to rename and format the `.cspell.json` file.