### PR TITLE
refactor!: implement analytic continuation

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -69,16 +69,15 @@ def render_coupled_width() -> None:
     )
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     q0_squared = breakup_momentum_squared(m0 ** 2, m_a, m_b)
-    q = sp.sqrt(q_squared)
-    q0 = sp.sqrt(q0_squared)
-    ff = BlattWeisskopf(L, z=q_squared * d ** 2)
-    ff0 = BlattWeisskopf(L, z=q0_squared * d ** 2)
+    form_factor = BlattWeisskopf(L, z=q_squared * d ** 2)
+    form_factor0 = BlattWeisskopf(L, z=q0_squared * d ** 2)
+    rho = phase_space_factor(s, m_a, m_b)
+    rho0 = phase_space_factor(m0 ** 2, m_a, m_b)
     running_width = running_width.subs(
         {
-            2 * q: sp.Symbol("q(s)"),
-            2 * q0: sp.Symbol("q(m_{0})"),
-            ff: sp.Symbol("B_{L}(q)"),
-            ff0: sp.Symbol("B_{L}(q_{0})"),
+            rho / rho0: sp.Symbol(R"\rho(s)") / sp.Symbol(R"\rho(m_{0})"),
+            form_factor: sp.Symbol("B_{L}(q)"),
+            form_factor0: sp.Symbol("B_{L}(q_{0})"),
         }
     )
     update_docstring(
@@ -90,8 +89,9 @@ def render_coupled_width() -> None:
     .. math:: \Gamma(s) = {sp.latex(running_width)}
         :label: coupled_width
 
-    where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf` and :math:`q(s)` is
-    defined by :eq:`breakup_momentum_squared`.
+    where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf`, :math:`q(s)` is
+    defined by :eq:`breakup_momentum_squared`, and :math:`\rho(s)` is defined
+    by :eq:`phase_space_factor`.
     """,
     )
 

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -260,7 +260,7 @@
    "outputs": [],
    "source": [
     "some_amplitude = list(model.components.values())[0]\n",
-    "some_amplitude.doit()"
+    "some_amplitude.doit().n(2)"
    ]
   },
   {
@@ -285,7 +285,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "some_amplitude.doit().subs(model.parameter_defaults)"
+    "some_amplitude.doit().subs(model.parameter_defaults).n(2)"
    ]
   },
   {

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "from ampform.dynamics import breakup_momentum_squared\n",
     "\n",
-    "s, m_a, m_b = sp.symbols(\"s, m_a, m_b\", real=True)\n",
+    "s, m_a, m_b = sp.symbols(\"s, m_a, m_b\")\n",
     "q_squared = breakup_momentum_squared(s, m_a, m_b)"
    ]
   },
@@ -152,11 +152,13 @@
     "jupyter": {
      "source_hidden": true
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
-    "rho_subs = rho.subs(4 * q_squared, sp.Symbol(\"q^{2}(s)\"))\n",
+    "rho_subs = rho.subs(4 * q_squared, 4 * sp.Symbol(\"q^{2}(s)\"))\n",
     "Math(fR\"\\hat{{\\rho}}(s) = {sp.latex(rho_subs)}\")"
    ]
   },

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -377,6 +377,11 @@
    "source": [
     "from ampform.dynamics import relativistic_breit_wigner_with_ff\n",
     "\n",
+    "\n",
+    "def breakup_momentum(s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol) -> sp.Expr:\n",
+    "    return sp.sqrt(breakup_momentum_squared(s, m_a, m_b))\n",
+    "\n",
+    "\n",
     "rel_bw_with_ff = relativistic_breit_wigner_with_ff(\n",
     "    s=s,\n",
     "    mass0=m0,\n",
@@ -385,6 +390,7 @@
     "    m_b=m_b,\n",
     "    angular_momentum=L,\n",
     "    meson_radius=d,\n",
+    "    # phsp_factor=breakup_momentum,\n",
     ")"
    ]
   },
@@ -635,7 +641,6 @@
     "    **sliders,\n",
     "    ylim=\"auto\",\n",
     ")\n",
-    "iplt.axvline(controls[\"m_a\"] + controls[\"m_b\"], linestyle=\"dotted\", c=\"gray\")\n",
     "plt.show()"
    ]
   }

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -212,7 +212,7 @@
    "source": [
     "from ampform.dynamics import relativistic_breit_wigner\n",
     "\n",
-    "m, m0, w0 = sp.symbols(\"m, m0, Gamma0\", real=True)\n",
+    "m, m0, w0 = sp.symbols(\"m, m0, Gamma0\")\n",
     "relativistic_breit_wigner(s=m ** 2, mass0=m0, gamma0=w0)"
    ]
   },
@@ -263,8 +263,9 @@
    "source": [
     "from ampform.dynamics import breakup_momentum_squared\n",
     "\n",
-    "m, m_a, m_b = sp.symbols(\"m, m_a, m_b\", real=True)\n",
-    "q_squared = breakup_momentum_squared(s=m ** 2, m_a=m_a, m_b=m_b)"
+    "m, m_a, m_b = sp.symbols(\"m, m_a, m_b\")\n",
+    "s = m ** 2\n",
+    "q_squared = breakup_momentum_squared(s, m_a, m_b)"
    ]
   },
   {
@@ -287,6 +288,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "{func}`.phase_space_factor`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ampform.dynamics import phase_space_factor\n",
+    "\n",
+    "rho = phase_space_factor(s, m_a, m_b)\n",
+    "rho.subs({4 * q_squared: 4 * sp.Symbol(\"q^{2}(m)\")})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "{func}`.coupled_width`:"
    ]
   },
@@ -301,7 +323,7 @@
     "from ampform.dynamics import coupled_width\n",
     "\n",
     "L = sp.Symbol(\"L\", integer=True)\n",
-    "m0, w0, d = sp.symbols(\"m0, Gamma0, d\", real=True)\n",
+    "m0, w0, d = sp.symbols(\"m0, Gamma0, d\")\n",
     "s = m ** 2\n",
     "running_width = coupled_width(\n",
     "    s=s,\n",
@@ -318,29 +340,22 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
      "hide-input"
     ]
    },
    "outputs": [],
    "source": [
-    "q_squared = breakup_momentum_squared(s, m_a, m_b)\n",
     "q0_squared = breakup_momentum_squared(m0 ** 2, m_a, m_b)\n",
-    "q = sp.sqrt(q_squared)\n",
-    "q0 = sp.sqrt(q0_squared)\n",
-    "ff = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
-    "ff0 = BlattWeisskopf(L, z=q0_squared * d ** 2)\n",
+    "form_factor = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
+    "form_factor0 = BlattWeisskopf(L, z=q0_squared * d ** 2)\n",
+    "rho0 = phase_space_factor(m0 ** 2, m_a, m_b)\n",
     "running_width = running_width.subs(\n",
     "    {\n",
-    "        2 * q: sp.Symbol(\"q(m)\"),\n",
-    "        2 * q0: sp.Symbol(\"q(m_{0})\"),\n",
-    "        ff: sp.Symbol(\"B_{L}(q)\"),\n",
-    "        ff0: sp.Symbol(\"B_{L}(q_{0})\"),\n",
-    "        sp.sqrt(s): m,\n",
-    "    }\n",
+    "        rho / rho0: sp.Symbol(R\"\\rho(m)\") / sp.Symbol(R\"\\rho(m_{0})\"),\n",
+    "        form_factor: sp.Symbol(\"B_{L}(q)\"),\n",
+    "        form_factor0: sp.Symbol(\"B_{L}(q_{0})\"),\n",
+    "    },\n",
     ")\n",
     "Math(fR\"\\Gamma(m) = {sp.latex(running_width)}\")"
    ]

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -247,9 +247,12 @@ def coupled_width(  # pylint: disable=too-many-arguments
 def phase_space_factor(
     s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
 ) -> sp.Expr:
-    """Standard phase-space factor, following :pdg-review:`2020; Resonances; p.4`."""
+    """Standard phase-space factor, using `complex_sqrt`.
+
+    See :pdg-review:`2020; Resonances; p.4`, Equation (49.8).
+    """
     q_squared = breakup_momentum_squared(s, m_a, m_b)
-    return sp.sqrt(sp.Abs(q_squared)) / (8 * sp.pi * sp.sqrt(s))
+    return complex_sqrt(q_squared) / (8 * sp.pi * sp.sqrt(s))
 
 
 def phase_space_factor_ac(

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -234,14 +234,9 @@ def coupled_width(  # pylint: disable=too-many-arguments
     form_factor0 = BlattWeisskopf(
         angular_momentum, z=q0_squared * meson_radius ** 2
     )
-    q = sp.sqrt(q_squared)
-    q0 = sp.sqrt(q0_squared)
-    return (
-        gamma0
-        * (mass0 / sp.sqrt(s))
-        * (form_factor ** 2 / form_factor0 ** 2)
-        * (q / q0)
-    )
+    rho = phase_space_factor(s, m_a, m_b)
+    rho0 = phase_space_factor(mass0 ** 2, m_a, m_b)
+    return gamma0 * (form_factor ** 2 / form_factor0 ** 2) * (rho / rho0)
 
 
 def phase_space_factor(

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -11,7 +11,16 @@ from typing import Any
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
 
-from .decorator import UnevaluatedExpression, implement_doit_method
+from .decorator import (
+    UnevaluatedExpression,
+    implement_doit_method,
+    verify_signature,
+)
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
 
 @implement_doit_method()
@@ -163,80 +172,18 @@ def relativistic_breit_wigner(
     return gamma0 * mass0 / (mass0 ** 2 - s - gamma0 * mass0 * sp.I)
 
 
-def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
-    s: sp.Symbol,
-    mass0: sp.Symbol,
-    gamma0: sp.Symbol,
-    m_a: sp.Symbol,
-    m_b: sp.Symbol,
-    angular_momentum: sp.Symbol,
-    meson_radius: sp.Symbol,
-) -> sp.Expr:
-    """Relativistic Breit-Wigner with `.BlattWeisskopf` factor.
+class PhaseSpaceFactor(Protocol):
+    """Protocol that is used by `.coupled_width`.
 
-    See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
-    :cite:`asnerDalitzPlotAnalysis2006`.
+    Use this `~typing.Protocol` when defining other implementations of a phase
+    space factor. Compare for instance :func:`.phase_space_factor` and
+    :func:`.phase_space_factor_ac`.
     """
-    q_squared = breakup_momentum_squared(s, m_a, m_b)
-    form_factor = BlattWeisskopf(
-        angular_momentum,
-        z=q_squared * meson_radius ** 2,
-    )
-    mass_dependent_width = coupled_width(
-        s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius
-    )
-    return (mass0 * gamma0 * form_factor) / (
-        mass0 ** 2 - s - mass_dependent_width * mass0 * sp.I
-    )
 
-
-def breakup_momentum_squared(
-    s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
-) -> sp.Expr:
-    r"""Squared value of the two-body breakup-up momentum.
-
-    For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
-    absolute value of the momentum of both :math:`a` and :math:`b` in the rest
-    frame of :math:`R`.
-
-    Args:
-        s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
-            Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
-            invariant mass of decaying particle :math:`R`.
-
-        m_a: Mass of decay product :math:`a`.
-        m_b: Mass of decay product :math:`b`.
-
-    See :pdg-review:`2020; Kinematics; p.3`.
-    """
-    return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)
-
-
-def coupled_width(  # pylint: disable=too-many-arguments
-    s: sp.Symbol,
-    mass0: sp.Symbol,
-    gamma0: sp.Symbol,
-    m_a: sp.Symbol,
-    m_b: sp.Symbol,
-    angular_momentum: sp.Symbol,
-    meson_radius: sp.Symbol,
-) -> sp.Expr:
-    """Mass-dependent width, coupled to the pole position of the resonance.
-
-    See :pdg-review:`2020; Resonances; p.6` and
-    :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
-    """
-    q_squared = breakup_momentum_squared(s, m_a, m_b)
-    q0_squared = breakup_momentum_squared(mass0 ** 2, m_a, m_b)
-    form_factor = BlattWeisskopf(
-        angular_momentum, z=q_squared * meson_radius ** 2
-    )
-    form_factor0 = BlattWeisskopf(
-        angular_momentum, z=q0_squared * meson_radius ** 2
-    )
-    rho = phase_space_factor(s, m_a, m_b)
-    rho0 = phase_space_factor(mass0 ** 2, m_a, m_b)
-    return gamma0 * (form_factor ** 2 / form_factor0 ** 2) * (rho / rho0)
+    def __call__(
+        self, s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
+    ) -> sp.Expr:
+        ...
 
 
 def phase_space_factor(
@@ -277,6 +224,86 @@ def phase_space_factor_ac(
             True,
         ),
     )
