### PR TITLE
docs: remove myst-nb glue cells

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,6 +36,4 @@ rst-directives =
     deprecated,
     envvar,
     exception,
-    glue:figure,
-    glue:math,
     seealso,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,10 @@ if os.path.exists(f"../src/{package}/version.py"):
     __release = get_distribution(package).version
     version = ".".join(__release.split(".")[:3])
 
-# -- Generate API skeleton ----------------------------------------------------
+# -- Generate API ------------------------------------------------------------
+sys.path.insert(0, os.path.abspath("."))
+import extend_docstrings
+
 shutil.rmtree("api", ignore_errors=True)
 subprocess.call(
     " ".join(

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -1,0 +1,69 @@
+# flake8: noqa
+# pylint: disable=invalid-name
+
+"""Extend docstrings of the API.
+
+This small script is used by ``conf.py`` to dynamically modify docstrings.
+"""
+
+import textwrap
+from typing import Callable, Type, Union
+
+import sympy as sp
+
+from ampform.dynamics import (
+    BlattWeisskopf,
+    relativistic_breit_wigner,
+    relativistic_breit_wigner_with_ff,
+)
+
+
+def update_docstring(
+    class_type: Union[Callable, Type], appended_text: str
+) -> None:
+    appended_text = textwrap.indent(appended_text, prefix=4 * " ")
+    assert class_type.__doc__ is not None
+    class_type.__doc__ += appended_text
+
+
+L = sp.Symbol("L", integer=True)
+z = sp.Symbol("z", real=True)
+ff2 = BlattWeisskopf(L, z) ** 2
+update_docstring(
+    BlattWeisskopf,
+    f"""
+
+.. math:: {sp.latex(ff2)} = {sp.latex(ff2.doit())}
+""",
+)
+
+
+m, m0, w0 = sp.symbols("m m0 Gamma", real=True)
+rel_bw = relativistic_breit_wigner(m, m0, w0)
+update_docstring(
+    relativistic_breit_wigner,
+    f"""
+
+.. math:: {sp.latex(rel_bw)}
+""",
+)
+
+
+m, m0, w0, ma, mb, d = sp.symbols("m m0 Gamma m_a m_b d", real=True)
+rel_bw_with_ff = relativistic_breit_wigner_with_ff(
+    mass=m,
+    mass0=m0,
+    gamma0=w0,
+    m_a=ma,
+    m_b=mb,
+    angular_momentum=0,
+    meson_radius=d,
+)
+update_docstring(
+    relativistic_breit_wigner_with_ff,
+    f"""
+For :math:`L=0`, this lineshape has the following form:
+
+.. math:: {sp.latex(rel_bw_with_ff.doit())}
+""",
+)

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -45,9 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
-    "The formulas and figures on this page have been generated with the lineshapes in the {mod}`.dynamics` module, so as to [glue](https://myst-nb.readthedocs.io/en/latest/use/glue.html) them back in to the API of that module.\n",
-    "```"
+    "AmpForm provides a few common lineshapes through the {mod}`.dynamics` module. This pages shows some of the properties of these lineshapes. It's also possible to insert {doc}`custom lineshapes <custom>` into the amplitude model."
    ]
   },
   {
@@ -63,7 +61,6 @@
    },
    "outputs": [],
    "source": [
-    "import myst_nb\n",
     "import sympy as sp"
    ]
   },
