### PR TITLE
refactor!: switch to Blatt-Weisskopf squared

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -83,8 +83,8 @@ def render_coupled_width() -> None:
     update_docstring(
         coupled_width,
         fR"""
-    AmpForm uses the following shape for the "mass-dependent" width in a
-    `.relativistic_breit_wigner_with_ff`:
+    With that in mind, the "mass-dependent" width in a
+    `.relativistic_breit_wigner_with_ff` becomes:
 
     .. math:: \Gamma(s) = {sp.latex(running_width)}
         :label: coupled_width

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -12,7 +12,7 @@ from typing import Callable, Type, Union
 import sympy as sp
 
 from ampform.dynamics import (
-    BlattWeisskopf,
+    BlattWeisskopfSquared,
     breakup_momentum_squared,
     complex_sqrt,
     coupled_width,
@@ -33,12 +33,12 @@ def update_docstring(
 def render_blatt_weisskopf() -> None:
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
-    ff2 = BlattWeisskopf(L, z) ** 2
+    ff2 = BlattWeisskopfSquared(L, z)
     update_docstring(
-        BlattWeisskopf,
+        BlattWeisskopfSquared,
         f"""
     .. math:: {sp.latex(ff2)} = {sp.latex(ff2.doit())}
-        :label: BlattWeisskopf
+        :label: BlattWeisskopfSquared
     """,
     )
 
@@ -69,15 +69,15 @@ def render_coupled_width() -> None:
     )
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     q0_squared = breakup_momentum_squared(m0 ** 2, m_a, m_b)
-    form_factor = BlattWeisskopf(L, z=q_squared * d ** 2)
-    form_factor0 = BlattWeisskopf(L, z=q0_squared * d ** 2)
+    form_factor_sq = BlattWeisskopfSquared(L, z=q_squared * d ** 2)
+    form_factor0_sq = BlattWeisskopfSquared(L, z=q0_squared * d ** 2)
     rho = phase_space_factor(s, m_a, m_b)
     rho0 = phase_space_factor(m0 ** 2, m_a, m_b)
     running_width = running_width.subs(
         {
             rho / rho0: sp.Symbol(R"\rho(s)") / sp.Symbol(R"\rho(m_{0})"),
-            form_factor: sp.Symbol("B_{L}(q)"),
-            form_factor0: sp.Symbol("B_{L}(q_{0})"),
+            form_factor_sq: sp.Symbol("B_{L}^2(q)"),
+            form_factor0_sq: sp.Symbol("B_{L}^2(q_{0})"),
         }
     )
     update_docstring(
@@ -89,9 +89,9 @@ def render_coupled_width() -> None:
     .. math:: \Gamma(s) = {sp.latex(running_width)}
         :label: coupled_width
 
-    where :math:`B_L(q)` is defined by :eq:`BlattWeisskopf`, :math:`q(s)` is
-    defined by :eq:`breakup_momentum_squared`, and :math:`\rho(s)` is defined
-    by :eq:`phase_space_factor`.
+    where :math:`B_L^2(q)` is defined by :eq:`BlattWeisskopfSquared`,
+    :math:`q(s)` is defined by :eq:`breakup_momentum_squared`, and
+    :math:`\rho(s)` is defined by :eq:`phase_space_factor`.
     """,
     )
 
@@ -171,26 +171,26 @@ def render_relativistic_breit_wigner_with_ff() -> None:
         meson_radius=d,
     )
     q_squared = breakup_momentum_squared(s, m_a, m_b)
-    ff = BlattWeisskopf(L, z=q_squared * d ** 2)
+    ff_sq = BlattWeisskopfSquared(L, z=q_squared * d ** 2)
     mass_dependent_width = coupled_width(s, m0, w0, m_a, m_b, L, d)
     rel_bw_with_ff = rel_bw_with_ff.subs(
         {
             2 * q_squared: 2 * sp.Symbol("q^{2}(s)"),
-            ff: sp.Symbol(R"B_{L}\left(q(s)\right)"),
+            ff_sq: sp.Symbol(R"B_{L}^2\left(q(s)\right)"),
             mass_dependent_width: sp.Symbol(R"\Gamma(s)"),
         }
     )
     update_docstring(
         relativistic_breit_wigner_with_ff,
         fR"""
-    The general form of a relativistic Breit-Wigner with `.BlattWeisskopf` form
+    The general form of a relativistic Breit-Wigner with Blatt-Weisskopf form
     factor is:
 
     .. math:: {sp.latex(rel_bw_with_ff)}
         :label: relativistic_breit_wigner_with_ff
 
-    where :math:`\Gamma(s)` is defined by :eq:`coupled_width`, :math:`B_L(q)`
-    is defined by :eq:`BlattWeisskopf`, and :math:`q(s)` is defined by
+    where :math:`\Gamma(s)` is defined by :eq:`coupled_width`, :math:`B_L^2(q)`
+    is defined by :eq:`BlattWeisskopfSquared`, and :math:`q(s)` is defined by
     :eq:`breakup_momentum_squared`.
     """,
     )

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -201,15 +201,15 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import BlattWeisskopf, breakup_momentum_squared\n",
+    "from ampform.dynamics import BlattWeisskopfSquared, breakup_momentum_squared\n",
     "\n",
     "q_squared = breakup_momentum_squared(m ** 2, m_a, m_b)\n",
