### PR TITLE
docs: add tip about jupyter-katex

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -157,6 +157,7 @@
         "isinstance",
         "jpsi",
         "jupyterlab",
+        "katex",
         "kernelspec",
         "kmatrix",
         "kwargs",

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -292,6 +292,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{tip}\n",
+    "\n",
+    "To view the full expression for the amplitude model without crashing Jupyter Lab, install [`jupyterlab-katex`](https://pypi.org/project/jupyterlab-katex).\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plotting"
    ]
   },
@@ -622,7 +633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The complete amplitude model can only be rendered if [`jupyterlab-katex`](https://pypi.org/project/jupyterlab-katex) is installed. However, since KaTeX is less extensive than MathJax, this is only pointed out as a tip, and `jupyterlab-katex` is not added to the requirements.