### PR TITLE
feat: allow modify expression names

### DIFF
--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -326,6 +326,7 @@ class CoupledWidth(UnevaluatedExpression):
 
     # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L74-L77
     __slots__ = ("phsp_factor",)
+    phsp_factor: PhaseSpaceFactorProtocol
     is_commutative = True
 
     def __new__(  # pylint: disable=too-many-arguments
@@ -353,7 +354,7 @@ class CoupledWidth(UnevaluatedExpression):
         expr._args = args
         expr.phsp_factor = PhaseSpaceFactor
         if evaluate:
-            return expr.evaluate()  # pylint: disable=no-member
+            return expr.evaluate()
         return expr
 
     def __getnewargs__(self) -> tuple:

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -352,6 +352,7 @@ class CoupledWidth(UnevaluatedExpression):
         expr._assumptions = cls.default_assumptions
         expr._mhash = None
         expr._args = args
+        expr.name = None
         expr.phsp_factor = PhaseSpaceFactor
         if evaluate:
             return expr.evaluate()
@@ -360,7 +361,7 @@ class CoupledWidth(UnevaluatedExpression):
     def __getnewargs__(self) -> tuple:
         # Pickling support, see
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L124-L126
-        return (*self.args, self.phsp_factor)
+        return (*self.args, self.name, self.phsp_factor)
 
     def evaluate(self) -> sp.Expr:
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius = self.args

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -195,7 +195,8 @@ class PhaseSpaceFactor(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"\rho\!\left({s}\right)"
+        name = R"\rho" if self.name is None else self.name
+        return fR"{name}\!\left({s}\right)"
 
 
 @implement_doit_method()
@@ -227,7 +228,8 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"\hat{{\rho}}\left({s}\right)"
+        name = R"\hat{\rho}" if self.name is None else self.name
+        return fR"{name}\left({s}\right)"
 
 
 @implement_doit_method()
@@ -256,7 +258,8 @@ class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"\rho_\mathrm{{ac}}\!\left({s}\right)"
+        name = R"\rho_\mathrm{ac}" if self.name is None else self.name
+        return fR"{name}\!\left({s}\right)"
 
 
 @implement_doit_method()
@@ -282,7 +285,8 @@ class PhaseSpaceFactorComplex(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"\rho_\mathrm{{c}}\!\left({s}\right)"
+        name = R"\rho_\mathrm{c}" if self.name is None else self.name
+        return fR"{name}\!\left({s}\right)"
 
 
 def _analytic_continuation(
@@ -379,7 +383,8 @@ class CoupledWidth(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"\Gamma\!\left({s}\right)"
+        name = R"\Gamma" if self.name is None else self.name
+        return fR"{name}\!\left({s}\right)"
 
 
 @implement_doit_method()
@@ -415,7 +420,8 @@ class BreakupMomentumSquared(UnevaluatedExpression):
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         s = printer._print(self.args[0])
-        return fR"q^2\!\left({s}\right)"
+        name = "q^2" if self.name is None else self.name
+        return fR"{name}\!\left({s}\right)"
 
 
 def relativistic_breit_wigner(


### PR DESCRIPTION
Added an instance attribute to `UnevaluatedExpr` so that it can be used in the LaTeX rendering. In addition, the LaTeX rendering of of classes like `PhaseSpaceFactor` is affected by the name of their arguments (if they have any). This comes in handy in the relativistic K-matrix, when we want to distinguish between different `CoupledWidth`s and `PhaseSpaceFactor`s in the LaTeX rendering.