### PR TITLE
feat: wrap complex sqrt in symp.Expr class

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -84,6 +84,7 @@
         "jupyter",
         "lambdified",
         "lambdify",
+        "lambdifying",
         "lineshape",
         "lineshapes",
         "mathbb",

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,9 @@ disable=
     missing-module-docstring,   # pydocstyle
     redefined-builtin, # flake8-built
     too-few-public-methods, # data containers (attrs) and interface classes
+    ungrouped-imports,  # isort
     unused-import, # https://www.flake8rules.com/rules/F401
+    wrong-import-order,  # isort
 
 [SIMILARITIES]
 ignore-imports=yes # https://stackoverflow.com/a/30007053

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -13,9 +13,9 @@ import sympy as sp
 
 from ampform.dynamics import (
     BlattWeisskopfSquared,
+    ComplexSqrt,
     _analytic_continuation,
     breakup_momentum_squared,
-    complex_sqrt,
     coupled_width,
     phase_space_factor,
     phase_space_factor_ac,
@@ -99,11 +99,12 @@ def render_coupled_width() -> None:
 
 def render_complex_sqrt() -> None:
     x = sp.Symbol("x", real=True)
+    complex_sqrt = ComplexSqrt(x)
     update_docstring(
-        complex_sqrt,
-        fR"""
-    .. math:: {sp.latex(complex_sqrt(x))}
-        :label: complex_sqrt
+        ComplexSqrt,
+        f"""
+    .. math:: {sp.latex(complex_sqrt)} == {complex_sqrt.evaluate()}
+        :label: ComplexSqrt
     """,
     )
 

--- a/src/ampform/data.py
+++ b/src/ampform/data.py
@@ -22,7 +22,6 @@ from typing import (
 
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
-from numpy.lib.scimath import sqrt as complex_sqrt
 
 try:
     from numpy.typing import ArrayLike, DTypeLike
@@ -164,13 +163,15 @@ class FourMomentumSequence(NDArrayOperatorsMixin, abc.Sequence):
         return ScalarSequence(np.arccos(self.p_z / self.p_norm()))
 
     def mass(self) -> ScalarSequence:
-        mass_squared = self.mass_squared()
-        if np.min(mass_squared) < 0:
-            return ScalarSequence(complex_sqrt(mass_squared))
+        mass_squared = self.mass_squared(dtype=np.complex64)
         return ScalarSequence(np.sqrt(mass_squared))
 
-    def mass_squared(self) -> ScalarSequence:
-        return ScalarSequence(self.energy ** 2 - self.p_norm() ** 2)
+    def mass_squared(
+        self, dtype: Optional[DTypeLike] = None
+    ) -> ScalarSequence:
+        return ScalarSequence(
+            self.energy ** 2 - self.p_norm() ** 2, dtype=dtype
+        )
 
 
 class MatrixSequence(NDArrayOperatorsMixin, abc.Sequence):

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -1,4 +1,4 @@
-# cspell:ignore Asner
+# cspell:ignore asner Lambdifier
 # pylint: disable=protected-access, unbalanced-tuple-unpacking, unused-argument
 """Lineshape functions that describe the dynamics of an interaction.
 
@@ -9,6 +9,7 @@
 from typing import Any, Optional
 
 import sympy as sp
+from sympy.plotting.experimental_lambdify import Lambdifier
 from sympy.printing.printer import Printer
 
 from .decorator import (
@@ -401,3 +402,7 @@ class ComplexSqrt(sp.Expr):
         printer.module_imports["cmath"].add("sqrt as csqrt")
         x = printer._print(self.args[0])
         return f"csqrt({x})"
+
+
+# Needed for sympy.plot
+Lambdifier.builtin_functions_different["ComplexSqrt"] = "sqrt"

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -193,12 +193,12 @@ class PhaseSpaceFactor(Protocol):
 def phase_space_factor(
     s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
 ) -> sp.Expr:
-    """Standard phase-space factor, using `complex_sqrt`.
+    """Standard phase-space factor, using `ComplexSqrt`.
 
     See :pdg-review:`2020; Resonances; p.4`, Equation (49.8).
     """
     q_squared = breakup_momentum_squared(s, m_a, m_b)
-    return complex_sqrt(q_squared) / (8 * sp.pi * sp.sqrt(s))
+    return ComplexSqrt(q_squared) / (8 * sp.pi * sp.sqrt(s))
 
 
 def phase_space_factor_ac(
@@ -326,22 +326,6 @@ def breakup_momentum_squared(
     See :pdg-review:`2020; Kinematics; p.3`.
     """
     return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)
-
-
-def complex_sqrt(x: sp.Symbol) -> sp.Expr:
-    """Square root that follows the positive root if :math:`x < 0`.
-
-    >>> complex_sqrt(2)
-    sqrt(2)
-    >>> complex_sqrt(-2)
-    sqrt(2)*I
-    >>> complex_sqrt(-4)
-    2*I
-    """
-    return sp.Piecewise(
-        (sp.I * sp.sqrt(-x), x < 0),
-        (sp.sqrt(x), True),
-    )
 
 
 # cspell:ignore cmath csqrt numpycode

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -50,6 +50,7 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
 
     See also :ref:`usage/dynamics/lineshapes:Form factor`.
     """
+    is_commutative = True
 
     def __new__(  # pylint: disable=arguments-differ
         cls,
@@ -367,6 +368,7 @@ class ComplexSqrt(sp.Expr):
     This class is particularly important for lambdifying, because many
     computational backends have optimized 'complex square root' functions.
     """
+    is_commutative = True
 
     def __new__(  # pylint: disable=arguments-differ
         cls,

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -381,6 +381,8 @@ class ComplexSqrt(sp.Expr):
 
     def evaluate(self) -> sp.Expr:
         x = self.args[0]
+        if not x.is_real:
+            return sp.sqrt(x)
         return sp.Piecewise(
             (sp.I * sp.sqrt(-x), x < 0),
             (sp.sqrt(x), True),

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -396,9 +396,8 @@ class ComplexSqrt(sp.Expr):
         return fR"\sqrt[\mathrm{{c}}]{{{x}}}"
 
     def _numpycode(self, printer: Printer, *args: Any) -> str:
-        printer.module_imports["numpy.lib.scimath"].add("sqrt as csqrt")
         x = printer._print(self.args[0])
-        return f"csqrt({x})"
+        return f"sqrt({x})"
 
     def _pythoncode(self, printer: Printer, *args: Any) -> str:
         printer.module_imports["cmath"].add("sqrt as csqrt")

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -394,3 +394,8 @@ class ComplexSqrt(sp.Expr):
         printer.module_imports["numpy.lib.scimath"].add("sqrt as csqrt")
         x = printer._print(self.args[0])
         return f"csqrt({x})"
+
+    def _pythoncode(self, printer: Printer, *args: Any) -> str:
+        printer.module_imports["cmath"].add("sqrt as csqrt")
+        x = printer._print(self.args[0])
+        return f"csqrt({x})"

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from typing import Any, Callable, Type
 
 import sympy as sp
-from sympy.printing.latex import LatexPrinter
+from sympy.printing.latex import Printer
 
 
 class UnevaluatedExpression(sp.Expr):
@@ -23,7 +23,7 @@ class UnevaluatedExpression(sp.Expr):
         pass
 
     @abstractmethod
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+    def _latex(self, printer: Printer, *args: Any) -> str:
         """Provide a mathematical Latex representation for notebooks."""
         args = tuple(map(printer._print, self.args))
         return f"{self.__class__.__name__}{args}"

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,8 +1,10 @@
+# pylint: disable=no-self-use
 import pytest
 import qrules as q
 import sympy as sp
 from sympy import preorder_traversal
 
+from ampform.dynamics import ComplexSqrt
 from ampform.helicity import HelicityModel
 
 
@@ -99,3 +101,19 @@ def round_nested(expression: sp.Expr, n_decimals: int) -> sp.Expr:
         if isinstance(node, sp.Pow) and node.args[1] == 1 / 2:
             expression = expression.subs(node, round(node.n(), n_decimals))
     return expression
+
+
+class TestComplexSqrt:
+    @pytest.mark.parametrize("module", ["numpy"])
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            (4, 2),
+            (-4, 2j),
+        ],
+    )
+    def test_lambdify(self, module: str, input_value, expected):
+        x = sp.Symbol("x")
+        expr = ComplexSqrt(x)
+        lambdified_expr = sp.lambdify((x,), expr, module)
+        assert lambdified_expr(input_value) == expected

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -6,6 +6,7 @@ import pytest
 import qrules as q
 import sympy as sp
 from sympy import preorder_traversal
+from sympy.plotting.experimental_lambdify import experimental_lambdify
 
 from ampform.dynamics import ComplexSqrt
 from ampform.helicity import HelicityModel
@@ -107,6 +108,19 @@ def round_nested(expression: sp.Expr, n_decimals: int) -> sp.Expr:
 
 
 class TestComplexSqrt:
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            (1.0, 1.0),
+            (4, 2),
+        ],
+    )
+    def test_experimental_lambdify(self, input_value, expected):
+        x = sp.Symbol("x")
+        expr = ComplexSqrt(input_value)
+        lambdified = experimental_lambdify((x,), expr)
+        assert lambdified(input_value) == expected
+
     @pytest.mark.parametrize("module", ["math", "numpy"])
     @pytest.mark.parametrize(
         ("input_value", "expected"),

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,4 +1,7 @@
+# cspell:disable cmath
 # pylint: disable=no-self-use
+import cmath
+
 import pytest
 import qrules as q
 import sympy as sp
@@ -110,10 +113,11 @@ class TestComplexSqrt:
         [
             (4, 2),
             (-4, 2j),
+            (1j, cmath.sqrt(1j)),
         ],
     )
     def test_lambdify(self, module: str, input_value, expected):
         x = sp.Symbol("x")
         expr = ComplexSqrt(x)
         lambdified_expr = sp.lambdify((x,), expr, module)
