### PR TITLE
docs: extend docstrings helicity and kinematics

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,7 @@ ignore = # more info: https://www.flake8rules.com/
     RST299 # missing pygments
     RST201 # block quote ends without a blank line (black formatting)
     RST301 # unexpected indentation (related to google style docstring)
+    RST307 # false-positive error in math directive
     W503 # https://github.com/psf/black#line-breaks--binary-operators
 radon-max-cc = 8
 radon-no-assert = True

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -9,3 +9,4 @@ add_ignore =
     D203, # conflicts with D211
     D213, # multi-line docstring should start at the second line
     D407, # missing dashed underline after section
+    D416, # section name does not have to end with a colon

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -7,6 +7,7 @@ This small script is used by ``conf.py`` to dynamically modify docstrings.
 """
 
 import inspect
+import logging
 import textwrap
 from typing import Callable, Type, Union
 
@@ -27,7 +28,10 @@ from ampform.dynamics import (
     relativistic_breit_wigner_with_ff,
 )
 from ampform.dynamics.math import ComplexSqrt
+from ampform.helicity import formulate_wigner_d
 from ampform.kinematics import get_helicity_angle_label
+
+logging.getLogger().setLevel(logging.ERROR)
 
 
 def update_docstring(
@@ -123,6 +127,30 @@ def render_coupled_width() -> None:
     where :math:`B_L^2(q)` is defined by :eq:`BlattWeisskopfSquared`,
     :math:`q(s)` is defined by :eq:`breakup_momentum_squared`, and
     :math:`\rho(s)` is (by default) defined by :eq:`phase_space_factor`.
+    """,
+    )
+
+
+def render_formulate_wigner_d() -> None:
+    reaction = qrules.generate_transitions(
+        initial_state=[("J/psi(1S)", [+1])],
+        final_state=[("gamma", [+1]), "f(0)(980)"],
+    )
+    transition = reaction.transitions[0]
+    dot = qrules.io.asdot(transition, render_initial_state_id=True)
+    for state_id in [0, 1, -1]:
+        dot = dot.replace(
+            f'label="{state_id}: ',
+            f'label="{state_id+2}: ',
+        )
+
+    update_docstring(
+        formulate_wigner_d,
+        f"""
+    .. graphviz::
+      :align: center
+
+{textwrap.indent(dot, 6 * ' ')}
     """,
     )
 

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -7,8 +7,10 @@ This small script is used by ``conf.py`` to dynamically modify docstrings.
 """
 
 import inspect
+import textwrap
 from typing import Callable, Type, Union
 
+import qrules
 import sympy as sp
 
 from ampform.dynamics import (
@@ -25,6 +27,7 @@ from ampform.dynamics import (
     relativistic_breit_wigner_with_ff,
 )
 from ampform.dynamics.math import ComplexSqrt
+from ampform.kinematics import get_helicity_angle_label
 
 
 def update_docstring(
@@ -120,6 +123,36 @@ def render_coupled_width() -> None:
     where :math:`B_L^2(q)` is defined by :eq:`BlattWeisskopfSquared`,
     :math:`q(s)` is defined by :eq:`breakup_momentum_squared`, and
     :math:`\rho(s)` is (by default) defined by :eq:`phase_space_factor`.
+    """,
+    )
+
+
+def render_get_helicity_angle_label() -> None:
+    topologies = qrules.topology.create_isobar_topologies(5)
+    dot1, dot2, *_ = tuple(
+        map(lambda t: qrules.io.asdot(t, render_resonance_id=True), topologies)
+    )
+    assert len
+    update_docstring(
+        get_helicity_angle_label,
+        f"""
+
+    .. panels::
+      :body: text-center
+
+      .. graphviz::
+        :name: one-to-five-topology-0
+        :caption: :code:`topologies[0]`
+
+{textwrap.indent(dot1, 8 * ' ')}
+
+      ---
+
+      .. graphviz::
+        :name: one-to-five-topology-1
+        :caption: :code:`topologies[1]`
+
+{textwrap.indent(dot2, 8 * ' ')}
     """,
     )
 

