### PR TITLE
docs: improve math in dynamics API

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -13,6 +13,7 @@ import sympy as sp
 
 from ampform.dynamics import (
     BlattWeisskopf,
+    breakup_momentum,
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
 )
@@ -32,8 +33,17 @@ ff2 = BlattWeisskopf(L, z) ** 2
 update_docstring(
     BlattWeisskopf,
     f"""
-
 .. math:: {sp.latex(ff2)} = {sp.latex(ff2.doit())}
+    :label: BlattWeisskopf
+""",
+)
+
+m, m_a, m_b = sp.symbols("m m_a m_b")
+q = breakup_momentum(m, m_a, m_b)
+update_docstring(
+    breakup_momentum,
+    f"""
+.. math:: q^2(m) = {sp.latex(q ** 2)}
 """,
 )
 
@@ -43,7 +53,6 @@ rel_bw = relativistic_breit_wigner(m, m0, w0)
 update_docstring(
     relativistic_breit_wigner,
     f"""
-
 .. math:: {sp.latex(rel_bw)}
 """,
 )

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -44,21 +44,23 @@ update_docstring(
     breakup_momentum,
     f"""
 .. math:: q^2(m) = {sp.latex(q ** 2)}
+    :label: breakup_momentum
 """,
 )
 
 
-m, m0, w0 = sp.symbols("m m0 Gamma", real=True)
+m, m0, w0 = sp.symbols("m m0 Gamma")
 rel_bw = relativistic_breit_wigner(m, m0, w0)
 update_docstring(
     relativistic_breit_wigner,
     f"""
 .. math:: {sp.latex(rel_bw)}
+    :label: relativistic_breit_wigner
 """,
 )
 
 
-m, m0, w0, ma, mb, d = sp.symbols("m m0 Gamma m_a m_b d", real=True)
+m, m0, w0, ma, mb, d = sp.symbols("m m0 Gamma m_a m_b d")
 rel_bw_with_ff = relativistic_breit_wigner_with_ff(
     mass=m,
     mass0=m0,
@@ -68,11 +70,23 @@ rel_bw_with_ff = relativistic_breit_wigner_with_ff(
     angular_momentum=0,
     meson_radius=d,
 )
+q = breakup_momentum(m, m_a, m_b)
+q0 = breakup_momentum(m0, m_a, m_b)
+rel_bw_with_ff = rel_bw_with_ff.subs(
+    {
+        2 * q: sp.Symbol("q^{2}(m)"),
+        2 * q0: sp.Symbol("q^{2}(m_0)"),
+    }
+)
 update_docstring(
     relativistic_breit_wigner_with_ff,
     f"""
-For :math:`L=0`, this lineshape has the following form:
+For :math:`L=0`, a relativistic Breit-Wigner with `.BlattWeisskopf` form factor
+has the following form:
 
 .. math:: {sp.latex(rel_bw_with_ff.doit())}
+    :label: relativistic_breit_wigner_with_ff
+
+where :math:`q^2(m)` is defined by :eq:`breakup_momentum`.
 """,
 )

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -67,26 +67,31 @@ rel_bw_with_ff = relativistic_breit_wigner_with_ff(
     gamma0=w0,
     m_a=ma,
     m_b=mb,
-    angular_momentum=0,
+    angular_momentum=L,
     meson_radius=d,
 )
 q = breakup_momentum(m, m_a, m_b)
 q0 = breakup_momentum(m0, m_a, m_b)
+ff = BlattWeisskopf(L, z=(q * d) ** 2)
+ff0 = BlattWeisskopf(L, z=(q0 * d) ** 2)
 rel_bw_with_ff = rel_bw_with_ff.subs(
     {
         2 * q: sp.Symbol("q^{2}(m)"),
         2 * q0: sp.Symbol("q^{2}(m_0)"),
+        ff: sp.Symbol("B_{L}(q)"),
+        ff0: sp.Symbol("B_{L}(q_{0})"),
     }
 )
 update_docstring(
     relativistic_breit_wigner_with_ff,
     f"""
-For :math:`L=0`, a relativistic Breit-Wigner with `.BlattWeisskopf` form factor
-has the following form:
+The general form of a relativistic Breit-Wigner with `.BlattWeisskopf` form
+factor is:
 
-.. math:: {sp.latex(rel_bw_with_ff.doit())}
-    :label: relativistic_breit_wigner_with_ff
+.. math:: {sp.latex(rel_bw_with_ff)}
+    :label: relativistic_breit_wigner_with_ff_general
 
-where :math:`q^2(m)` is defined by :eq:`breakup_momentum`.
+where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf` and :math:`q^2(m)` is
+defined by :eq:`breakup_momentum`.
 """,
 )


### PR DESCRIPTION
#42 makes it easier to dynamically generate latex for the math in behind the `dynamics` module. This makes it easier to cross-reference the formulas as follows:
<details>
<summary>Screenshot of generated API</summary>

![image](https://user-images.githubusercontent.com/29308176/116678800-0c403100-a9aa-11eb-8272-ed6a80a072ea.png)

</details>

It now also becomes easier to extract for instance running width (both in coding and in math definitions).