-        assert lambdified_expr(input_value) == expected
+        assert pytest.approx(lambdified_expr(input_value)) == expected

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -126,7 +126,7 @@ class TestComplexSqrt:
         ("input_value", "expected"),
         [
             (4, 2),
-            (-4, 2j),
+            ((-4 + 0j), 2j),
             (1j, cmath.sqrt(1j)),
         ],
     )

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -104,7 +104,7 @@ def round_nested(expression: sp.Expr, n_decimals: int) -> sp.Expr:
 
 
 class TestComplexSqrt:
-    @pytest.mark.parametrize("module", ["numpy"])
+    @pytest.mark.parametrize("module", ["math", "numpy"])
     @pytest.mark.parametrize(
         ("input_value", "expected"),
         [

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -81,17 +81,22 @@ def test_generate(
     expression = round_nested(expression, n_decimals=2)
 
     expression = sp.piecewise_fold(expression)
-    assert isinstance(expression, sp.Piecewise)
-    expression, condition = expression.args[1].args
-    assert condition
-    assert isinstance(expression, sp.Add)
     a1, a2 = tuple(map(str, expression.args))
+    sqrt = "ComplexSqrt"
     if formalism == "canonical":
-        assert a1 == "0.08/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)"
-        assert a2 == "0.23/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)"
+        assert (
+            a1 == f"0.08/(-m**2 + 0.98 - 0.12*I*{sqrt}(m**2/4 - 0.02)/Abs(m))"
+        )
+        assert (
+            a2 == f"0.23/(-m**2 + 2.27 - 0.34*I*{sqrt}(m**2/4 - 0.02)/Abs(m))"
+        )
     elif formalism == "helicity":
-        assert a1 == "0.17/(-m**2 - 0.17*I*sqrt(m**2 - 0.07)/Abs(m) + 2.27)"
-        assert a2 == "0.06/(-m**2 - 0.06*I*sqrt(m**2 - 0.07)/Abs(m) + 0.98)"
+        assert (
+            a1 == f"0.17/(-m**2 + 2.27 - 0.34*I*{sqrt}(m**2/4 - 0.02)/Abs(m))"
+        )
+        assert (
+            a2 == f"0.06/(-m**2 + 0.98 - 0.12*I*{sqrt}(m**2/4 - 0.02)/Abs(m))"
+        )
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Replaces `complex_sqrt()` with a `ComplexSqrt` class that derives from `sympy.Expr`, so that it renders better in LaTeX expression. This also allows overwriting the lambdify methods, so that the `ComplexSqrt` can for instance be lambdified to [`numpy.lib.scimath.sqrt`](https://numpy.org/devdocs/reference/generated/numpy.lib.scimath.sqrt.html).

_This PR has been superseded by #58, but has been made to document how to provide custom lambdify methods._