+
+
+def coupled_width(  # pylint: disable=too-many-arguments
+    s: sp.Symbol,
+    mass0: sp.Symbol,
+    gamma0: sp.Symbol,
+    m_a: sp.Symbol,
+    m_b: sp.Symbol,
+    angular_momentum: sp.Symbol,
+    meson_radius: sp.Symbol,
+    phsp_factor: PhaseSpaceFactor = phase_space_factor,
+) -> sp.Expr:
+    """Mass-dependent width, coupled to the pole position of the resonance.
+
+    See :pdg-review:`2020; Resonances; p.6` and
+    :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
+    """
+    if phsp_factor is not phase_space_factor:
+        verify_signature(phsp_factor, PhaseSpaceFactor)
+    q_squared = breakup_momentum_squared(s, m_a, m_b)
+    q0_squared = breakup_momentum_squared(mass0 ** 2, m_a, m_b)
+    form_factor = BlattWeisskopf(
+        angular_momentum, z=q_squared * meson_radius ** 2
+    )
+    form_factor0 = BlattWeisskopf(
+        angular_momentum, z=q0_squared * meson_radius ** 2
+    )
+    rho = phsp_factor(s, m_a, m_b)
+    rho0 = phsp_factor(mass0 ** 2, m_a, m_b)
+    return gamma0 * (form_factor ** 2 / form_factor0 ** 2) * (rho / rho0)
+
+
+def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
+    s: sp.Symbol,
+    mass0: sp.Symbol,
+    gamma0: sp.Symbol,
+    m_a: sp.Symbol,
+    m_b: sp.Symbol,
+    angular_momentum: sp.Symbol,
+    meson_radius: sp.Symbol,
+    phsp_factor: PhaseSpaceFactor = phase_space_factor,
+) -> sp.Expr:
+    """Relativistic Breit-Wigner with `.BlattWeisskopf` factor.
+
+    See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
+    :cite:`asnerDalitzPlotAnalysis2006`.
+    """
+    q_squared = breakup_momentum_squared(s, m_a, m_b)
+    form_factor = BlattWeisskopf(
+        angular_momentum,
+        z=q_squared * meson_radius ** 2,
+    )
+    mass_dependent_width = coupled_width(
+        s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius, phsp_factor
+    )
+    return (mass0 * gamma0 * form_factor) / (
+        mass0 ** 2 - s - mass_dependent_width * mass0 * sp.I
+    )
+
+
+def breakup_momentum_squared(
+    s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
+) -> sp.Expr:
+    r"""Squared value of the two-body breakup-up momentum.
+
+    For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
+    absolute value of the momentum of both :math:`a` and :math:`b` in the rest
+    frame of :math:`R`.
+
+    Args:
+        s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
+            Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
+            invariant mass of decaying particle :math:`R`.
+
+        m_a: Mass of decay product :math:`a`.
+        m_b: Mass of decay product :math:`b`.
+
+    See :pdg-review:`2020; Kinematics; p.3`.
+    """
+    return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)
 
 
 def complex_sqrt(x: sp.Symbol) -> sp.Expr:

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -1,8 +1,6 @@
 """Build `~ampform.dynamics` with correct variable names and values."""
 
