### PR TITLE
fix: implement deep argument in doit, not new

### DIFF
--- a/src/ampform/__init__.py
+++ b/src/ampform/__init__.py
@@ -17,8 +17,8 @@ def get_builder(reaction: ReactionInfo) -> HelicityAmplitudeBuilder:
     """Get the correct `.HelicityAmplitudeBuilder`.
 
     For instance, get `.CanonicalAmplitudeBuilder` if the
-    `~qrules.transition.ReactionInfo.formalism` is :code:`"canonical-
-    helicity"`.
+    `~qrules.transition.ReactionInfo.formalism` is
+    :code:`"canonical-helicity"`.
     """
     formalism = reaction.formalism
     if formalism is None:

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -56,11 +56,9 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
         cls,
         angular_momentum: sp.Symbol,
         z: sp.Symbol,
-        evaluate: bool = False,
         **hints: Any,
     ) -> "BlattWeisskopfSquared":
-        args = sp.sympify((angular_momentum, z))
-        return create_expression(cls, evaluate, *args, **hints)
+        return create_expression(cls, angular_momentum, z, **hints)
 
     def evaluate(self) -> sp.Expr:
         angular_momentum, z = self.args

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -107,12 +107,16 @@ def implement_doit_method() -> Callable[
 
 
 def create_expression(
-    cls: Type[UnevaluatedExpression], evaluate: bool, *args: Any, **kwargs: Any
+    cls: Type[UnevaluatedExpression],
+    *args: Any,
+    evaluate: bool = False,
+    **kwargs: Any,
 ) -> sp.Expr:
     """Helper function for implementing :code:`Expr.__new__`.
 
     See e.g. source code of `.BlattWeisskopfSquared`.
     """
+    args = sp.sympify(args)
     expr = sp.Expr.__new__(cls, *args, **kwargs)
     if evaluate:
         return expr.evaluate()  # pylint: disable=no-member

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -1,5 +1,6 @@
 """Tools for defining lineshapes with `sympy`."""
 
+import functools
 from abc import abstractmethod
 from typing import Any, Callable, Type
 
@@ -92,6 +93,7 @@ def implement_doit_method() -> Callable[
     def decorator(
         decorated_class: Type[UnevaluatedExpression],
     ) -> Type[UnevaluatedExpression]:
+        @functools.wraps(decorated_class.doit)
         def doit_method(self: Any, deep: bool = True, **hints: Any) -> sp.Expr:
             expr = type(self)(*self.args, **hints, evaluate=True)
             if deep:

--- a/src/ampform/dynamics/decorator.py
+++ b/src/ampform/dynamics/decorator.py
@@ -1,7 +1,7 @@
 """Tools for defining lineshapes with `sympy`."""
 
 from abc import abstractmethod
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Type
 
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
@@ -92,8 +92,11 @@ def implement_doit_method() -> Callable[
     def decorator(
         decorated_class: Type[UnevaluatedExpression],
     ) -> Type[UnevaluatedExpression]:
-        def doit_method(self: Any, **hints: Any) -> sp.Expr:
-            return type(self)(*self.args, **hints, evaluate=True)
+        def doit_method(self: Any, deep: bool = True, **hints: Any) -> sp.Expr:
+            expr = type(self)(*self.args, **hints, evaluate=True)
+            if deep:
+                return expr.doit()
+            return expr
 
         decorated_class.doit = doit_method
         return decorated_class
@@ -108,11 +111,7 @@ def create_expression(
 
     See e.g. source code of `.BlattWeisskopfSquared`.
     """
-    # pylint: disable=no-member
-    deep: Optional[bool] = kwargs.pop("deep", None)
     expr = sp.Expr.__new__(cls, *args, **kwargs)
     if evaluate:
-        expr = expr.evaluate()
-    if deep:
-        expr = expr.doit(deep=deep)
+        return expr.evaluate()  # pylint: disable=no-member
     return expr


### PR DESCRIPTION
Fixes a small bug that was introduced by the new function `create_expression`, which was introduced in #113. That function allowed handling the `deep` argument in `doit`, so that expressions containing a `BlattWeisskopfSquared` can be called with `doit(deep=False)`. The fix was faulty though; this PR is the correct implementation.