### PR TITLE
refactor: rename decorator sub-module to sympy

### DIFF
--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -12,11 +12,12 @@ from typing import Any, Optional
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
 
-from .decorator import (
+from ampform.sympy import (
     UnevaluatedExpression,
     create_expression,
     implement_doit_method,
 )
+
 from .math import ComplexSqrt
 
 try:

--- a/src/ampform/sympy.py
+++ b/src/ampform/sympy.py
@@ -1,4 +1,4 @@
-"""Tools for defining lineshapes with `sympy`."""
+"""Tools that facilitate in building :mod:`sympy` expressions."""
 
 import functools
 from abc import abstractmethod


### PR DESCRIPTION
The `ampform.dynamics.decorator` sub-module does more than just providing decorators. It generally contains functions that help building `sympy.Expr` classes (and instances), so it is better moved and renamed to a more general place: `ampform.sympy`.