@@ -131,53 +128,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
-     "hide-input",
-     "keep_output"
+     "hide-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle B_L\\left(z\\right)^{2}$"
-      ],
-      "text/plain": [
-       "BlattWeisskopf(L, z)**2"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\begin{cases} 1 & \\text{for}\\: L = 0 \\\\\\frac{2 z}{z + 1} & \\text{for}\\: L = 1 \\\\\\frac{13 z^{2}}{9 z + \\left(z - 3\\right)^{2}} & \\text{for}\\: L = 2 \\\\\\frac{277 z^{3}}{z \\left(z - 15\\right)^{2} + \\left(2 z - 5\\right) \\left(18 z - 45\\right)} & \\text{for}\\: L = 3 \\\\\\frac{12746 z^{4}}{25 z \\left(2 z - 21\\right)^{2} + \\left(z^{2} - 45 z + 105\\right)^{2}} & \\text{for}\\: L = 4 \\\\\\frac{998881 z^{5}}{z^{5} + 15 z^{4} + 315 z^{3} + 6300 z^{2} + 99225 z + 893025} & \\text{for}\\: L = 5 \\\\\\frac{118394977 z^{6}}{z^{6} + 21 z^{5} + 630 z^{4} + 18900 z^{3} + 496125 z^{2} + 9823275 z + 108056025} & \\text{for}\\: L = 6 \\\\\\frac{19727003738 z^{7}}{z^{7} + 28 z^{6} + 1134 z^{5} + 47250 z^{4} + 1819125 z^{3} + 58939650 z^{2} + 1404728325 z + 18261468225} & \\text{for}\\: L = 7 \\\\\\frac{4392846440677 z^{8}}{z^{8} + 36 z^{7} + 1890 z^{6} + 103950 z^{5} + 5457375 z^{4} + 255405150 z^{3} + 9833098275 z^{2} + 273922023375 z + 4108830350625} & \\text{for}\\: L = 8 \\end{cases}$"
-      ],
-      "text/plain": [
-       "Piecewise((1, Eq(L, 0)), (2*z/(z + 1), Eq(L, 1)), (13*z**2/(9*z + (z - 3)**2), Eq(L, 2)), (277*z**3/(z*(z - 15)**2 + (2*z - 5)*(18*z - 45)), Eq(L, 3)), (12746*z**4/(25*z*(2*z - 21)**2 + (z**2 - 45*z + 105)**2), Eq(L, 4)), (998881*z**5/(z**5 + 15*z**4 + 315*z**3 + 6300*z**2 + 99225*z + 893025), Eq(L, 5)), (118394977*z**6/(z**6 + 21*z**5 + 630*z**4 + 18900*z**3 + 496125*z**2 + 9823275*z + 108056025), Eq(L, 6)), (19727003738*z**7/(z**7 + 28*z**6 + 1134*z**5 + 47250*z**4 + 1819125*z**3 + 58939650*z**2 + 1404728325*z + 18261468225), Eq(L, 7)), (4392846440677*z**8/(z**8 + 36*z**7 + 1890*z**6 + 103950*z**5 + 5457375*z**4 + 255405150*z**3 + 9833098275*z**2 + 273922023375*z + 4108830350625), Eq(L, 8)))"
-      ]
-     },
-     "metadata": {
-      "scrapbook": {
-       "mime_prefix": "",
-       "name": "BlattWeisskopf"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ampform.dynamics import BlattWeisskopf\n",
     "\n",
     "L = sp.Symbol(\"L\", integer=True)\n",
     "z = sp.Symbol(\"z\", real=True)\n",
     "ff2 = BlattWeisskopf(L, z) ** 2\n",
-    "display(ff2)\n",
-    "myst_nb.glue(\"BlattWeisskopf\", ff2.doit())"
+    "display(ff2, ff2.doit())"
    ]
   },
   {
@@ -206,43 +168,24 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input",
-     "keep_output"
+     "hide-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\frac{\\Gamma m_{0}}{- i \\Gamma m_{0} - m^{2} + m_{0}^{2}}$"
-      ],
-      "text/plain": [
-       "Gamma*m0/(-I*Gamma*m0 - m**2 + m0**2)"
-      ]
-     },
-     "metadata": {
-      "scrapbook": {
-       "mime_prefix": "",
-       "name": "relativistic_breit_wigner"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ampform.dynamics import relativistic_breit_wigner\n",
     "\n",
     "m, m0, w0 = sp.symbols(\"m m0 Gamma\", real=True)\n",
-    "myst_nb.glue(\n",
-    "    \"relativistic_breit_wigner\",\n",
-    "    relativistic_breit_wigner(m, m0, w0),\n",
-    ")"
+    "relativistic_breit_wigner(m, m0, w0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-input"
     ]
@@ -263,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See {func}`.relativistic_breit_wigner_with_ff`:"
+    "See {func}`.relativistic_breit_wigner_with_ff`. For $L=0$, the shape is:"
    ]
   },
   {
@@ -271,51 +214,32 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input",
-     "keep_output"
+     "hide-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\frac{\\Gamma m_{0}}{- \\frac{i \\Gamma m_{0}^{2} \\sqrt{\\frac{\\left(m^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m^{2}}}}{m \\sqrt{\\frac{\\left(m_{0}^{2} - \\left(m_{a} - m_{b}\\right)^{2}\\right) \\left(m_{0}^{2} - \\left(m_{a} + m_{b}\\right)^{2}\\right)}{m_{0}^{2}}}} - m^{2} + m_{0}^{2}}$"
-      ],
-      "text/plain": [
-       "Gamma*m0/(-I*Gamma*m0**2*sqrt((m**2 - (m_a - m_b)**2)*(m**2 - (m_a + m_b)**2)/m**2)/(m*sqrt((m0**2 - (m_a - m_b)**2)*(m0**2 - (m_a + m_b)**2)/m0**2)) - m**2 + m0**2)"
-      ]
-     },
-     "metadata": {
-      "scrapbook": {
-       "mime_prefix": "",
-       "name": "relativistic_breit_wigner_with_ff"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ampform.dynamics import relativistic_breit_wigner_with_ff\n",
     "\n",
-    "m, m0, w0, ma, mb, meson_radius = sp.symbols(\"m m0 Gamma m_a m_b d\", real=True)\n",
-    "myst_nb.glue(\n",
-    "    \"relativistic_breit_wigner_with_ff\",\n",
-    "    relativistic_breit_wigner_with_ff(\n",
-    "        mass=m,\n",
-    "        mass0=m0,\n",
-    "        gamma0=w0,\n",
-    "        m_a=ma,\n",
-    "        m_b=mb,\n",
-    "        angular_momentum=0,\n",
-    "        meson_radius=meson_radius,\n",
-    "    ).doit(),\n",
-    ")"
+    "m, m0, w0, ma, mb, d = sp.symbols(\"m m0 Gamma m_a m_b d\", real=True)\n",
+    "relativistic_breit_wigner_with_ff(\n",
+    "    mass=m,\n",
+    "    mass0=m0,\n",
+    "    gamma0=w0,\n",
+    "    m_a=ma,\n",
+    "    m_b=mb,\n",
+    "    angular_momentum=0,\n",
+    "    meson_radius=d,\n",
+    ").doit()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-input"
     ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ addopts =
     --doctest-continue-on-failure
     --doctest-modules
     --durations=3
+    --ignore=docs/conf.py
 filterwarnings =
     error
 norecursedirs =

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -24,12 +24,7 @@ class BlattWeisskopf(UnevaluatedExpression):
             choice is :math:`z = (d q)^2` with :math:`d` the impact parameter
             and :math:`q` the `breakup_momentum`.
 
-    Function :math:`B_L(z)` is defined as:
-
-    .. glue:math:: BlattWeisskopf
-        :label: BlattWeisskopf
-
-    Each of these cases has been taken from
+    Each of these casesfor :math:`L` has been taken from
     :cite:`chungPartialWaveAnalysis1995`, p. 415, and
     :cite:`chungFormulasAngularMomentumBarrier2015`. For a good overview of
     where to use these Blatt-Weisskopf functions, see
@@ -160,9 +155,6 @@ def relativistic_breit_wigner(
 ) -> sp.Expr:
     """Relativistic Breit-Wigner lineshape.
 
-    .. glue:math:: relativistic_breit_wigner
-        :label: relativistic_breit_wigner
-
     See :ref:`usage/dynamics/lineshapes:_Without_ form factor` and
     :cite:`asnerDalitzPlotAnalysis2006`.
     """
@@ -179,11 +171,6 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     meson_radius: sp.Symbol,
 ) -> sp.Expr:
     """Relativistic Breit-Wigner with `.BlattWeisskopf` factor.
-
-    For :math:`L=0`, this lineshape has the following form:
-
-    .. glue:math:: relativistic_breit_wigner_with_ff
-        :label: relativistic_breit_wigner_with_ff
 
     See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
     :cite:`asnerDalitzPlotAnalysis2006`.


### PR DESCRIPTION
The `lineshapes` notebook was used to insert a mathematical rendering of the implementations in the dynamics module into its docstrings. This has some disadvantages:

- Output cells have to be updated whenever some implementation. This could be countered with pytest-notebook, but that is bothersome if a notebook generates figures.

- The link between the module and that notebook is note immediately clear.

The math is now inserted through Sphinx only (through `conf.py`), which makes it easier to extend the `dynamics` module with more lineshapes and render their mathematics.