### PR TITLE
refactor: remove verify_signature

### DIFF
--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -11,11 +11,7 @@ from typing import Any, Optional
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
 
-from .decorator import (
-    UnevaluatedExpression,
-    implement_doit_method,
-    verify_signature,
-)
+from .decorator import UnevaluatedExpression, implement_doit_method
 from .math import ComplexSqrt
 
 try:
@@ -296,8 +292,6 @@ def coupled_width(  # pylint: disable=too-many-arguments
     """
     if phsp_factor is None:
         phsp_factor = phase_space_factor
-    else:
-        verify_signature(phsp_factor, PhaseSpaceFactor)
     assert phsp_factor is not None  # pyright v1.1.151
     q_squared = breakup_momentum_squared(s, m_a, m_b)
     q0_squared = breakup_momentum_squared(mass0 ** 2, m_a, m_b)

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -17,9 +17,6 @@ from . import (
     relativistic_breit_wigner_with_ff,
 )
 
-# pyright: reportUnusedImport=false
-from .decorator import verify_signature  # noqa: F401
-
 try:
     from typing import Protocol
 except ImportError:

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -1,8 +1,6 @@
 """Tools for defining lineshapes with `sympy`."""
 
-import inspect
 from abc import abstractmethod
-from collections import OrderedDict
 from typing import Any, Callable, Type
 
 import sympy as sp
@@ -101,30 +99,3 @@ def implement_doit_method() -> Callable[
         return decorated_class
 
     return decorator
-
-
-def verify_signature(builder: Callable, protocol: Type[Callable]) -> None:
-    """Check signature of a builder function dynamically.
-
-    Dynamically check whether a builder has the same signature as that of the
-    given `~typing.Protocol` (a `~typing.Callable`). This function is needed
-    because :func:`typing.runtime_checkable` only checks members and methods,
-    not the signature of those methods.
-    """
-    expected_signature = inspect.signature(protocol.__call__)
-    signature = inspect.signature(builder)
-    if signature.return_annotation != expected_signature.return_annotation:
-        raise ValueError(
-            f'Builder "{builder.__name__}" has return type {expected_signature.return_annotation};'
-            f" expected {signature.return_annotation}"
-        )
-    expected_parameters = OrderedDict(expected_signature.parameters.items())
-    del expected_parameters["self"]
-    assert signature.return_annotation == expected_signature.return_annotation
-    if signature.parameters != expected_parameters:
-        raise ValueError(
-            f'Builder "{builder.__name__}" has parameters\n'
-            f"  {list(signature.parameters.values())}\n"
-            "This should be\n"
-            f"  {list(expected_parameters.values())}"
-        )

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -32,7 +32,6 @@ from sympy.printing.latex import LatexPrinter
 from ampform.dynamics.builder import (
     ResonanceDynamicsBuilder,
     TwoBodyKinematicVariableSet,
-    verify_signature,
 )
 from ampform.kinematics import (
     HelicityAdapter,
@@ -150,7 +149,6 @@ class HelicityAmplitudeBuilder:
     def set_dynamics(
         self, particle_name: str, dynamics_builder: ResonanceDynamicsBuilder
     ) -> None:
-        verify_signature(dynamics_builder, ResonanceDynamicsBuilder)
         for transition in self.__reaction.transitions:
             for node_id in transition.topology.nodes:
                 decay = TwoBodyDecay.from_transition(transition, node_id)


### PR DESCRIPTION
This check makes the framework less flexible and the additional code is not worth the 'friendly' exception. It is required for https://github.com/ComPWA/compwa-org/pull/37, where a special class `PhaseSpaceFactor` is inserted into `coupled_width`.