### PR TITLE
fix!: use same coefficient names for canonical

### DIFF
--- a/src/ampform/helicity/naming.py
+++ b/src/ampform/helicity/naming.py
@@ -159,20 +159,6 @@ class CanonicalAmplitudeNameGenerator(HelicityAmplitudeNameGenerator):
             names.append(canonical_name)
         return "; ".join(names)
 
-    def generate_coefficient_name(
-        self, transition: StateTransition, node_id: int
-    ) -> str:
-        incoming_state, outgoing_states = get_helicity_info(
-            transition, node_id
-        )
-        return (
-            _state_to_str(incoming_state, use_helicity=False)
-            + self.__generate_ls_arrow(transition, node_id)
-            + " ".join(
-                _state_to_str(s, use_helicity=False) for s in outgoing_states
-            )
-        )
-
     def __generate_ls_arrow(
         self, transition: StateTransition, node_id: int
     ) -> str:

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -19,10 +19,9 @@ class TestAmplitudeBuilder:
     def test_formulate(self, reaction: ReactionInfo):
         if reaction.formalism == "canonical-helicity":
             n_amplitudes = 16
-            n_parameters = 4
         else:
             n_amplitudes = 8
-            n_parameters = 2
+        n_parameters = 2
 
         model_builder = get_builder(reaction)
         model = model_builder.formulate()

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -18,10 +18,9 @@ def test_generate(
     formalism, model = amplitude_model
     if formalism == "canonical-helicity":
         n_amplitudes = 16
-        n_parameters = 10
     else:
         n_amplitudes = 8
-        n_parameters = 8
+    n_parameters = 8
     assert len(model.parameter_defaults) == n_parameters
     assert len(model.components) == 4 + n_amplitudes
     assert len(model.expression.free_symbols) == 7 + n_parameters


### PR DESCRIPTION
Partially reverts #80 by removing the distinction between coefficients in the canonical and helicity basis.

[stable branch on RTD](https://ampform.readthedocs.io/en/stable/usage/formalism.html):
![stable](https://user-images.githubusercontent.com/29308176/125647849-8018fba1-3587-4d46-ad2c-59cf503b4a7c.png)

[PR #96 on RTD](https://ampform--96.org.readthedocs.build/en/96/usage/formalism.html) (with cell output [here](https://ampform.readthedocs.io/en/revert-coefficient-names/usage/formalism.html)):
![reverted](https://user-images.githubusercontent.com/29308176/125647887-033455b5-5bd0-468e-875e-be46468ed09f.png)

This PR will be released as a pre-release for comparison, but it might be reverted in the actual follow-up release.