--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -146,17 +146,17 @@ def render_formulate_clebsch_gordan_coefficients() -> None:
     update_docstring(
         formulate_clebsch_gordan_coefficients,
         __get_graphviz_state_transition_example(
-            formalism="canonical-helicity", transition_number=1, gamma_spin=-1
+            formalism="canonical-helicity", transition_number=1
         ),
     )
 
 
 def __get_graphviz_state_transition_example(
-    formalism: str, transition_number: int = 0, gamma_spin: int = +1
+    formalism: str, transition_number: int = 0
 ) -> str:
     reaction = qrules.generate_transitions(
         initial_state=[("J/psi(1S)", [+1])],
-        final_state=[("gamma", [gamma_spin]), "f(0)(980)"],
+        final_state=[("gamma", [-1]), "f(0)(980)"],
         formalism=formalism,
     )
     transition = reaction.transitions[transition_number]

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -337,18 +337,55 @@ def extract_particle_collection(
 def formulate_clebsch_gordan_coefficients(
     transition: StateTransition, node_id: int
 ) -> sp.Expr:
-    """Compute two Clebsch-Gordan coefficients for a state transition node.
+    r"""Compute the two Clebsch-Gordan coefficients for a state transition node.
 
+    In the **canonical basis** (also called **partial wave basis**),
+    :doc:`Clebsch-Gordan coefficients <sympy:modules/physics/quantum/cg>`
+    ensure that the projection of angular momentum is conserved
+    (:cite:`kutschkeAngularDistributionCookbook1996`, p. 4). When calling
+    :func:`~qrules.generate_transitions` with
+    :code:`formalism="canonical-helicity"`, AmpForm formulates the amplitude in
+    the canonical basis from amplitudes in the helicity basis using the
+    transformation in :cite:`chungSpinFormalismsUpdated2014`, Eq. (4.32). See
+    also :cite:`kutschkeAngularDistributionCookbook1996`, Eq. (28).
+
+    This function produces the two Clebsch-Gordan coefficients in
+    :cite:`chungSpinFormalismsUpdated2014`, Eq. (4.32). For a two-body decay
+    :math:`1 \to 2, 3`, we get:
+
+    .. math:: C^{s_1,\lambda}_{L,0,S,\lambda} C^{S,\lambda}_{s_2,\lambda_2,s_3,-\lambda_3}
+        :label: formulate_clebsch_gordan_coefficients
+
+    with:
+
+    - :math:`s_i` the intrinsic `Spin.magnitude
+      <qrules.particle.Spin.magnitude>` of each state :math:`i`,
+    - :math:`\lambda_{2}, \lambda_{3}` the helicities of the decay products
+      (can be taken to be their `~qrules.transition.State.spin_projection` when
+      following a constistent boosting procedure),
+    - :math:`\lambda=\lambda_{2}-\lambda_{3}`,
+    - :math:`L` the *total* angular momentum of the final state pair
+      (`~qrules.quantum_numbers.InteractionProperties.l_magnitude`),
+    - :math:`S` the coupled spin magnitude of the final state pair
+      (`~qrules.quantum_numbers.InteractionProperties.s_magnitude`),
+    - and :math:`C^{j_3,m_3}_{j_1,m_1,j_2,m_2} = \langle
+      j1,m1;j2,m2|j3,m3\rangle`, as in :doc:`sympy:modules/physics/quantum/cg`.
+
+    Example
+    -------
     >>> import qrules
     >>> reaction = qrules.generate_transitions(
     ...     initial_state=[("J/psi(1S)", [+1])],
-    ...     final_state=[("gamma", [+1]), "f(0)(980)"],
+    ...     final_state=[("gamma", [-1]), "f(0)(980)"],
     ... )
-    >>> transition = reaction.transitions[0]
+    >>> transition = reaction.transitions[1]  # angular momentum 2
     >>> formulate_clebsch_gordan_coefficients(transition, node_id=0)
-    CG(0, 0, 1, 1, 1, 1)*CG(1, 1, 0, 0, 1, 1)
+    CG(1, -1, 0, 0, 1, -1)*CG(2, 0, 1, -1, 1, -1)
 
-    .. seealso:: :doc:`sympy:modules/physics/quantum/cg`
+    .. math::
+        C^{s_1,\lambda}_{L,0,S,\lambda} C^{S,\lambda}_{s_2,\lambda_2,s_3,-\lambda_3}
+        = C^{1,(-1-0)}_{2,0,1,(-1-0)} C^{1,(-1-0)}_{1,-1,0,0}
+        = C^{1,-1}_{2,0,1,-1} C^{1,-1}_{1,-1,0,0}
     """
     decay = TwoBodyDecay.from_transition(transition, node_id)
 

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -382,8 +382,35 @@ def formulate_clebsch_gordan_coefficients(
 
 
 def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
-    """Compute `~sympy.physics.quantum.spin.WignerD` for a transition node.
+    r"""Compute `~sympy.physics.quantum.spin.WignerD` for a transition node.
 
+    Following :cite:`kutschkeAngularDistributionCookbook1996`, Eq. (10). For a
+    two-body decay :math:`1 \to 2, 3`, we get
+
+    .. math:: D^{s_1}_{m_1,\lambda_2-\lambda_3}(-\phi,\theta,0)
+        :label: formulate_wigner_d
+
+    with:
+
+    - :math:`s_1` the `Spin.magnitude <qrules.particle.Spin.magnitude>` of the
+      decaying state,
+    - :math:`m_1` the `~qrules.transition.State.spin_projection` of the
+      decaying state,
+    - :math:`\lambda_{2}, \lambda_{3}` the helicities of the decay products in
+      in the restframe of :math:`1` (can be taken to be their intrinsic
+      `~qrules.transition.State.spin_projection` when following a constistent
+      boosting procedure),
+    - and :math:`\phi` and :math:`\theta` the helicity angles (see also
+      :func:`.get_helicity_angle_label`).
+
+    Note that :math:`\lambda_2, \lambda_3` are ordered by their number of
+    children, then by their state ID (see :class:`.TwoBodyDecay`).
+
+    See :cite:`kutschkeAngularDistributionCookbook1996`, Eq. (30) for an
+    example of Wigner-:math:`D` functions in a *sequential* two-body decay.
+
+    Example
+    -------
     >>> import qrules
     >>> reaction = qrules.generate_transitions(
     ...     initial_state=[("J/psi(1S)", [+1])],
@@ -392,6 +419,11 @@ def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
     >>> transition = reaction.transitions[0]
     >>> formulate_wigner_d(transition, node_id=0)
     WignerD(1, 1, 1, -phi_0, theta_0, 0)
+
+    .. math::
+        D^{s_1}_{m_1,\lambda_2-\lambda_3}\left(-\phi,\theta,0\right)
+        = D^{1}_{+1,(+1-0)}\left(-\phi_0,\theta_0,0\right)
+        = D^{1}_{1,1}\left(-\phi_0,\theta_0,0\right)
     """
     decay = TwoBodyDecay.from_transition(transition, node_id)
     _, phi, theta = _generate_kinematic_variables(transition, node_id)

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -451,16 +451,16 @@ def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
     >>> import qrules
     >>> reaction = qrules.generate_transitions(
     ...     initial_state=[("J/psi(1S)", [+1])],
-    ...     final_state=[("gamma", [+1]), "f(0)(980)"],
+    ...     final_state=[("gamma", [-1]), "f(0)(980)"],
     ... )
     >>> transition = reaction.transitions[0]
     >>> formulate_wigner_d(transition, node_id=0)
-    WignerD(1, 1, 1, -phi_0, theta_0, 0)
+    WignerD(1, 1, -1, -phi_0, theta_0, 0)
 
     .. math::
         D^{s_1}_{m_1,\lambda_2-\lambda_3}\left(-\phi,\theta,0\right)
-        = D^{1}_{+1,(+1-0)}\left(-\phi_0,\theta_0,0\right)
-        = D^{1}_{1,1}\left(-\phi_0,\theta_0,0\right)
+        = D^{1}_{+1,(-1-0)}\left(-\phi_0,\theta_0,0\right)
+        = D^{1}_{1,-1}\left(-\phi_0,\theta_0,0\right)
     """
     decay = TwoBodyDecay.from_transition(transition, node_id)
     _, phi, theta = _generate_kinematic_variables(transition, node_id)

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -409,7 +409,10 @@ def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
 
 
 def get_prefactor(transition: StateTransition) -> float:
-    """Calculate the product of all prefactors defined in this transition."""
+    """Calculate the product of all prefactors defined in this transition.
+
+    .. seealso:: `qrules.quantum_numbers.InteractionProperties.parity_prefactor`
+    """
     prefactor = 1.0
     for node_id in transition.topology.nodes:
         interaction = transition.interactions[node_id]

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -7,7 +7,7 @@ from qrules.particle import Spin
 from qrules.quantum_numbers import InteractionProperties
 from qrules.transition import State, StateTransition
 
-from ampform.kinematics import assert_two_body_decay
+from ampform.kinematics import _assert_two_body_decay
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -116,7 +116,7 @@ def get_helicity_info(
     transition: StateTransition, node_id: int
 ) -> Tuple[State, Tuple[State, State]]:
     """Extract in- and outgoing states for a two-body decay node."""
-    assert_two_body_decay(transition.topology, node_id)
+    _assert_two_body_decay(transition.topology, node_id)
     in_edge_ids = transition.topology.get_edge_ids_ingoing_to_node(node_id)
     out_edge_ids = transition.topology.get_edge_ids_outgoing_from_node(node_id)
     in_helicity_list = get_sorted_states(transition, in_edge_ids)

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -376,6 +376,15 @@ def determine_attached_final_state(
 
     These are attached downward (forward in time) for a given edge (resembling
     the root).
+
+    Example
+    -------
+    For **edge 5** in Figure :ref:`one-to-five-topology-0`, we get:
+
+    >>> from qrules.topology import create_isobar_topologies
+    >>> topologies = create_isobar_topologies(5)
+    >>> determine_attached_final_state(topologies[0], state_id=5)
+    [0, 3, 4]
     """
     edge = topology.edges[state_id]
     if edge.ending_node_id is None:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -178,6 +178,25 @@ def get_helicity_angle_label(
 
 
 def get_invariant_mass_label(topology: Topology, state_id: int) -> str:
+    """Generate an invariant mass label for a state (edge on a topology).
+
+    Example
+    -------
+    In the case shown in Figure :ref:`one-to-five-topology-0`, the invariant
+    mass of state :math:`5` is :math:`m_{034}`, because
+    :math:`p_5=p_0+p_3+p_4`:
+
+    >>> from qrules.topology import create_isobar_topologies
+    >>> topologies = create_isobar_topologies(5)
+    >>> get_invariant_mass_label(topologies[0], state_id=5)
+    'm_034'
+
+    Naturally, the 'invariant' mass label for a final state is just the mass of the
+    state itself:
+
+    >>> get_invariant_mass_label(topologies[0], state_id=1)
+    'm_1'
+    """
     final_state_ids = determine_attached_final_state(topology, state_id)
     return f"m_{''.join(map(str, sorted(final_state_ids)))}"
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -52,7 +52,7 @@ class HelicityAdapter:
         self.register_topology(transition.topology)
 
     def register_topology(self, topology: Topology) -> None:
-        assert_isobar_topology(topology)
+        _assert_isobar_topology(topology)
         if len(self.registered_topologies) == 0:
             object.__setattr__(
                 self,
@@ -153,7 +153,7 @@ def get_helicity_angle_label(
 
     As noted, the top-most parent (initial state) is not listed in the label.
     """
-    assert_isobar_topology(topology)
+    _assert_isobar_topology(topology)
 
     def recursive_label(topology: Topology, state_id: int) -> str:
         edge = topology.edges[state_id]
@@ -349,12 +349,12 @@ def _compute_invariant_masses(
     return DataSet(invariant_masses)
 
 
-def assert_isobar_topology(topology: Topology) -> None:
+def _assert_isobar_topology(topology: Topology) -> None:
     for node_id in topology.nodes:
-        assert_two_body_decay(topology, node_id)
+        _assert_two_body_decay(topology, node_id)
 
 
-def assert_two_body_decay(topology: Topology, node_id: int) -> None:
+def _assert_two_body_decay(topology: Topology, node_id: int) -> None:
     parent_state_ids = topology.get_edge_ids_ingoing_to_node(node_id)
     if len(parent_state_ids) != 1:
         raise ValueError(

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -24,8 +24,9 @@ class HelicityAdapter:
 
     The `.transform` method forms the bridge between four-momentum data for the
     decay you are studying and the kinematic variables that are in the
-    `.HelicityModel`. These are invariant mass and the :math:`\theta` and
-    :math:`\phi` helicity angles.
+    `.HelicityModel`. These are invariant mass (see
+    :func:`.get_invariant_mass_label`) and the :math:`\theta` and :math:`\phi`
+    helicity angles (see :func:`.get_helicity_angle_label`).
     """
 
     reaction_info: ReactionInfo = attr.ib(validator=instance_of(ReactionInfo))


### PR DESCRIPTION
Added several examples that explain the implementations in the `helicity` and `kinematics` modules.

A preview of the API can be viewed here:
https://ampform--100.org.readthedocs.build/en/100/api/ampform.html