-    "ff = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
+    "ff2 = BlattWeisskopfSquared(L, z=q_squared * d ** 2)\n",
     "bw.subs(\n",
     "    {\n",
     "        running_gamma1: sp.Symbol(R\"\\Gamma_{1}(m)\"),\n",
     "        running_gamma2: sp.Symbol(R\"\\Gamma_{2}(m)\"),\n",
-    "        ff: sp.Symbol(\"B_{L}(q)\"),\n",
+    "        sp.sqrt(ff2): sp.Symbol(\"B_{L}(q)\"),\n",
     "    },\n",
     ")"
    ]
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "with $B_L(q)$ a {class}`.BlattWeisskopf` barrier factor and $q(m)$ the {func}`.breakup_momentum_squared`."
+    "with $B_L(q)$ a Blatt-Weisskopf barrier factor (see {class}`.BlattWeisskopfSquared`) and $q(m)$ the {func}`.breakup_momentum_squared`."
    ]
   },
   {

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -147,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "AmpForm uses {class}`.BlattWeisskopf` functions $B_L$ as _barrier factors_ (also called _form factors_):"
+    "AmpForm uses Blatt-Weisskopf functions $B_L$ as _barrier factors_ (also called _form factors_, see {class}`.BlattWeisskopfSquared`):"
    ]
   },
   {
@@ -158,11 +158,11 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import BlattWeisskopf\n",
+    "from ampform.dynamics import BlattWeisskopfSquared\n",
     "\n",
     "L = sp.Symbol(\"L\", integer=True)\n",
     "z = sp.Symbol(\"z\", real=True)\n",
-    "ff2 = BlattWeisskopf(L, z) ** 2"
+    "ff2 = BlattWeisskopfSquared(L, z)"
    ]
   },
   {
@@ -347,14 +347,14 @@
    "outputs": [],
    "source": [
     "q0_squared = breakup_momentum_squared(m0 ** 2, m_a, m_b)\n",
-    "form_factor = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
-    "form_factor0 = BlattWeisskopf(L, z=q0_squared * d ** 2)\n",
+    "ff = BlattWeisskopfSquared(L, z=q_squared * d ** 2)\n",
+    "ff0_sq = BlattWeisskopfSquared(L, z=q0_squared * d ** 2)\n",
     "rho0 = phase_space_factor(m0 ** 2, m_a, m_b)\n",
     "running_width = running_width.subs(\n",
     "    {\n",
     "        rho / rho0: sp.Symbol(R\"\\rho(m)\") / sp.Symbol(R\"\\rho(m_{0})\"),\n",
-    "        form_factor: sp.Symbol(\"B_{L}(q)\"),\n",
-    "        form_factor0: sp.Symbol(\"B_{L}(q_{0})\"),\n",
+    "        ff: sp.Symbol(\"B_{L}(q)\"),\n",
+    "        ff0_sq: sp.Symbol(\"B_{L}(q_{0})\"),\n",
     "    },\n",
     ")\n",
     "Math(fR\"\\Gamma(m) = {sp.latex(running_width)}\")"
@@ -408,7 +408,7 @@
    "outputs": [],
    "source": [
     "q_squared = breakup_momentum_squared(s, m_a, m_b)\n",
-    "ff = BlattWeisskopf(L, z=q_squared * d ** 2)\n",
+    "ff = sp.sqrt(BlattWeisskopfSquared(L, z=q_squared * d ** 2))\n",
     "mass_dependent_width = coupled_width(s, m0, w0, m_a, m_b, L, d)\n",
     "rel_bw_with_ff.subs(\n",
     "    {\n",

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -643,6 +643,122 @@
     ")\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "### Blatt-Weisskopf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "L = sp.Symbol(\"L\", integer=True)\n",
+    "m, m_a, m_b, d = sp.symbols(\"m, m_a, m_b, d\")\n",
+    "q_squared = breakup_momentum_squared(m ** 2, m_a, m_b)\n",
+    "ff2 = BlattWeisskopfSquared(L, z=q_squared * d ** 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "np_blatt_weisskopf, sliders = symplot.prepare_sliders(\n",
+    "    plot_symbol=m,\n",
+    "    expression=ff2.doit(),\n",
+    ")\n",
+    "np_breakup_momentum = sp.lambdify((m, L, d, m_a, m_b), q_squared, \"numpy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "plot_domain = np.linspace(0.01, 4, 500)\n",
+    "sliders.set_ranges(\n",
+    "    L=(0, 8),\n",
+    "    m_a=(0, 2, 200),\n",
+    "    m_b=(0, 2, 200),\n",
+    "    d=(0, 5),\n",
+    ")\n",
+    "sliders.set_values(\n",
+    "    L=1,\n",
+    "    m_a=0.3,\n",
+    "    m_b=0.2,\n",
+    "    d=3,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import mpl_interactions.ipyplot as iplt\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "ax.set_xlabel(\"$m$\")\n",
+    "controls = iplt.plot(\n",
+    "    plot_domain,\n",
+    "    np_blatt_weisskopf,\n",
+    "    **sliders,\n",
+    "    ylim=\"auto\",\n",
+    "    label=R\"$B_L^2\\left(q(m)\\right)$\",\n",
+    "    linestyle=\"dotted\",\n",
+    "    ax=ax,\n",
+    ")\n",
+    "iplt.plot(\n",
+    "    plot_domain,\n",
+    "    np_breakup_momentum,\n",
+    "    controls=controls,\n",
+    "    ylim=\"auto\",\n",
+    "    label=\"$q^2(m)$\",\n",
+    "    linestyle=\"dashed\",\n",
+    "    ax=ax,\n",
+    ")\n",
+    "iplt.title(\n",
+    "    \"Effect of Blatt-Weisskopf factor\\n$L={L}, m_a={m_a:.2f}, m_b={m_b:.2f}$\",\n",
+    "    controls=controls,\n",
+    ")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -35,12 +35,15 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
             and :math:`q` the breakup-momentum (see
             `breakup_momentum_squared`).
 
-    This version of the Blatt-Weisskopf function can be used directly as a
-    barrier factor, because it is normalized in the sense that equal powers of
-    :math:`z` appear in the nominator and the denominator. Each of these cases
-    for :math:`L` has been taken from :cite:`chungPartialWaveAnalysis1995`, p.
-    415, and :cite:`chungFormulasAngularMomentumBarrier2015`. For a good
-    overview of where to use these Blatt-Weisskopf functions, see
+    Note that equal powers of :math:`z` appear in the nominator and the
+    denominator, while some sources have nominator :math:`1`, instead of
+    :math:`z^L`. Compare for instance :pdg-review:`2020; Resonances; p.6`, just
+    before Equation (49.20).
+
+    Each of these cases for :math:`L` has been taken from
+    :cite:`chungPartialWaveAnalysis1995`, p. 415, and
+    :cite:`chungFormulasAngularMomentumBarrier2015`. For a good overview of
+    where to use these Blatt-Weisskopf functions, see
     :cite:`asnerDalitzPlotAnalysis2006`.
 
     See also :ref:`usage/dynamics/lineshapes:Form factor`.

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -35,10 +35,12 @@ class BlattWeisskopf(UnevaluatedExpression):
             and :math:`q` the breakup-momentum (see
             `breakup_momentum_squared`).
 
-    Each of these casesfor :math:`L` has been taken from
-    :cite:`chungPartialWaveAnalysis1995`, p. 415, and
-    :cite:`chungFormulasAngularMomentumBarrier2015`. For a good overview of
-    where to use these Blatt-Weisskopf functions, see
+    This version of the Blatt-Weisskopf function can be used directly as a
+    barrier factor, because it is normalized in the sense that equal powers of
+    :math:`z` appear in the nominator and the denominator. Each of these cases
+    for :math:`L` has been taken from :cite:`chungPartialWaveAnalysis1995`, p.
+    415, and :cite:`chungFormulasAngularMomentumBarrier2015`. For a good
+    overview of where to use these Blatt-Weisskopf functions, see
     :cite:`asnerDalitzPlotAnalysis2006`.
 
     See also :ref:`usage/dynamics/lineshapes:Form factor`.
@@ -236,10 +238,17 @@ def coupled_width(  # pylint: disable=too-many-arguments
     meson_radius: sp.Symbol,
     phsp_factor: PhaseSpaceFactor = phase_space_factor,
 ) -> sp.Expr:
-    """Mass-dependent width, coupled to the pole position of the resonance.
+    r"""Mass-dependent width, coupled to the pole position of the resonance.
 
     See :pdg-review:`2020; Resonances; p.6` and
     :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
+
+    Note that the `.BlattWeisskopf` of AmpForm is normalized in the sense that
+    equal powers of :math:`z` appear in the nominator and the denominator,
+    while the definition in the PDG (as well as some other sources), always
+    have :math:`1` in the nominator of the Blatt-Weisskopf. In that case,
+    one needs an additional factor :math:`\left(q/q_0\right)^{2L}` in the
+    definition for :math:`\Gamma(m)`.
     """
     if phsp_factor is not phase_space_factor:
         verify_signature(phsp_factor, PhaseSpaceFactor)

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -269,7 +269,7 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     """Relativistic Breit-Wigner with `.BlattWeisskopf` factor.
 
     See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
-    :cite:`asnerDalitzPlotAnalysis2006`.
+    :pdg-review:`2020; Resonances; p.6`.
     """
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     form_factor = BlattWeisskopf(

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -24,13 +24,13 @@ except ImportError:
 
 
 @implement_doit_method()
-class BlattWeisskopf(UnevaluatedExpression):
-    r"""Blatt-Weisskopf function :math:`B_L(z)`, up to :math:`L \leq 8`.
+class BlattWeisskopfSquared(UnevaluatedExpression):
+    r"""Blatt-Weisskopf function :math:`B_L^2(z)`, up to :math:`L \leq 8`.
 
     Args:
         angular_momentum: Angular momentum :math:`L` of the decaying particle.
 
-        z: Argument of the Blatt-Weisskopf function :math:`B_L(z)`. A usual
+        z: Argument of the Blatt-Weisskopf function :math:`B_L^2(z)`. A usual
             choice is :math:`z = (d q)^2` with :math:`d` the impact parameter
             and :math:`q` the breakup-momentum (see
             `breakup_momentum_squared`).
@@ -52,7 +52,7 @@ class BlattWeisskopf(UnevaluatedExpression):
         z: sp.Symbol,
         evaluate: bool = False,
         **hints: Any,
-    ) -> "BlattWeisskopf":
+    ) -> "BlattWeisskopfSquared":
         args = sp.sympify((angular_momentum, z))
         if evaluate:
             # pylint: disable=no-member
@@ -61,106 +61,101 @@ class BlattWeisskopf(UnevaluatedExpression):
 
     def evaluate(self) -> sp.Expr:
         angular_momentum, z = self.args
-        return sp.sqrt(
-            sp.Piecewise(
+        return sp.Piecewise(
+            (
+                1,
+                sp.Eq(angular_momentum, 0),
+            ),
+            (
+                2 * z / (z + 1),
+                sp.Eq(angular_momentum, 1),
+            ),
+            (
+                13 * z ** 2 / ((z - 3) * (z - 3) + 9 * z),
+                sp.Eq(angular_momentum, 2),
+            ),
+            (
                 (
-                    1,
-                    sp.Eq(angular_momentum, 0),
+                    277
+                    * z ** 3
+                    / (z * (z - 15) * (z - 15) + 9 * (2 * z - 5) * (2 * z - 5))
                 ),
+                sp.Eq(angular_momentum, 3),
+            ),
+            (
                 (
-                    2 * z / (z + 1),
-                    sp.Eq(angular_momentum, 1),
-                ),
-                (
-                    13 * z ** 2 / ((z - 3) * (z - 3) + 9 * z),
-                    sp.Eq(angular_momentum, 2),
-                ),
-                (
-                    (
-                        277
-                        * z ** 3
-                        / (
-                            z * (z - 15) * (z - 15)
-                            + 9 * (2 * z - 5) * (2 * z - 5)
-                        )
-                    ),
-                    sp.Eq(angular_momentum, 3),
-                ),
-                (
-                    (
-                        12746
-                        * z ** 4
-                        / (
-                            (z ** 2 - 45 * z + 105) * (z ** 2 - 45 * z + 105)
-                            + 25 * z * (2 * z - 21) * (2 * z - 21)
-                        )
-                    ),
-                    sp.Eq(angular_momentum, 4),
-                ),
-                (
-                    998881
-                    * z ** 5
+                    12746
+                    * z ** 4
                     / (
-                        z ** 5
-                        + 15 * z ** 4
-                        + 315 * z ** 3
-                        + 6300 * z ** 2
-                        + 99225 * z
-                        + 893025
-                    ),
-                    sp.Eq(angular_momentum, 5),
+                        (z ** 2 - 45 * z + 105) * (z ** 2 - 45 * z + 105)
+                        + 25 * z * (2 * z - 21) * (2 * z - 21)
+                    )
                 ),
-                (
-                    118394977
-                    * z ** 6
-                    / (
-                        z ** 6
-                        + 21 * z ** 5
-                        + 630 * z ** 4
-                        + 18900 * z ** 3
-                        + 496125 * z ** 2
-                        + 9823275 * z
-                        + 108056025
-                    ),
-                    sp.Eq(angular_momentum, 6),
+                sp.Eq(angular_momentum, 4),
+            ),
+            (
+                998881
+                * z ** 5
+                / (
+                    z ** 5
+                    + 15 * z ** 4
+                    + 315 * z ** 3
+                    + 6300 * z ** 2
+                    + 99225 * z
+                    + 893025
                 ),
-                (
-                    19727003738
-                    * z ** 7
-                    / (
-                        z ** 7
-                        + 28 * z ** 6
-                        + 1134 * z ** 5
-                        + 47250 * z ** 4
-                        + 1819125 * z ** 3
-                        + 58939650 * z ** 2
-                        + 1404728325 * z
-                        + 18261468225
-                    ),
-                    sp.Eq(angular_momentum, 7),
+                sp.Eq(angular_momentum, 5),
+            ),
+            (
+                118394977
+                * z ** 6
+                / (
+                    z ** 6
+                    + 21 * z ** 5
+                    + 630 * z ** 4
+                    + 18900 * z ** 3
+                    + 496125 * z ** 2
+                    + 9823275 * z
+                    + 108056025
                 ),
-                (
-                    4392846440677
-                    * z ** 8
-                    / (
-                        z ** 8
-                        + 36 * z ** 7
-                        + 1890 * z ** 6
-                        + 103950 * z ** 5
-                        + 5457375 * z ** 4
-                        + 255405150 * z ** 3
-                        + 9833098275 * z ** 2
-                        + 273922023375 * z
-                        + 4108830350625
-                    ),
-                    sp.Eq(angular_momentum, 8),
+                sp.Eq(angular_momentum, 6),
+            ),
+            (
+                19727003738
+                * z ** 7
+                / (
+                    z ** 7
+                    + 28 * z ** 6
+                    + 1134 * z ** 5
+                    + 47250 * z ** 4
+                    + 1819125 * z ** 3
+                    + 58939650 * z ** 2
+                    + 1404728325 * z
+                    + 18261468225
                 ),
-            )
+                sp.Eq(angular_momentum, 7),
+            ),
+            (
+                4392846440677
+                * z ** 8
+                / (
+                    z ** 8
+                    + 36 * z ** 7
+                    + 1890 * z ** 6
+                    + 103950 * z ** 5
+                    + 5457375 * z ** 4
+                    + 255405150 * z ** 3
+                    + 9833098275 * z ** 2
+                    + 273922023375 * z
+                    + 4108830350625
+                ),
+                sp.Eq(angular_momentum, 8),
+            ),
         )
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         angular_momentum, z = tuple(map(printer._print, self.args))
-        return fR"B_{{{angular_momentum}}}\left({z}\right)"
+        return fR"B_{{{angular_momentum}}}^2\left({z}\right)"
 
 
 def relativistic_breit_wigner(
@@ -243,26 +238,26 @@ def coupled_width(  # pylint: disable=too-many-arguments
     See :pdg-review:`2020; Resonances; p.6` and
     :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
 
-    Note that the `.BlattWeisskopf` of AmpForm is normalized in the sense that
-    equal powers of :math:`z` appear in the nominator and the denominator,
-    while the definition in the PDG (as well as some other sources), always
-    have :math:`1` in the nominator of the Blatt-Weisskopf. In that case,
-    one needs an additional factor :math:`\left(q/q_0\right)^{2L}` in the
-    definition for :math:`\Gamma(m)`.
+    Note that the `.BlattWeisskopfSquared` of AmpForm is normalized in the
+    sense that equal powers of :math:`z` appear in the nominator and the
+    denominator, while the definition in the PDG (as well as some other
+    sources), always have :math:`1` in the nominator of the Blatt-Weisskopf. In
+    that case, one needs an additional factor :math:`\left(q/q_0\right)^{2L}`
+    in the definition for :math:`\Gamma(m)`.
     """
     if phsp_factor is not phase_space_factor:
         verify_signature(phsp_factor, PhaseSpaceFactor)
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     q0_squared = breakup_momentum_squared(mass0 ** 2, m_a, m_b)
-    form_factor = BlattWeisskopf(
+    form_factor_sq = BlattWeisskopfSquared(
         angular_momentum, z=q_squared * meson_radius ** 2
     )
-    form_factor0 = BlattWeisskopf(
+    form_factor0_sq = BlattWeisskopfSquared(
         angular_momentum, z=q0_squared * meson_radius ** 2
     )
     rho = phsp_factor(s, m_a, m_b)
     rho0 = phsp_factor(mass0 ** 2, m_a, m_b)
-    return gamma0 * (form_factor ** 2 / form_factor0 ** 2) * (rho / rho0)
+    return gamma0 * (form_factor_sq / form_factor0_sq) * (rho / rho0)
 
 
 def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
@@ -275,15 +270,16 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     meson_radius: sp.Symbol,
     phsp_factor: PhaseSpaceFactor = phase_space_factor,
 ) -> sp.Expr:
-    """Relativistic Breit-Wigner with `.BlattWeisskopf` factor.
+    """Relativistic Breit-Wigner with `.BlattWeisskopfSquared` factor.
 
     See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
     :pdg-review:`2020; Resonances; p.6`.
     """
     q_squared = breakup_momentum_squared(s, m_a, m_b)
-    form_factor = BlattWeisskopf(
-        angular_momentum,
-        z=q_squared * meson_radius ** 2,
+    form_factor = sp.sqrt(
+        BlattWeisskopfSquared(
+            angular_momentum, z=q_squared * meson_radius ** 2
+        )
     )
     mass_dependent_width = coupled_width(
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius, phsp_factor

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -7,7 +7,7 @@ import sympy as sp
 from qrules.particle import Particle
 
 from . import (
-    BlattWeisskopf,
+    BlattWeisskopfSquared,
     breakup_momentum_squared,
     relativistic_breit_wigner,
     relativistic_breit_wigner_with_ff,
@@ -50,7 +50,11 @@ def create_non_dynamic(
 def create_non_dynamic_with_ff(
     resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
 ) -> Tuple[sp.Expr, Dict[sp.Symbol, float]]:
-    """Generate a `.BlattWeisskopf` form factor for a two-body decay."""
+    """Generate (only) a Blatt-Weisskopf form factor for a two-body decay.
+
+    Returns the `~sympy.functions.elementary.miscellaneous.sqrt` of a
+    `.BlattWeisskopfSquared`.
+    """
     angular_momentum = variable_pool.angular_momentum
     if angular_momentum is None:
         raise ValueError(
@@ -62,8 +66,12 @@ def create_non_dynamic_with_ff(
         m_b=variable_pool.out_edge_inv_mass2,
     )
     meson_radius = sp.Symbol(f"d_{resonance.name}")
+    form_factor_squared = BlattWeisskopfSquared(
+        angular_momentum,
+        z=q_squared * meson_radius ** 2,
+    )
     return (
-        BlattWeisskopf(angular_momentum, z=q_squared * meson_radius ** 2),
+        sp.sqrt(form_factor_squared),
         {meson_radius: 1},
     )
 


### PR DESCRIPTION
The value of Blatt-Weisskopf squared can be negative. This leaves it up to the caller how to handle these negative values if a square root is to be taken. Note that this becomes particularly important when the Blatt-Weisskopf function is used as a damping factor, like in `relativistic_breit_wigner_with_ff` and `create_non_dynamics_with_ff`, as opposed to `coupled_width` (where the square value is used).

Also improved some of the references for the lineshapes. In addition, a new interactive widget shows the effect of a Blatt-Weisskopf factor.