### PR TITLE
fix!: remove faulty terms in analytic continuation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -199,6 +199,7 @@
         "savefig",
         "seealso",
         "sharex",
+        "sharey",
         "startswith",
         "suptitle",
         "sympify",

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -13,6 +13,7 @@ import sympy as sp
 
 from ampform.dynamics import (
     BlattWeisskopfSquared,
+    _analytic_continuation,
     breakup_momentum_squared,
     complex_sqrt,
     coupled_width,
@@ -125,15 +126,8 @@ def render_phase_space_factor() -> None:
 
 
 def render_phase_space_factor_ac() -> None:
-    s, m_a, m_b = sp.symbols("s, m_a, m_b")
-    rho_analytic = phase_space_factor_ac(s, m_a, m_b)
-    rho = phase_space_factor(s, m_a, m_b)
-    rho_analytic = rho_analytic.subs(
-        {
-            rho: sp.Symbol(R"\hat{\rho}"),
-            1 / rho: sp.Symbol(R"\left(\hat{\rho}\right)^{-1}"),
-        }
-    )
+    s, m_a, m_b, rho = sp.symbols(R"s, m_a, m_b, \hat{\rho}")
+    rho_analytic = _analytic_continuation(rho, s, s_threshold=(m_a + m_b) ** 2)
     update_docstring(
         phase_space_factor_ac,
         fR"""

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -84,6 +84,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import warnings\n",
+    "\n",
+    "logging.basicConfig()\n",
+    "logging.getLogger().setLevel(logging.ERROR)\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -253,7 +253,7 @@
    },
    "outputs": [],
    "source": [
-    "plot_domain = np.linspace(0, 4, 1_000)\n",
+    "plot_domain = np.linspace(0, 3, 1_000)\n",
     "sliders.set_ranges(\n",
     "    m_a=(0, 2, 200),\n",
     "    m_b=(0, 2, 200),\n",
@@ -268,6 +268,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "remove-output",
      "hide-input"
@@ -279,7 +282,7 @@
     "ax_abs, ax_real, ax_imag = axes\n",
     "for ax in axes:\n",
     "    ax.set_xlabel(\"$m$\")\n",
-    "ylim = (-0.02, 0.05)\n",
+    "ylim = (0, 0.05)\n",
     "\n",
     "ax_abs.set_title(R\"$\\left|\\rho\\right|$\")\n",
     "controls = iplt.plot(\n",

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -193,13 +193,11 @@
    },
    "outputs": [],
    "source": [
-    "rho_analytic_subs = rho_analytic.subs(\n",
-    "    {\n",
-    "        rho: sp.Symbol(R\"\\hat{\\rho}\"),\n",
-    "        1 / rho: sp.Symbol(R\"\\left(\\hat{\\rho}\\right)^{-1}\"),\n",
-    "    }\n",
-    ")\n",
-    "Math(fR\"\\hat{{\\rho}}(s) = {sp.latex(rho_analytic_subs)}\")"
+    "from ampform.dynamics import _analytic_continuation\n",
+    "\n",
+    "_analytic_continuation(\n",
+    "    sp.Symbol(R\"\\hat{\\rho}\"), s, s_threshold=(m_a + m_b) ** 2\n",
+    ")"
    ]
   },
   {
@@ -242,7 +240,7 @@
    "source": [
     "m = sp.Symbol(\"m\", real=True)\n",
     "rho = phase_space_factor(m ** 2, m_a, m_b)\n",
-    "rho_ac = phase_space_factor_ac(m ** 2, m_a, m_b) * 8 * sp.pi\n",
+    "rho_ac = phase_space_factor_ac(m ** 2, m_a, m_b)\n",
     "np_rho, sliders = symplot.prepare_sliders(plot_symbol=m, expression=rho)\n",
     "np_rho_ac = sp.lambdify((m, m_a, m_b), rho_ac, \"numpy\")"
    ]
@@ -255,14 +253,14 @@
    },
    "outputs": [],
    "source": [
-    "plot_domain = np.linspace(0, 5, 1_000)\n",
+    "plot_domain = np.linspace(0, 4, 1_000)\n",
     "sliders.set_ranges(\n",
     "    m_a=(0, 2, 200),\n",
     "    m_b=(0, 2, 200),\n",
     ")\n",
     "sliders.set_values(\n",
-    "    m_a=0.4,\n",
-    "    m_b=0.9,\n",
+    "    m_a=0.45,\n",
+    "    m_b=1.4,\n",
     ")"
    ]
   },
@@ -270,9 +268,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
      "remove-output",
      "hide-input"
@@ -280,12 +275,11 @@
    },
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(1, 3, figsize=(10, 4), tight_layout=True)\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(10, 4), tight_layout=True, sharey=True)\n",
     "ax_abs, ax_real, ax_imag = axes\n",
     "for ax in axes:\n",
     "    ax.set_xlabel(\"$m$\")\n",
-    "    ax.set_yticks([])\n",
-    "ylim = (0, 0.05)\n",
+    "ylim = (-0.02, 0.05)\n",
     "\n",
     "ax_abs.set_title(R\"$\\left|\\rho\\right|$\")\n",
     "controls = iplt.plot(\n",
@@ -295,6 +289,7 @@
     "    **sliders,\n",
     "    ylim=ylim,\n",
     "    ax=ax_abs,\n",
+    "    linestyle=\"dotted\",\n",
     ")\n",
     "iplt.plot(\n",
     "    plot_domain,\n",
@@ -303,6 +298,7 @@
     "    controls=controls,\n",
     "    ylim=ylim,\n",
     "    ax=ax_abs,\n",
+    "    linestyle=\"dashed\",\n",
     ")\n",
     "plt.legend(loc=\"upper right\")\n",
     "\n",
@@ -314,6 +310,7 @@
     "    controls=controls,\n",
     "    ylim=ylim,\n",
     "    ax=ax_real,\n",
+    "    linestyle=\"dotted\",\n",
     ")\n",
     "iplt.plot(\n",
     "    plot_domain,\n",
@@ -322,6 +319,7 @@
     "    controls=controls,\n",
     "    ylim=ylim,\n",
     "    ax=ax_real,\n",
+    "    linestyle=\"dashed\",\n",
     ")\n",
     "plt.legend(loc=\"upper right\")\n",
     "\n",
@@ -332,6 +330,7 @@
     "    label=\"normal\",\n",
     "    controls=controls,\n",
     "    ylim=ylim,\n",
+    "    linestyle=\"dotted\",\n",
     "    ax=ax_imag,\n",
     ")\n",
     "iplt.plot(\n",
@@ -341,6 +340,7 @@
     "    controls=controls,\n",
     "    ylim=ylim,\n",
     "    ax=ax_imag,\n",
+    "    linestyle=\"dashed\",\n",
     ")\n",
     "plt.legend(loc=\"upper right\")\n",
     "\n",

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -184,6 +184,7 @@ class PhaseSpaceFactor(Protocol):
     def __call__(
         self, s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
     ) -> sp.Expr:
+        """Expected `~inspect.signature`."""
         ...
 
 
@@ -203,25 +204,31 @@ def phase_space_factor_ac(
 ) -> sp.Expr:
     """Analytic continuation for the `phase_space_factor`.
 
-    See :pdg-review:`2014; Resonances; p.8`.
+    See :pdg-review:`2014; Resonances; p.8` and
+    :doc:`/usage/dynamics/analytic-continuation`.
 
-    .. warning:: The PDG states that this formula applies to a two-body decay
-        **with equal masses** only.
+    **Warning**: The PDG specifically derives this formula for a two-body decay
+    *with equal masses*.
     """
     rho = phase_space_factor(s, m_a, m_b)
     s_threshold = (m_a + m_b) ** 2
+    return _analytic_continuation(rho, s, s_threshold)
+
+
+def _analytic_continuation(
+    rho: sp.Symbol, s: sp.Symbol, s_threshold: sp.Symbol
+) -> sp.Expr:
     return sp.Piecewise(
         (
-            -rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
+            sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
             s < 0,
         ),
         (
-            (-rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))) + sp.I * rho)
-            / (sp.I * 16 * sp.pi * s),
+            rho + sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
             s > s_threshold,
         ),
         (
-            (-2 * rho / sp.pi * sp.atan(1 / rho)) / (sp.I * 16 * sp.pi * s),
+            2 * sp.I * rho / sp.pi * sp.atan(1 / rho),
             True,
         ),
     )

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -210,7 +210,8 @@ def phase_space_factor_ac(
     **Warning**: The PDG specifically derives this formula for a two-body decay
     *with equal masses*.
     """
-    rho = phase_space_factor(s, m_a, m_b)
+    q_squared = breakup_momentum_squared(s, m_a, m_b)
+    rho = sp.sqrt(sp.Abs(q_squared)) / (8 * sp.pi * sp.sqrt(s))
     s_threshold = (m_a + m_b) ** 2
     return _analytic_continuation(rho, s, s_threshold)
 


### PR DESCRIPTION
`phase_space_factor_ac` was taken from ComPWA, but this contained terms involving `s` that are already in the original `phase_space_factor` (which comes from the PDG, not ComPWA). In addition, the analytic continuation re-used the standard 'standard' `phase_space_factor`, which uses `complex_sqrt`. This has been fixed as well.