### PR TITLE
refactor: improve signature of coupled_width

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -91,7 +91,7 @@ def render_coupled_width() -> None:
 
     where :math:`B_L^2(q)` is defined by :eq:`BlattWeisskopfSquared`,
     :math:`q(s)` is defined by :eq:`breakup_momentum_squared`, and
-    :math:`\rho(s)` is defined by :eq:`phase_space_factor`.
+    :math:`\rho(s)` is (by default) defined by :eq:`phase_space_factor`.
     """,
     )
 

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -239,7 +239,8 @@ def coupled_width(  # pylint: disable=too-many-arguments
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
     See :pdg-review:`2020; Resonances; p.6` and
-    :cite:`asnerDalitzPlotAnalysis2006`, equation (6).
+    :cite:`asnerDalitzPlotAnalysis2006`, equation (6). Default value for
+    :code:`phsp_factor` is :meth:`phase_space_factor`.
 
     Note that the `.BlattWeisskopfSquared` of AmpForm is normalized in the
     sense that equal powers of :math:`z` appear in the nominator and the

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -6,7 +6,7 @@
     :doc:`/usage/dynamics/analytic-continuation`
 """
 
-from typing import Any
+from typing import Any, Optional
 
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
@@ -234,7 +234,7 @@ def coupled_width(  # pylint: disable=too-many-arguments
     m_b: sp.Symbol,
     angular_momentum: sp.Symbol,
     meson_radius: sp.Symbol,
-    phsp_factor: PhaseSpaceFactor = phase_space_factor,
+    phsp_factor: Optional[PhaseSpaceFactor] = None,
 ) -> sp.Expr:
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
@@ -248,8 +248,10 @@ def coupled_width(  # pylint: disable=too-many-arguments
     that case, one needs an additional factor :math:`\left(q/q_0\right)^{2L}`
     in the definition for :math:`\Gamma(m)`.
     """
-    if phsp_factor is not phase_space_factor:
+    if phsp_factor is not None:
         verify_signature(phsp_factor, PhaseSpaceFactor)
+    else:
+        phsp_factor = phase_space_factor
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     q0_squared = breakup_momentum_squared(mass0 ** 2, m_a, m_b)
     form_factor_sq = BlattWeisskopfSquared(


### PR DESCRIPTION
The signature of functions that have arguments with functions as default values (for an argument that expects a callable) do not render well. So it's better to use `Optional[PhaseSpaceFactor] = None` instead.