### PR TITLE
fix!: define sqrt rho dagger as conjugate only

### DIFF
--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -846,9 +846,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, as in {ref}`usage/dynamics/k-matrix:Non-relativistic K-matrix`, the $\\boldsymbol{K}$-matrix reduces to something of a {func}`.relativistic_breit_wigner`. This time, the width has been replaced by a {class}`.CoupledWidth` and some {class}`.PhaseSpaceFactor`s have been inserted that take case of the decay into two decay products:[^conjugate-phsp-factor]\n",
-    "\n",
-    "[^conjugate-phsp-factor]: The two {class}`.PhaseSpaceFactor`s $\\sqrt{\\rho_0(s)}$ cancel out within phase space, where they are real."
+    "Again, as in {ref}`usage/dynamics/k-matrix:Non-relativistic K-matrix`, the $\\boldsymbol{K}$-matrix reduces to something of a {func}`.relativistic_breit_wigner`. This time, the width has been replaced by a {class}`.CoupledWidth` and some {class}`.PhaseSpaceFactor`s have been inserted that take case of the decay into two decay products:"
    ]
   },
   {

--- a/src/ampform/dynamics/kmatrix.py
+++ b/src/ampform/dynamics/kmatrix.py
@@ -202,8 +202,8 @@ class NonRelativisticPVector(TMatrix):
     def _create_matrices(
         n_channels: int,
     ) -> Tuple[sp.Matrix, sp.Matrix, sp.Matrix]:
-        k_matrix = create_symbol_matrix("K", m=n_channels, n=1)
-        p_vector = create_symbol_matrix("P", m=n_channels, n=n_channels)
+        k_matrix = create_symbol_matrix("K", m=n_channels, n=n_channels)
+        p_vector = create_symbol_matrix("P", m=n_channels, n=1)
         t_matrix = (sp.eye(n_channels) - sp.I * k_matrix).inv() * p_vector
         return t_matrix, k_matrix, p_vector
 

--- a/src/ampform/dynamics/kmatrix.py
+++ b/src/ampform/dynamics/kmatrix.py
@@ -204,8 +204,8 @@ class NonRelativisticPVector(TMatrix):
     ) -> Tuple[sp.Matrix, sp.Matrix, sp.Matrix]:
         k_matrix = create_symbol_matrix("K", m=n_channels, n=n_channels)
         p_vector = create_symbol_matrix("P", m=n_channels, n=1)
-        t_matrix = (sp.eye(n_channels) - sp.I * k_matrix).inv() * p_vector
-        return t_matrix, k_matrix, p_vector
+        f_vector = (sp.eye(n_channels) - sp.I * k_matrix).inv() * p_vector
+        return f_vector, k_matrix, p_vector
 
     @classmethod
     def formulate(
@@ -215,15 +215,15 @@ class NonRelativisticPVector(TMatrix):
         parametrize: bool = True,
         **kwargs: Any,
     ) -> sp.Matrix:
-        t_matrix, k_matrix, p_vector = cls._create_matrices(n_channels)
+        f_vector, k_matrix, p_vector = cls._create_matrices(n_channels)
         if not parametrize:
-            return t_matrix
+            return f_vector
         s = sp.Symbol("s")
         resonance_mass = sp.IndexedBase("m")
         resonance_width = sp.IndexedBase("Gamma")
         residue_constant = sp.IndexedBase("gamma")
         resonance_idx = sp.Symbol("R", integer=True, positive=True)
-        return t_matrix.xreplace(
+        return f_vector.xreplace(
             {
                 k_matrix[i, j]: NonRelativisticKMatrix.parametrization(
                     i=i,


### PR DESCRIPTION
Previously, rho dagger was erroneously taken to be the conjugate of the inverse (should be transpose). This fixes this error. It also extracts the rho-matrix construction to a separate function.

There was also a small bug in the _P_-vector: matrix size of _P_ and _K_ had been swapped.

---

Original:
![image](https://user-images.githubusercontent.com/29308176/128636160-8929d306-6503-473d-bd22-1495b9690a36.png)

New:
![image](https://user-images.githubusercontent.com/29308176/128636226-a8b05ddf-677d-4bc4-97a6-785353b2b702.png)