-import inspect
-from collections import OrderedDict
-from typing import Callable, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import attr
 import sympy as sp
@@ -14,6 +12,9 @@ from . import (
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
 )
+
+# pyright: reportUnusedImport=false
+from .decorator import verify_signature  # noqa: F401
 
 try:
     from typing import Protocol
@@ -135,32 +136,3 @@ class ResonanceDynamicsBuilder(Protocol):
         self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
     ) -> Tuple[sp.Expr, Dict[sp.Symbol, float]]:
         ...
-
-
-def verify_signature(builder: Callable) -> None:
-    """Check signature of a builder function dynamically.
-
-    Dynamically check whether a builder has the same signature as
-    `.ResonanceDynamicsBuilder`. This function is needed because
-    `typing.runtime_checkable` only checks members and methods, not the
-    signature of those methods.
-    """
-    signature = inspect.signature(builder)
-    if signature.return_annotation != __EXPECTED.return_annotation:
-        raise ValueError(
-            f'Builder "{builder.__name__}" has return type {__EXPECTED.return_annotation};'
-            f" expected {signature.return_annotation}"
-        )
-    expected_parameters = OrderedDict(__EXPECTED.parameters.items())
-    del expected_parameters["self"]
-    assert signature.return_annotation == __EXPECTED.return_annotation
-    if signature.parameters != expected_parameters:
-        raise ValueError(
-            f'Builder "{builder.__name__}" has parameters\n'
-            f"  {list(signature.parameters.values())}\n"
-            "This should be\n"
-            f"  {list(expected_parameters.values())}"
-        )
-
-
-__EXPECTED = inspect.signature(ResonanceDynamicsBuilder.__call__)

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -1,6 +1,8 @@
 """Tools for defining lineshapes with `sympy`."""
 
