### PR TITLE
build: move nbstripout to pre-commit

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -102,7 +102,6 @@ nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==3.0.0
 nbformat==5.1.3
-nbstripout==0.4.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.3.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -98,7 +98,6 @@ nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==3.0.0
 nbformat==5.1.3
-nbstripout==0.4.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.3.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -98,7 +98,6 @@ nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==3.0.0
 nbformat==5.1.3
-nbstripout==0.4.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.3.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -98,7 +98,6 @@ nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==3.0.0
 nbformat==5.1.3
-nbstripout==0.4.0
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.3.0

--- a/.cspell.json
+++ b/.cspell.json
@@ -166,7 +166,6 @@
         "nbformat",
         "nbody",
         "nbsphinx",
-        "nbstripout",
         "ndarray",
         "noqa",
         "nrows",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,11 @@ repos:
       - id: nbqa-isort
         args: [--nbqa-mutate]
 
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.4.0
+    hooks:
+      - id: nbstripout
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.1
     hooks:
@@ -79,7 +84,7 @@ repos:
         language_version: 12.18.2 # prettier does not specify node correctly
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.134
+    rev: v1.1.135
     hooks:
       - id: pyright
 
@@ -115,13 +120,6 @@ repos:
         language: system
         types:
           - python
-
-      - id: nbstripout
-        name: nbstripout
-        entry: nbstripout
-        language: system
-        types:
-          - jupyter
 
       - id: pydocstyle
         name: pydocstyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ test =
 format =
     black
     isort
-    nbstripout
 lint =
     flake8
     flake8-blind-except


### PR DESCRIPTION
Pre-commit hooks should only be local if the corresponding tool can also be used through other applications (e.g. IDEs or Jupyter Lab), so that their versions are in sync. And `nbstripout` can only be used through the terminal, so is best enforced through pre-commit only.