### PR TITLE
refactor: return square value of break-up momentum

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -43,7 +43,7 @@ flake8-comprehensions==3.4.0
 flake8-plugin-utils==1.3.1
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.4.1
-flake8-rst-docstrings==0.2.2
+flake8-rst-docstrings==0.2.3
 flake8-use-fstring==1.1
 flake8==3.9.1
 future==0.18.2
@@ -130,7 +130,7 @@ pycparser==2.20
 pydata-sphinx-theme==0.6.3
 pydocstyle==6.0.0
 pyflakes==2.3.1
-pygments==2.8.1
+pygments==2.9.0
 pylint==2.8.2
 pyparsing==2.4.7
 pyrsistent==0.17.3

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -41,7 +41,7 @@ flake8-comprehensions==3.4.0
 flake8-plugin-utils==1.3.1
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.4.1
-flake8-rst-docstrings==0.2.2
+flake8-rst-docstrings==0.2.3
 flake8-use-fstring==1.1
 flake8==3.9.1
 future==0.18.2
@@ -128,7 +128,7 @@ pycparser==2.20
 pydata-sphinx-theme==0.6.3
 pydocstyle==6.0.0
 pyflakes==2.3.1
-pygments==2.8.1
+pygments==2.9.0
 pylint==2.8.2
 pyparsing==2.4.7
 pyrsistent==0.17.3

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -41,7 +41,7 @@ flake8-comprehensions==3.4.0
 flake8-plugin-utils==1.3.1
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.4.1
-flake8-rst-docstrings==0.2.2
+flake8-rst-docstrings==0.2.3
 flake8-use-fstring==1.1
 flake8==3.9.1
 future==0.18.2
@@ -128,7 +128,7 @@ pycparser==2.20
 pydata-sphinx-theme==0.6.3
 pydocstyle==6.0.0
 pyflakes==2.3.1
-pygments==2.8.1
+pygments==2.9.0
 pylint==2.8.2
 pyparsing==2.4.7
 pyrsistent==0.17.3

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -41,7 +41,7 @@ flake8-comprehensions==3.4.0
 flake8-plugin-utils==1.3.1
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.4.1
-flake8-rst-docstrings==0.2.2
+flake8-rst-docstrings==0.2.3
 flake8-use-fstring==1.1
 flake8==3.9.1
 future==0.18.2
@@ -128,7 +128,7 @@ pycparser==2.20
 pydata-sphinx-theme==0.6.3
 pydocstyle==6.0.0
 pyflakes==2.3.1
-pygments==2.8.1
+pygments==2.9.0
 pylint==2.8.2
 pyparsing==2.4.7
 pyrsistent==0.17.3

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -13,7 +13,7 @@ import sympy as sp
 
 from ampform.dynamics import (
     BlattWeisskopf,
-    breakup_momentum,
+    breakup_momentum_squared,
     coupled_width,
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
@@ -42,12 +42,12 @@ def render_blatt_weisskopf() -> None:
 
 def render_breakup_momentum() -> None:
     m, m_a, m_b = sp.symbols("m m_a m_b")
-    q = breakup_momentum(m, m_a, m_b)
+    q_squared = breakup_momentum_squared(m, m_a, m_b)
     update_docstring(
-        breakup_momentum,
+        breakup_momentum_squared,
         f"""
-    .. math:: q^2(m) = {sp.latex(q ** 2)}
-        :label: breakup_momentum
+    .. math:: q^2(m) = {sp.latex(q_squared)}
+        :label: breakup_momentum_squared
     """,
     )
 
@@ -64,14 +64,16 @@ def render_coupled_width() -> None:
         angular_momentum=L,
         meson_radius=d,
     )
