### PR TITLE
fix: define testpaths in pytest.ini

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,6 +41,7 @@
         "docs/conf.py",
         "pyproject.toml",
         "pyrightconfig.json",
+        "pytest.ini",
         "requirements*.txt",
         "setup.cfg",
         "setup.py",

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: pip install -c .constraints/py38.txt -e .
+  - init: pip install -c .constraints/py3.8.txt -e .
 
 github:
   prebuilds:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.11
+    rev: 0.0.12
     hooks:
       - id: check-dev-files
       - id: fix-first-nbcell

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,17 @@
+[coverage:run]
+branch = True
+source = src
+
+[pytest]
+addopts =
+    --color=yes
+    --doctest-continue-on-failure
+    --doctest-modules
+    --durations=3
+filterwarnings =
+    error
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+testpaths =
+    src
+    tests

--- a/tox.ini
+++ b/tox.ini
@@ -108,19 +108,3 @@ allowlist_externals =
 commands =
     mypy src tests # run separately because of potential caching problems
     pre-commit run {posargs} -a
-
-[coverage:run]
-branch = True
-source = src
-
-[pytest]
-addopts =
-    --color=yes
-    --doctest-continue-on-failure
-    --doctest-modules
-    --durations=3
-    --ignore docs/conf.py
-filterwarnings =
-    error
-markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Since 35aa838, it is become impossible to run tests through VSCode. Defining testpaths fixes this. In addition, it removes the last
'non-tox' section from the tox.ini file (see 81402eb).

See also https://github.com/ComPWA/qrules/pull/42