+import inspect
 from abc import abstractmethod
+from collections import OrderedDict
 from typing import Any, Callable, Type
 
 import sympy as sp
@@ -99,3 +101,30 @@ def implement_doit_method() -> Callable[
         return decorated_class
 
     return decorator
+
+
+def verify_signature(builder: Callable, protocol: Type[Callable]) -> None:
+    """Check signature of a builder function dynamically.
+
+    Dynamically check whether a builder has the same signature as that of the
+    given `~typing.Protocol` (a `~typing.Callable`). This function is needed
+    because `typing.runtime_checkable` only checks members and methods, not the
+    signature of those methods.
+    """
+    expected_signature = inspect.signature(protocol.__call__)
+    signature = inspect.signature(builder)
+    if signature.return_annotation != expected_signature.return_annotation:
+        raise ValueError(
+            f'Builder "{builder.__name__}" has return type {expected_signature.return_annotation};'
+            f" expected {signature.return_annotation}"
+        )
+    expected_parameters = OrderedDict(expected_signature.parameters.items())
+    del expected_parameters["self"]
+    assert signature.return_annotation == expected_signature.return_annotation
+    if signature.parameters != expected_parameters:
+        raise ValueError(
+            f'Builder "{builder.__name__}" has parameters\n'
+            f"  {list(signature.parameters.values())}\n"
+            "This should be\n"
+            f"  {list(expected_parameters.values())}"
+        )

--- a/src/ampform/helicity.py
+++ b/src/ampform/helicity.py
@@ -480,7 +480,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
     def set_dynamics(
         self, particle_name: str, dynamics_builder: ResonanceDynamicsBuilder
     ) -> None:
-        verify_signature(dynamics_builder)
+        verify_signature(dynamics_builder, ResonanceDynamicsBuilder)
         for transition in self.__graphs:
             for node_id in transition.topology.nodes:
                 decay = _TwoBodyDecay.from_graph(transition, node_id)

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -54,8 +54,8 @@ def test_generate(
     assert len(expression.free_symbols) == 1
 
     existing_symbol = next(iter(expression.free_symbols))
-    mass = sp.Symbol("m", real=True)
-    expression = expression.subs({existing_symbol: mass})
+    m = sp.Symbol("m", real=True)
+    expression = expression.subs({existing_symbol: m})
 
     expression = round_nested(expression, n_decimals=2)
 
@@ -74,16 +74,18 @@ def test_generate(
     expression = round_nested(expression, n_decimals=2)
     expression = round_nested(expression, n_decimals=2)
 
+    expression = sp.piecewise_fold(expression)
+    assert isinstance(expression, sp.Piecewise)
+    expression, condition = expression.args[1].args
+    assert condition
+    assert isinstance(expression, sp.Add)
+    a1, a2 = tuple(map(str, expression.args))
     if formalism == "canonical":
-        assert tuple(map(str, expression.args)) == (
-            "0.08/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)",
-            "0.23/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)",
-        )
+        assert a1 == "0.08/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)"
+        assert a2 == "0.23/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)"
     elif formalism == "helicity":
-        assert tuple(map(str, expression.args)) == (
-            "0.17/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)",
-            "0.06/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)",
-        )
+        assert a1 == "0.17/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)"
+        assert a2 == "0.06/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)"
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Implement `phase_space_factor` introduced by #51 into the `coupled_width`. The 'default' `phase_space_factor` has been adapted so that it can handle negative square roots.

Note: the overall lineshape of amplitude models does not change in the domain where it was defined so far. Only undefined domains are extended (see `test_dynamics.py`).