-    q = breakup_momentum(m, m_a, m_b)
-    q0 = breakup_momentum(m0, m_a, m_b)
-    ff = BlattWeisskopf(L, z=(q * d) ** 2)
-    ff0 = BlattWeisskopf(L, z=(q0 * d) ** 2)
+    q_squared = breakup_momentum_squared(m, m_a, m_b)
+    q0_squared = breakup_momentum_squared(m0, m_a, m_b)
+    q = sp.sqrt(q_squared)
+    q0 = sp.sqrt(q0_squared)
+    ff = BlattWeisskopf(L, z=q_squared * d ** 2)
+    ff0 = BlattWeisskopf(L, z=q0_squared * d ** 2)
     running_width = running_width.subs(
         {
-            2 * q: sp.Symbol("q^{2}(m)"),
-            2 * q0: sp.Symbol("q^{2}(m_0)"),
+            2 * q: sp.Symbol("q(m)"),
+            2 * q0: sp.Symbol("q(m_0)"),
             ff: sp.Symbol("B_{L}(q)"),
             ff0: sp.Symbol("B_{L}(q_{0})"),
         }
@@ -86,7 +88,7 @@ def render_coupled_width() -> None:
         :label: coupled_width
 
     where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf` and :math:`q^2(m)`
-    is defined by :eq:`breakup_momentum`.
+    is defined by :eq:`breakup_momentum_squared`.
     """,
     )
 
@@ -115,12 +117,12 @@ def render_relativistic_breit_wigner_with_ff() -> None:
         angular_momentum=L,
         meson_radius=d,
     )
-    q = breakup_momentum(m, m_a, m_b)
-    ff = BlattWeisskopf(L, z=(q * d) ** 2)
+    q_squared = breakup_momentum_squared(m, m_a, m_b)
+    ff = BlattWeisskopf(L, z=q_squared * d ** 2)
     mass_dependent_width = coupled_width(m, m0, w0, m_a, m_b, L, d)
     rel_bw_with_ff = rel_bw_with_ff.subs(
         {
-            2 * q: sp.Symbol("q^{2}(m)"),
+            2 * q_squared: sp.Symbol("q^{2}(m)"),
             ff: sp.Symbol(R"B_{L}\left(q(m)\right)"),
             mass_dependent_width: sp.Symbol(R"\Gamma(m)"),
         }
@@ -136,7 +138,7 @@ def render_relativistic_breit_wigner_with_ff() -> None:
 
     where :math:`\Gamma(m)` is defined by :eq:`coupled_width`, :math:`B_L(q)`
     is defined by :eq:`BlattWeisskopf`, and :math:`q^2(m)` is defined by
-    :eq:`breakup_momentum`.
+    :eq:`breakup_momentum_squared`.
     """,
     )
 

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -197,10 +197,10 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import BlattWeisskopf, breakup_momentum\n",
+    "from ampform.dynamics import BlattWeisskopf, breakup_momentum_squared\n",
     "\n",
-    "q = breakup_momentum(m, m_a, m_b)\n",
-    "ff = BlattWeisskopf(L, z=(q * d) ** 2)\n",
+    "q_squared = breakup_momentum_squared(m, m_a, m_b)\n",
+    "ff = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
     "bw.subs(\n",
     "    {\n",
     "        running_gamma1: sp.Symbol(R\"\\Gamma_{1}(m)\"),\n",
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "with $B_L(q)$ a {class}`.BlattWeisskopf` barrier factor and $q(m)$ the {func}`.breakup_momentum`."
+    "with $B_L(q)$ a {class}`.BlattWeisskopf` barrier factor and $q(m)$ the {func}`.breakup_momentum_squared`."
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,9 +60,9 @@ doc =
     dataclasses; python_version < '3.7'
     ipympl
     matplotlib
+    mdit-py-plugins < 0.2.7  # temporary fix
     mpl_interactions
     myst-nb >= 0.11  # myst_enable_extensions
-    myst-parser < 0.14  # temporary fix
     Sphinx >= 3
     sphinx-book-theme
     sphinx-copybutton

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -22,7 +22,8 @@ class BlattWeisskopf(UnevaluatedExpression):
 
         z: Argument of the Blatt-Weisskopf function :math:`B_L(z)`. A usual
             choice is :math:`z = (d q)^2` with :math:`d` the impact parameter
-            and :math:`q` the `breakup_momentum`.
+            and :math:`q` the breakup-momentum (see
+            `breakup_momentum_squared`).
 
     Each of these casesfor :math:`L` has been taken from
     :cite:`chungPartialWaveAnalysis1995`, p. 415, and
@@ -175,8 +176,11 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
     :cite:`asnerDalitzPlotAnalysis2006`.
     """
-    q = breakup_momentum(mass, m_a, m_b)
-    form_factor = BlattWeisskopf(angular_momentum, z=(q * meson_radius) ** 2)
+    q_squared = breakup_momentum_squared(mass, m_a, m_b)
+    form_factor = BlattWeisskopf(
+        angular_momentum,
+        z=q_squared * meson_radius ** 2,
+    )
     mass_dependent_width = coupled_width(
         mass, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius
     )
@@ -185,10 +189,10 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     )
 
 
-def breakup_momentum(
+def breakup_momentum_squared(
     m_r: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
 ) -> sp.Expr:
-    r"""Two-body breakup-up momentum.
+    r"""Squared value of the two-body breakup-up momentum.
 
     For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
     absolute value of the momentum of both :math:`a` and :math:`b` in the rest
@@ -196,7 +200,7 @@ def breakup_momentum(
 
     See :pdg-review:`2020; Kinematics; p.3`.
     """
-    return sp.sqrt(
+    return (
         (m_r ** 2 - (m_a + m_b) ** 2)
         * (m_r ** 2 - (m_a - m_b) ** 2)
         / (4 * m_r ** 2)
@@ -217,10 +221,16 @@ def coupled_width(  # pylint: disable=too-many-arguments
     See :pdg-review:`2020; Resonances; p.6` and
     :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
     """
-    q = breakup_momentum(mass, m_a, m_b)
-    q0 = breakup_momentum(mass0, m_a, m_b)
-    form_factor = BlattWeisskopf(angular_momentum, z=(q * meson_radius) ** 2)
-    form_factor0 = BlattWeisskopf(angular_momentum, z=(q0 * meson_radius) ** 2)
+    q_squared = breakup_momentum_squared(mass, m_a, m_b)
+    q0_squared = breakup_momentum_squared(mass0, m_a, m_b)
+    form_factor = BlattWeisskopf(
+        angular_momentum, z=q_squared * meson_radius ** 2
+    )
+    form_factor0 = BlattWeisskopf(
+        angular_momentum, z=q0_squared * meson_radius ** 2
+    )
+    q = sp.sqrt(q_squared)
+    q0 = sp.sqrt(q0_squared)
     return (
         gamma0
         * (mass0 / mass)

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -10,7 +10,7 @@ from qrules.particle import Particle
 
 from . import (
     BlattWeisskopf,
-    breakup_momentum,
+    breakup_momentum_squared,
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
 )
@@ -55,14 +55,14 @@ def create_non_dynamic_with_ff(
         raise ValueError(
             "Angular momentum is not defined but is required in the form factor!"
         )
-    q = breakup_momentum(
+    q_squared = breakup_momentum_squared(
         variable_pool.in_edge_inv_mass,
         variable_pool.out_edge_inv_mass1,
         variable_pool.out_edge_inv_mass2,
     )
     meson_radius = sp.Symbol(f"d_{resonance.name}")
     return (
-        BlattWeisskopf(angular_momentum, z=(q * meson_radius) ** 2),
+        BlattWeisskopf(angular_momentum, z=q_squared * meson_radius ** 2),
         {meson_radius: 1},
     )
 


### PR DESCRIPTION
The original `breakup_momentum` contains a `sqrt`. This is inconvenient for the caller, because it does not allow handling negative values the break-up momentum _squared_. This is becomes important in phase space factors.