### PR TITLE
docs: widen cell output where needed

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -54,6 +54,7 @@ def render_blatt_weisskopf() -> None:
         f"""
     .. math:: {sp.latex(ff2)} = {sp.latex(ff2.doit())}
         :label: BlattWeisskopfSquared
+        :class: full-width
     """,
     )
 

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -142,7 +142,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "intensities = model_no_dynamics.expression.args\n",
@@ -263,7 +267,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "some_amplitude = list(model.components.values())[0]\n",
@@ -458,7 +466,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "sorted(model.expression.free_symbols, key=lambda s: s.name)"
@@ -641,7 +653,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -156,7 +156,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -42,9 +42,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Dynamics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "{{ run_interactive }}"
    ]
   },
   {
@@ -266,13 +275,6 @@
     ")\n",
     "plt.legend()\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{{ run_interactive }}"
    ]
   },
   {
@@ -686,13 +688,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{{ run_interactive }}"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -700,7 +695,8 @@
      "source_hidden": true
     },
     "tags": [
-     "remove-input"
+     "remove-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -84,6 +84,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "{{ run_interactive }}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Analytic continuation allows one to handle resonances just below threshold ($m_0 < m_a + m_b$  in Eq. {eq}`relativistic_breit_wigner_with_ff`). In practice, this entails using a specific function for $\\rho$ in Eq. {eq}`coupled_width`."
    ]
   },
@@ -498,13 +505,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{{ run_interactive }}"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -512,7 +512,8 @@
      "source_hidden": true
     },
     "tags": [
-     "remove-input"
+     "remove-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -313,7 +313,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -90,7 +90,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "dot = qrules.io.asdot(reaction, collapse_graphs=True)\n",

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -129,7 +129,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "import inspect\n",
@@ -281,7 +285,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "m, theta = free_symbols\n",

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -517,7 +517,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -89,6 +89,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```{margin}\n",
+    "{cite}`meyerMatrixTutorial2008`, slide 14\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "A $K$-matrix for two poles and one channel can be parametrized as follows:"
    ]
   },
@@ -102,15 +111,6 @@
     "\n",
     "L = sp.Symbol(\"L\", integer=True)\n",
     "m_a, m_b, d = sp.symbols(\"m_a m_b d\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{margin}\n",
-    "{cite}`meyerMatrixTutorial2008`, slide 14\n",
-    "```"
    ]
   },
   {

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -407,6 +407,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "{{ run_interactive }}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "That's it. Now, we do the same as in {doc}`/usage/interactive`, but with some slight adaptations to combine the $K$-matrix and Breit-Wigner formulations of both amplitudes in one plot. Notice in the Argand plot how the $K$-matrix preserves unitarity, while the Breit-Wigners do not!"
    ]
   },
@@ -482,13 +489,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{{ run_interactive }}"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -496,7 +496,8 @@
      "source_hidden": true
     },
     "tags": [
-     "remove-input"
+     "remove-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -153,7 +153,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/formalism.ipynb
+++ b/docs/usage/formalism.ipynb
@@ -173,7 +173,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],
@@ -240,7 +241,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],
@@ -263,7 +265,8 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -343,7 +343,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "from symplot import SliderKwargs\n",
@@ -569,7 +573,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/usage/modify.ipynb
+++ b/docs/usage/modify.ipynb
@@ -141,7 +141,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "original_coefficients = [\n",
@@ -231,7 +235,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
     "assert new_model != original_model"
@@ -247,7 +258,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "new_model.parameter_defaults"
@@ -256,7 +271,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "new_model.components[\n",
@@ -286,7 +305,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
     "assert (\n",
@@ -314,7 +340,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "parameter_couplings = [\n",
@@ -391,7 +421,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "new_model.components[\n",
@@ -402,7 +436,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/usage/symplot.ipynb
+++ b/docs/usage/symplot.ipynb
@@ -263,7 +263,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Widen cells where their input and/or output is so wide that a horizontal scrollbar appears. This can be done with the `full-width` tag:
https://sphinx-book-theme.readthedocs.io/en/latest/layout.html#full-width-content

For instance:
![image](https://user-images.githubusercontent.com/29308176/126994273-dff09705-9dde-4a88-92c6-387c75a62aef.png)


versus ([v0.10.3](https://ampform.readthedocs.io/en/0.10.3/usage/amplitude.html#build-sympy-expression)):
![image](https://user-images.githubusercontent.com/29308176/126994210-0ef405d2-83e8-41cd-bee3-169ab1e9e9db.png)

