### PR TITLE
refactor: extract function for coupled width

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -14,6 +14,7 @@ import sympy as sp
 from ampform.dynamics import (
     BlattWeisskopf,
     breakup_momentum,
+    coupled_width,
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
 )
@@ -48,6 +49,42 @@ update_docstring(
 """,
 )
 
+m, m0, w0, ma, mb, d = sp.symbols("m m0 Gamma m_a m_b d")
+running_width = coupled_width(
+    mass=m,
+    mass0=m0,
+    gamma0=w0,
+    m_a=ma,
+    m_b=mb,
+    angular_momentum=L,
+    meson_radius=d,
+)
+q = breakup_momentum(m, m_a, m_b)
+q0 = breakup_momentum(m0, m_a, m_b)
+ff = BlattWeisskopf(L, z=(q * d) ** 2)
+ff0 = BlattWeisskopf(L, z=(q0 * d) ** 2)
+running_width = running_width.subs(
+    {
+        2 * q: sp.Symbol("q^{2}(m)"),
+        2 * q0: sp.Symbol("q^{2}(m_0)"),
+        ff: sp.Symbol("B_{L}(q)"),
+        ff0: sp.Symbol("B_{L}(q_{0})"),
+    }
+)
+update_docstring(
+    coupled_width,
+    fR"""
+AmpForm uses the following shape for the "mass-dependent" width in a
+`.relativistic_breit_wigner_with_ff`:
+
+.. math:: \Gamma(m) = {sp.latex(running_width)}
+    :label: coupled_width
+
+where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf` and :math:`q^2(m)` is
+defined by :eq:`breakup_momentum`.
+""",
+)
+
 
 m, m0, w0 = sp.symbols("m m0 Gamma")
 rel_bw = relativistic_breit_wigner(m, m0, w0)
@@ -71,27 +108,26 @@ rel_bw_with_ff = relativistic_breit_wigner_with_ff(
     meson_radius=d,
 )
 q = breakup_momentum(m, m_a, m_b)
-q0 = breakup_momentum(m0, m_a, m_b)
 ff = BlattWeisskopf(L, z=(q * d) ** 2)
-ff0 = BlattWeisskopf(L, z=(q0 * d) ** 2)
+mass_dependent_width = coupled_width(m, m0, w0, m_a, m_b, L, d)
 rel_bw_with_ff = rel_bw_with_ff.subs(
     {
         2 * q: sp.Symbol("q^{2}(m)"),
-        2 * q0: sp.Symbol("q^{2}(m_0)"),
-        ff: sp.Symbol("B_{L}(q)"),
-        ff0: sp.Symbol("B_{L}(q_{0})"),
+        ff: sp.Symbol(R"B_{L}\left(q(m)\right)"),
+        mass_dependent_width: sp.Symbol(R"\Gamma(m)"),
     }
 )
 update_docstring(
     relativistic_breit_wigner_with_ff,
-    f"""
+    fR"""
 The general form of a relativistic Breit-Wigner with `.BlattWeisskopf` form
 factor is:
 
 .. math:: {sp.latex(rel_bw_with_ff)}
     :label: relativistic_breit_wigner_with_ff_general
 
-where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf` and :math:`q^2(m)` is
-defined by :eq:`breakup_momentum`.
+where :math:`\Gamma(m)` is defined by :eq:`coupled_width`, :math:`B_L(q)` is
+defined by :eq:`BlattWeisskopf`, and :math:`q^2(m)` is defined by
+:eq:`breakup_momentum`.
 """,
 )

--- a/docs/usage/k-matrix.ipynb
+++ b/docs/usage/k-matrix.ipynb
@@ -76,14 +76,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Mass-dependent width"
+    "## Amplitude definition"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In both the $K$-matrix and the relativistic Breit-Wigner, it is important to use a _mass-dependent width_ (also called _running width_). This width makes use of {class}`.BlattWeisskopf` barrier factors. Those factors depend on angular momentum $L$, meson radius $d$, and the masses of the decay products $m_a$ and $m_b$:"
+    "A $K$-matrix for two poles and one channel can be parametrized as follows:"
    ]
   },
   {
@@ -100,69 +100,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ampform.dynamics import BlattWeisskopf, breakup_momentum\n",
-    "\n",
-    "\n",
-    "def running_width(m, m0, gamma0):\n",
-    "    q = breakup_momentum(m, m_a, m_b)\n",
-    "    q0 = breakup_momentum(m0, m_a, m_b)\n",
-    "    form_factor = BlattWeisskopf(L, z=(q * d) ** 2)\n",
-    "    form_factor0 = BlattWeisskopf(L, z=(q0 * d) ** 2)\n",
-    "    return (\n",
-    "        gamma0 * (m0 / m) * (form_factor ** 2 / form_factor0 ** 2) * (q / q0)\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "m, m0, gamma0 = sp.symbols(\"m, m0, Gamma0\")\n",
-    "q = breakup_momentum(m, m_a, m_b)\n",
-    "q0 = breakup_momentum(m0, m_a, m_b)\n",
-    "form_factor = BlattWeisskopf(L, z=(q * d) ** 2)\n",
-    "form_factor0 = BlattWeisskopf(L, z=(q0 * d) ** 2)\n",
-    "running_width(m, m0, gamma0).subs(\n",
-    "    {\n",
-    "        form_factor ** 2: sp.Symbol(\"B^{2}_{L}(q)\"),\n",
-    "        form_factor0 ** 2: sp.Symbol(\"B^{2}_{L}(q_0)\"),\n",
-    "    },\n",
-    ").subs(\n",
-    "    {\n",
-    "        2 * q: sp.Symbol(\"q\"),\n",
-    "        2 * q0: sp.Symbol(\"q0\"),\n",
-    "    },\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Amplitude definition"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A $K$-matrix for two poles and one channel reduces to the following:\n",
-    "\n",
-    "\n",
     "```{margin}\n",
     "{cite}`meyerMatrixTutorial2018`, slide 14\n",
     "```"
@@ -174,9 +114,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from ampform.dynamics import coupled_width\n",
+    "\n",
+    "\n",
     "def kmatrix_term(m, m1, gamma1, m2, gamma2):\n",
-    "    running_gamma1 = running_width(m, m1, gamma1)\n",
-    "    running_gamma2 = running_width(m, m2, gamma2)\n",
+    "    running_gamma1 = coupled_width(m, m1, gamma1, m_a, m_b, L, d)\n",
+    "    running_gamma2 = coupled_width(m, m2, gamma2, m_a, m_b, L, d)\n",
     "    return (m1 * running_gamma1) / (\n",
     "        (m1 ** 2 - m ** 2)\n",
     "        - sp.I * m1 * running_gamma1\n",
@@ -204,8 +147,8 @@
    },
    "outputs": [],
    "source": [
-    "running_gamma1 = running_width(m, m1, gamma1)\n",
-    "running_gamma2 = running_width(m, m2, gamma2)\n",
+    "running_gamma1 = coupled_width(m, m1, gamma1, m_a, m_b, L, d)\n",
+    "running_gamma2 = coupled_width(m, m2, gamma2, m_a, m_b, L, d)\n",
     "kmatrix.subs(\n",
     "    {\n",
     "        running_gamma1: sp.Symbol(R\"\\Gamma_{1}(m)\"),\n",
@@ -218,7 +161,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Two Breit-Wigner 'poles' with the same parameters would look like this (making use of {func}`.relativistic_breit_wigner_with_ff`:"
+    "where $\\Gamma(m)$ is the {func}`.coupled_width`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two Breit-Wigner 'poles' with the same parameters would look like this (making use of {func}`.relativistic_breit_wigner_with_ff`):"
    ]
   },
   {
@@ -247,8 +197,8 @@
    },
    "outputs": [],
    "source": [
-    "running_gamma1 = running_width(m, m1, gamma1)\n",
-    "running_gamma2 = running_width(m, m2, gamma2)\n",
+    "from ampform.dynamics import BlattWeisskopf, breakup_momentum\n",
+    "\n",
     "q = breakup_momentum(m, m_a, m_b)\n",
     "ff = BlattWeisskopf(L, z=(q * d) ** 2)\n",
     "bw.subs(\n",
@@ -258,6 +208,13 @@
     "        ff: sp.Symbol(\"B_{L}(q)\"),\n",
     "    },\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "with $B_L(q)$ a {class}`.BlattWeisskopf` barrier factor and $q(m)$ the {func}`.breakup_momentum`."
    ]
   },
   {

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -176,14 +176,9 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     :cite:`asnerDalitzPlotAnalysis2006`.
     """
     q = breakup_momentum(mass, m_a, m_b)
-    q0 = breakup_momentum(mass0, m_a, m_b)
     form_factor = BlattWeisskopf(angular_momentum, z=(q * meson_radius) ** 2)
-    form_factor0 = BlattWeisskopf(angular_momentum, z=(q0 * meson_radius) ** 2)
-    mass_dependent_width = (
-        gamma0
-        * (mass0 / mass)
-        * (form_factor ** 2 / form_factor0 ** 2)
-        * (q / q0)
+    mass_dependent_width = coupled_width(
+        mass, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius
     )
     return (mass0 * gamma0 * form_factor) / (
         mass0 ** 2 - mass ** 2 - mass_dependent_width * mass0 * sp.I
@@ -205,4 +200,30 @@ def breakup_momentum(
         (m_r ** 2 - (m_a + m_b) ** 2)
         * (m_r ** 2 - (m_a - m_b) ** 2)
         / (4 * m_r ** 2)
+    )
+
+
+def coupled_width(  # pylint: disable=too-many-arguments
+    mass: sp.Symbol,
+    mass0: sp.Symbol,
+    gamma0: sp.Symbol,
+    m_a: sp.Symbol,
+    m_b: sp.Symbol,
+    angular_momentum: sp.Symbol,
+    meson_radius: sp.Symbol,
+) -> sp.Expr:
+    """Mass-dependent width, coupled to the pole position of the resonance.
+
+    See :pdg-review:`2020; Resonances; p.6` and
+    :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
+    """
+    q = breakup_momentum(mass, m_a, m_b)
+    q0 = breakup_momentum(mass0, m_a, m_b)
+    form_factor = BlattWeisskopf(angular_momentum, z=(q * meson_radius) ** 2)
+    form_factor0 = BlattWeisskopf(angular_momentum, z=(q0 * meson_radius) ** 2)
+    return (
+        gamma0
+        * (mass0 / mass)
+        * (form_factor ** 2 / form_factor0 ** 2)
+        * (q / q0)
     )


### PR DESCRIPTION
The running width / coupled width / mass dependent width used in `relativisitc_breit_wigner_with_ff` is useful to _K_-matrix and Flatté. It's now exposed as a separate function:

![image](https://user-images.githubusercontent.com/29308176/116707244-baf66880-a9ce-11eb-9136-76ea6c061805.png)
