### PR TITLE
fix: only render gif if it has been generated

### DIFF
--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -455,8 +455,9 @@
    "source": [
     "%%capture\n",
     "# Export for Read the Docs\n",
+    "output_path = \"animation.gif\"\n",
     "if STATIC_WEB_PAGE:\n",
-    "    controls.save_animation(\"animation.gif\", fig, \"m_f980\", fps=25)"
+    "    controls.save_animation(output_path, fig, \"m_f980\", fps=25)"
    ]
   },
   {
@@ -473,12 +474,20 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": [
+     "remove-input"
+    ]
    },
+   "outputs": [],
    "source": [
-    "![animation](./animation.gif)"
+    "if STATIC_WEB_PAGE:\n",
+    "    from IPython.display import Image\n",
+    "\n",
+    "    with open(output_path, \"rb\") as f:\n",
+    "        display(Image(data=f.read(), format=\"png\"))"
    ]
   }
  ],

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -305,8 +305,8 @@
    "source": [
     "import os\n",
     "\n",
-    "MAKE_INTERACTIVE = not {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)\n",
-    "if not MAKE_INTERACTIVE:\n",
+    "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)\n",
+    "if STATIC_WEB_PAGE:\n",
     "    m_f980_values = np.linspace(0.8, 2.2, 100)\n",
     "    m_f980_values = np.concatenate((m_f980_values, np.flip(m_f980_values[1:])))"
    ]
@@ -455,7 +455,7 @@
    "source": [
     "%%capture\n",
     "# Export for Read the Docs\n",
-    "if not MAKE_INTERACTIVE:\n",
+    "if STATIC_WEB_PAGE:\n",
     "    controls.save_animation(\"animation.gif\", fig, \"m_f980\", fps=25)"
    ]
   },


### PR DESCRIPTION
Addendum to #23. It fixes problems like [this one](https://readthedocs.org/projects/ampform/builds/13499438/) on RTD, as well as when running `tox -e doc` locally.