### PR TITLE
fix: remove links to expertsystem

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,6 @@ nitpick_ignore = [
 intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable", None),
     "compwa-org": ("https://compwa-org.readthedocs.io", None),
-    "expertsystem": ("https://expertsystem.readthedocs.io/en/stable", None),
     "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "mpl_interactions": (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ nitpick_ignore = [
 # Intersphinx settings
 intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable", None),
-    "compwa-org": ("https://compwa-org.readthedocs.io", None),
+    "compwa-org": ("https://compwa-org.readthedocs.io/en/stable", None),
     "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "mpl_interactions": (

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,10 @@
 
 :::{margin}
 
-The original project was the {doc}`PWA Expert System <expertsystem:index>`.
-AmpForm originates from its {mod}`~expertsystem.amplitude` module.
+The original project was the [PWA Expert System](https://expertsystem.rtfd.io).
+AmpForm originates from its
+[`~expertsystem.amplitude`](https://expertsystem.readthedocs.io/en/stable/api/expertsystem.amplitude.html)
+module.
 
 :::
 

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the dynamic terms in an amplitude model are set to $1$ by the {class}`.HelicityAmplitudeBuilder`. The method {meth}`.set_dynamics` can then be used to set dynamics lineshapes for specific resonances. The {mod}`.dynamics.builder` module provides some tools to set standard lineshapes (see below), but it is also possible to set {doc}`custom dynamics <usage/dynamics/custom>`.\n",
+    "By default, the dynamic terms in an amplitude model are set to $1$ by the {class}`.HelicityAmplitudeBuilder`. The method {meth}`.set_dynamics` can then be used to set dynamics lineshapes for specific resonances. The {mod}`.dynamics.builder` module provides some tools to set standard lineshapes (see below), but it is also possible to set {doc}`custom dynamics </usage/dynamics/custom>`.\n",
     "\n",
     "The standard lineshapes provided by AmpForm are illustrated below. For more info, have a look at the following pages:\n",
     "\n",

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -226,7 +226,7 @@ def phase_space_factor_analytic(
 ) -> sp.Expr:
     """Analytic continuation for the :func:`phase_space_factor`.
 
-    See :pdg-review:`2014; Resonances; p.8` and
+    See :pdg-review:`2018; Resonances; p.9` and
     :doc:`/usage/dynamics/analytic-continuation`.
 
     **Warning**: The PDG specifically derives this formula for a two-body decay

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -48,7 +48,7 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
     where to use these Blatt-Weisskopf functions, see
     :cite:`asnerDalitzPlotAnalysis2006`.
 
-    See also :ref:`usage/dynamics/lineshapes:Form factor`.
+    See also :ref:`usage/dynamics:Form factor`.
     """
     is_commutative = True
 
@@ -169,7 +169,7 @@ def relativistic_breit_wigner(
 ) -> sp.Expr:
     """Relativistic Breit-Wigner lineshape.
 
-    See :ref:`usage/dynamics/lineshapes:_Without_ form factor` and
+    See :ref:`usage/dynamics:_Without_ form factor` and
     :cite:`asnerDalitzPlotAnalysis2006`.
     """
     return gamma0 * mass0 / (mass0 ** 2 - s - gamma0 * mass0 * sp.I)
@@ -329,7 +329,7 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     continuation of the `.BlattWeisskopfSquared` damping factor behavior at
     :math:`s = (m_a + m_b)^2`.
 
-    See :ref:`usage/dynamics/lineshapes:_With_ form factor` and
+    See :ref:`usage/dynamics:_With_ form factor` and
     :pdg-review:`2020; Resonances; p.6`.
     """
     q_squared = breakup_momentum_squared(s, m_a, m_b)


### PR DESCRIPTION
Some links in the `expertsystem`, because [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) is a bit too eager.