### PR TITLE
refactor!: use n_poles instead of n_resonances

### DIFF
--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While {mod}`ampform` does not yet provide a generic way to formulate an amplitude model with $\\boldsymbol{K}$-matrix dynamics, the (experimental) {mod}`.kmatrix` module makes it fairly simple to produce a symbolic expression for a parameterized $\\boldsymbol{K}$-matrix with arbitrary resonances and channels and play around with it interactively. For more info on the $\\boldsymbol{K}$-matrix, see the classic paper by Chung {cite}`chungPartialWaveAnalysis1995`, {pdg-review}`Resonances`, or this instructive presentation {cite}`meyerMatrixTutorial2008`.\n",
+    "While {mod}`ampform` does not yet provide a generic way to formulate an amplitude model with $\\boldsymbol{K}$-matrix dynamics, the (experimental) {mod}`.kmatrix` module makes it fairly simple to produce a symbolic expression for a parameterized $\\boldsymbol{K}$-matrix with an arbitrary number of poles and channels and play around with it interactively. For more info on the $\\boldsymbol{K}$-matrix, see the classic paper by Chung {cite}`chungPartialWaveAnalysis1995`, {pdg-review}`Resonances`, or this instructive presentation {cite}`meyerMatrixTutorial2008`.\n",
     "\n",
     "Section {ref}`usage/dynamics/k-matrix:Physics` provides a summary of {cite}`chungPartialWaveAnalysis1995`, so that the equations can be referenced to in the {mod}`.kmatrix` module. It also points out some subtleties and deviations.\n",
     "\n",
@@ -122,7 +122,7 @@
     ]
    },
    "source": [
-    "The $\\boldsymbol{K}$-matrix formalism is used to describe coupled, two-body **formation processes** of the form $c_j d_j \\to R \\to a_i b_i$, with $i,j$ representing each separate channel and $R$ a number of resonances by which these channels are coupled."
+    "The $\\boldsymbol{K}$-matrix formalism is used to describe coupled, two-body **formation processes** of the form $c_j d_j \\to R \\to a_i b_i$, with $i,j$ representing each separate channel and $R$ an intermediate state by which these channels are coupled."
    ]
   },
   {
@@ -167,7 +167,7 @@
    "source": [
     "A small adaptation allows us to describe a coupled, two-body **production process** of the form $R \\to a_ib_i$ (see {ref}`usage/dynamics/k-matrix:Production processes`).\n",
     "\n",
-    "In the following, $n$ denotes the number of channels and $n_R$ the number of resonances. In the {mod}`.kmatrix` module, we use $0 \\leq i,j < n$ and $1 \\leq R \\leq n_R$."
+    "In the following, $n$ denotes the number of channels and $n_R$ the number of poles. In the {mod}`.kmatrix` module, we use $0 \\leq i,j < n$ and $1 \\leq R \\leq n_R$."
    ]
   },
   {
@@ -246,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Knowing the origin of the $\\boldsymbol{T}$-matrix, there is an important restriction that we need to comply with when we further formulate a {ref}`parametrization <usage/dynamics/k-matrix:Resonance parametrization>`: **unitarity**. This means that $\\boldsymbol{S}$ should conserve probability, namely $\\boldsymbol{S}^\\dagger\\boldsymbol{S} = \\boldsymbol{I}$. Luckily, there is a trick that makes this easier. If we express $\\boldsymbol{S}$ in terms of an operator $\\boldsymbol{K}$ by applying a [Cayley transformation](https://en.wikipedia.org/wiki/Cayley_transform):\n",
+    "Knowing the origin of the $\\boldsymbol{T}$-matrix, there is an important restriction that we need to comply with when we further formulate a {ref}`parametrization <usage/dynamics/k-matrix:Pole parametrization>`: **unitarity**. This means that $\\boldsymbol{S}$ should conserve probability, namely $\\boldsymbol{S}^\\dagger\\boldsymbol{S} = \\boldsymbol{I}$. Luckily, there is a trick that makes this easier. If we express $\\boldsymbol{S}$ in terms of an operator $\\boldsymbol{K}$ by applying a [Cayley transformation](https://en.wikipedia.org/wiki/Cayley_transform):\n",
     "\n",
     "```{margin}\n",
     "{cite}`chungPartialWaveAnalysis1995` Eq. (20)\n",
@@ -439,7 +439,7 @@
     "tags": []
    },
    "source": [
-    "### Resonance parametrization"
+    "### Pole parametrization"
    ]
   },
   {
@@ -476,7 +476,7 @@
     "\n",
     "with $\\gamma_{R,i}$ some _real_ constants and $\\Gamma^0_{R,i}$ the **partial width** of each pole. In the Lorentz-invariant form, the fixed width $\\Gamma^0$ is replaced by an \"energy dependent\" {class}`.CoupledWidth` $\\Gamma(s)$.[^phase-space-factor-normalization] The **width** for each pole can be computed as $\\Gamma^0_R = \\sum_i\\Gamma^0_{R,i}$.\n",
     "\n",
-    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.CoupledWidth` as in {pdg-review}`2020; Resonances; p.6`, Eq. (49.21). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor of the resonance mass. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_R(s)}$."
+    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.CoupledWidth` as in {pdg-review}`2020; Resonances; p.6`, Eq. (49.21). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor at the pole position $m_R$. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_i(m_R)}$."
    ]
   },
   {
@@ -500,7 +500,7 @@
     "\\end{eqnarray}\n",
     "$$ (P-vector parametrization)\n",
     "\n",
-    "with $B_{R,i}(q(s))$ the **centrifugal damping factor** (see {class}`~ampform.dynamics.BlattWeisskopfSquared`) for channel $i$ and $\\beta_R^0$ some (generally complex) constants that describe the production information of resonance $R$. Usually, these constants are rescaled just like the residue functions in {eq}`residue function`:\n",
+    "with $B_{R,i}(q(s))$ the **centrifugal damping factor** (see {class}`~ampform.dynamics.BlattWeisskopfSquared`) for channel $i$ and $\\beta_R^0$ some (generally complex) constants that describe the production information of the decaying state $R$. Usually, these constants are rescaled just like the residue functions in {eq}`residue function`:\n",
     "\n",
     "[^damping-factor-P-parametrization]: Just as with [^phase-space-factor-normalization], we have smuggled a bit in the last equation in order to be able to reproduce Eq. (49.19) in {pdg-review}`2020; Resonances; p.6` in the case $n=1,n_R=1$, on which {func}`.relativistic_breit_wigner_with_ff` is based.\n",
     "\n",
@@ -531,7 +531,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A non-relativistic $\\boldsymbol{K}$-matrix for an arbitrary number of channels and an arbitrary number of resonances can be formulated with the {meth}`.NonRelativisticKMatrix.formulate` method:"
+    "A non-relativistic $\\boldsymbol{K}$-matrix for an arbitrary number of channels and an arbitrary number of poles can be formulated with the {meth}`.NonRelativisticKMatrix.formulate` method:"
    ]
   },
   {
@@ -551,7 +551,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice how the $\\boldsymbol{K}$-matrix reduces to a {func}`.relativistic_breit_wigner` when there is one channel and one resonance (but for a residue constant $\\gamma$):"
+    "Notice how the $\\boldsymbol{K}$-matrix reduces to a {func}`.relativistic_breit_wigner` in the case of one channel and one pole (but for a residue constant $\\gamma$):"
    ]
   },
   {
@@ -568,7 +568,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's investigate the effect of using a $\\boldsymbol{K}$-matrix to describe **two resonances** in one channel and see how it compares with the sum of two Breit-Wigner functions. Two Breit-Wigner 'poles' with the same parameters would look like this:"
+    "Now let's investigate the effect of using a $\\boldsymbol{K}$-matrix to describe **two poles** in one channel and see how it compares with the sum of two Breit-Wigner functions (two 'resonances'). Two Breit-Wigner 'poles' with the same parameters would look like this:"
    ]
   },
   {
@@ -590,7 +590,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "while a $\\boldsymbol{K}$-matrix parametrizes the two resonances as:"
+    "while a $\\boldsymbol{K}$-matrix parametrizes the two poles as:"
    ]
   },
   {
@@ -829,7 +829,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Relativistic $\\boldsymbol{K}$-matrices for an arbitrary number of channels and an arbitrary number of resonances can be formulated with the {meth}`.RelativisticKMatrix.formulate` method:"
+    "Relativistic $\\boldsymbol{K}$-matrices for an arbitrary number of channels and an arbitrary number of poles can be formulated with the {meth}`.RelativisticKMatrix.formulate` method:"
    ]
   },
   {
@@ -868,7 +868,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly, the $\\boldsymbol{K}$-matrix with two resonances becomes (neglecting the $\\sqrt{\\rho_0(s)}$):"
+    "Similarly, the $\\boldsymbol{K}$-matrix with two poles becomes (neglecting the $\\sqrt{\\rho_0(s)}$):"
    ]
   },
   {
@@ -924,7 +924,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For one channel and an arbitrary number of resonances $n_R$, the $F$-vector gets the following form:"
+    "For one channel and an arbitrary number of poles $n_R$, the $F$-vector gets the following form:"
    ]
   },
   {
@@ -1344,7 +1344,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All $\\boldsymbol{K}$-matrices can be inspected interactively for arbitrary resonances and channels with the following applet:"
+    "All $\\boldsymbol{K}$-matrices can be inspected interactively for arbitrary poles and channels with the following applet:"
    ]
   },
   {

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -542,10 +542,8 @@
    "source": [
     "from ampform.dynamics.kmatrix import NonRelativisticKMatrix\n",
     "\n",
-    "n_resonances = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
-    "k_matrix_nr = NonRelativisticKMatrix.formulate(\n",
-    "    n_resonances=n_resonances, n_channels=1\n",
-    ")\n",
+    "n_poles = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
+    "k_matrix_nr = NonRelativisticKMatrix.formulate(n_poles=n_poles, n_channels=1)\n",
     "k_matrix_nr[0, 0]"
    ]
   },
@@ -562,7 +560,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k_matrix_1r = NonRelativisticKMatrix.formulate(n_resonances=1, n_channels=1)\n",
+    "k_matrix_1r = NonRelativisticKMatrix.formulate(n_poles=1, n_channels=1)\n",
     "k_matrix_1r[0, 0].doit().simplify()"
    ]
   },
@@ -601,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k_matrix_2r = NonRelativisticKMatrix.formulate(n_resonances=2, n_channels=1)\n",
+    "k_matrix_2r = NonRelativisticKMatrix.formulate(n_poles=2, n_channels=1)\n",
     "k_matrix = k_matrix_2r[0, 0].doit()"
    ]
   },
@@ -842,10 +840,8 @@
    "source": [
     "from ampform.dynamics.kmatrix import RelativisticKMatrix\n",
     "\n",
-    "n_resonances = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
-    "rel_k_matrix_nr = RelativisticKMatrix.formulate(\n",
-    "    n_resonances=n_resonances, n_channels=1\n",
-    ")\n",
+    "n_poles = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
+    "rel_k_matrix_nr = RelativisticKMatrix.formulate(n_poles=n_poles, n_channels=1)\n",
     "rel_k_matrix_nr[0, 0]"
    ]
   },
@@ -864,7 +860,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rel_k_matrix_1r = RelativisticKMatrix.formulate(n_resonances=1, n_channels=1)\n",
+    "rel_k_matrix_1r = RelativisticKMatrix.formulate(n_poles=1, n_channels=1)\n",
     "symplot.partial_doit(rel_k_matrix_1r[0, 0], sp.Sum).simplify(doit=False)"
    ]
   },
@@ -883,7 +879,7 @@
    },
    "outputs": [],
    "source": [
-    "rel_k_matrix_2r = RelativisticKMatrix.formulate(n_resonances=2, n_channels=1)\n",
+    "rel_k_matrix_2r = RelativisticKMatrix.formulate(n_poles=2, n_channels=1)\n",
     "rel_k_matrix_2r = symplot.partial_doit(rel_k_matrix_2r[0, 0], sp.Sum)"
    ]
   },
@@ -939,10 +935,8 @@
    "source": [
     "from ampform.dynamics.kmatrix import NonRelativisticPVector\n",
     "\n",
-    "n_resonances = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
-    "f_vector_nr = NonRelativisticPVector.formulate(\n",
-    "    n_resonances=n_resonances, n_channels=1\n",
-    ")\n",
+    "n_poles = sp.Symbol(\"n_R\", integer=True, positive=True)\n",
+    "f_vector_nr = NonRelativisticPVector.formulate(n_poles=n_poles, n_channels=1)\n",
     "f_vector_nr[0]"
    ]
   },
@@ -959,7 +953,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f_vector_1r = NonRelativisticPVector.formulate(n_resonances=1, n_channels=1)\n",
+    "f_vector_1r = NonRelativisticPVector.formulate(n_poles=1, n_channels=1)\n",
     "f_vector_1r[0].doit().simplify()"
    ]
   },
@@ -978,7 +972,7 @@
    },
    "outputs": [],
    "source": [
-    "f_vector_2r = NonRelativisticPVector.formulate(n_resonances=2, n_channels=1)\n",
+    "f_vector_2r = NonRelativisticPVector.formulate(n_poles=2, n_channels=1)\n",
     "f_vector = f_vector_2r[0].doit()"
    ]
   },
@@ -1206,8 +1200,8 @@
     "# 3D plot\n",
     "color_mesh = None\n",
     "color_mesh_bw = None\n",
-    "resonances_indicators = []\n",
-    "resonances_indicators_bw = []\n",
+    "pole_indicators = []\n",
+    "pole_indicators_bw = []\n",
     "\n",
     "\n",
     "def plot3(*, z_cutoff, complex_rendering, **kwargs):\n",
@@ -1242,8 +1236,8 @@
     "        color_mesh_bw.set_array(projection(Z_bw)[:-1, :-1])\n",
     "    color_mesh_bw.set_clim(vmin=-z_cutoff, vmax=+z_cutoff)\n",
     "\n",
-    "    if resonances_indicators:\n",
-    "        for R, (line, text) in enumerate(resonances_indicators, 1):\n",
+    "    if pole_indicators:\n",
+    "        for R, (line, text) in enumerate(pole_indicators, 1):\n",
     "            mass = kwargs[f\"m{R}\"]\n",
     "            line.set_xdata(mass)\n",
     "            text.set_x(mass + (x_max - x_min) * 0.008)\n",
@@ -1257,10 +1251,10 @@
     "                s=f\"$m_{R}$\",\n",
     "                c=\"red\",\n",
     "            )\n",
-    "            resonances_indicators.append((line, text))\n",
+    "            pole_indicators.append((line, text))\n",
     "\n",
-    "    if resonances_indicators_bw:\n",
-    "        for R, (line, text) in enumerate(resonances_indicators_bw, 1):\n",
+    "    if pole_indicators_bw:\n",
+    "        for R, (line, text) in enumerate(pole_indicators_bw, 1):\n",
     "            mass = kwargs[f\"m{R}\"]\n",
     "            line.set_xdata(mass)\n",
     "            text.set_x(mass + (x_max - x_min) * 0.008)\n",
@@ -1274,7 +1268,7 @@
     "                s=f\"$m_{R}$\",\n",
     "                c=\"red\",\n",
     "            )\n",
-    "            resonances_indicators_bw.append((line, text))\n",
+    "            pole_indicators_bw.append((line, text))\n",
     "\n",
     "\n",
     "# Create switch for imag/real/abs\n",
@@ -1375,7 +1369,7 @@
     "def plot(\n",
     "    kmatrix_type: TMatrix,\n",
     "    n_channels: int,\n",
-    "    n_resonances: int,\n",
+    "    n_poles: int,\n",
     "    angular_momentum: sp.Symbol = 0,\n",
     "    phsp_factor=dynamics.PhaseSpaceFactor,\n",
     ") -> None:\n",
@@ -1383,7 +1377,7 @@
     "    i, j = sp.symbols(\"i, j\", integer=True, negative=False)\n",
     "    j = i\n",
     "    expr = kmatrix_type.formulate(\n",
-    "        n_resonances=n_resonances,\n",
+    "        n_poles=n_poles,\n",
     "        n_channels=n_channels,\n",
     "        angular_momentum=angular_momentum,\n",
     "        phsp_factor=phsp_factor,\n",
@@ -1403,12 +1397,12 @@
     "    plot_domain_complex = X + Y * 1j\n",
     "\n",
     "    # Set slider values and ranges\n",
-    "    m0_values = np.linspace(x_min, x_max, num=n_resonances + 2)\n",
+    "    m0_values = np.linspace(x_min, x_max, num=n_poles + 2)\n",
     "    m0_values = m0_values[1:-1]\n",
     "    if \"L\" in sliders:\n",
     "        sliders.set_ranges(L=(0, 8))\n",
     "    sliders.set_ranges(i=(0, n_channels - 1))\n",
-    "    for R in range(1, n_resonances + 1):\n",
+    "    for R in range(1, n_poles + 1):\n",
     "        for i in range(n_channels):\n",
     "            if kmatrix_type is RelativisticKMatrix:\n",
     "                sliders.set_ranges(\n",
@@ -1465,11 +1459,11 @@
     "    if kmatrix_type in {NonRelativisticKMatrix, RelativisticKMatrix}:\n",
     "        fig.suptitle(\n",
     "            fR\"${n_channels} \\times {n_channels}$ $K$-matrix\"\n",
-    "            f\" with {n_resonances} resonances\"\n",
+    "            f\" with {n_poles} resonances\"\n",
     "        )\n",
     "    elif kmatrix_type is NonRelativisticPVector:\n",
     "        fig.suptitle(\n",
-    "            f\"$P$-vector for {n_channels} channels and {n_resonances} resonances\"\n",
+    "            f\"$P$-vector for {n_channels} channels and {n_poles} resonances\"\n",
     "        )\n",
     "\n",
     "    for ax in axes:\n",
@@ -1515,7 +1509,7 @@
     "\n",
     "    # 3D plot\n",
     "    color_mesh = None\n",
-    "    resonances_indicators = []\n",
+    "    pole_indicators = []\n",
     "    threshold_indicators = []\n",
     "\n",
     "    def plot3(*, z_cutoff, complex_rendering, **kwargs):\n",
@@ -1545,13 +1539,13 @@
     "            color_mesh.set_array(Z_values[:-1, :-1])\n",
     "        color_mesh.set_clim(vmin=-z_cutoff, vmax=+z_cutoff)\n",
     "\n",
-    "        if resonances_indicators:\n",
-    "            for R, (line, text) in enumerate(resonances_indicators, 1):\n",
+    "        if pole_indicators:\n",
+    "            for R, (line, text) in enumerate(pole_indicators, 1):\n",
     "                mass = kwargs[f\"m{R}\"]\n",
     "                line.set_xdata(mass)\n",
     "                text.set_x(mass + (x_max - x_min) * 0.008)\n",
     "        else:\n",
-    "            for R in range(1, n_resonances + 1):\n",
+    "            for R in range(1, n_poles + 1):\n",
     "                mass = kwargs[f\"m{R}\"]\n",
     "                line = ax_3d.axvline(mass, **mass_line_style)\n",
     "                text = ax_3d.text(\n",
@@ -1560,7 +1554,7 @@
     "                    s=f\"$m_{R}$\",\n",
     "                    c=\"red\",\n",
     "                )\n",
-    "                resonances_indicators.append((line, text))\n",
+    "                pole_indicators.append((line, text))\n",
     "\n",
     "        if kmatrix_type is RelativisticKMatrix:\n",
     "            x_offset = (x_max - x_min) * 0.015\n",
@@ -1646,7 +1640,7 @@
     "    # Create GUI\n",
     "    sliders_copy = dict(sliders)\n",
     "    h_boxes = []\n",
-    "    for R in range(1, n_resonances + 1):\n",
+    "    for R in range(1, n_poles + 1):\n",
     "        buttons = [sliders_copy.pop(f\"m{R}\")]\n",
     "        if n_channels == 1:\n",
     "            buttons += [\n",
@@ -1683,9 +1677,9 @@
     "%%time\n",
     "plot(\n",
     "    RelativisticKMatrix,\n",
-    "    n_resonances=2,\n",
-    "    n_channels=1,\n",
-    "    angular_momentum=L,\n",
+    "    n_poles=2,\n",
+    "    n_channels=2,\n",
+    "    angular_momentum=0,\n",
     "    phsp_factor=dynamics.PhaseSpaceFactor,\n",
     ")"
    ]

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -446,7 +446,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After all these matrix definitions, the final challenge is to choose a correct parametrization for the elements of $\\boldsymbol{K}$ and $P$ that accurately describes the resonances we observe. There are several choices, but a common one is the following summation over the **poles** $R$:[^complex-conjugate-parametrization]\n",
+    "After all these matrix definitions, the final challenge is to choose a correct parametrization for the elements of $\\boldsymbol{K}$ and $P$ that accurately describes the resonances we observe.[^pole-vs-resonance] There are several choices, but a common one is the following summation over the **poles** $R$:[^complex-conjugate-parametrization]\n",
     "\n",
     "[^complex-conjugate-parametrization]: Eqs. (51) and (52) in {cite}`chungPrimerKmatrixFormalism1995` take a complex conjugate of one of the residue functions and one of the phase space factors.\n",
     "\n",
@@ -1345,6 +1345,13 @@
    "metadata": {},
    "source": [
     "All $\\boldsymbol{K}$-matrices can be inspected interactively for arbitrary poles and channels with the following applet:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[^pole-vs-resonance]: See {pdg-review}`2020; Resonances; p.5` and Section 49.1 for a discussion about what poles and resonances are. See also the intro to Section 5 in {cite}`chungPartialWaveAnalysis1995`."
    ]
   },
   {

--- a/src/ampform/dynamics/kmatrix.py
+++ b/src/ampform/dynamics/kmatrix.py
@@ -29,7 +29,7 @@ class TMatrix(ABC):
     def formulate(
         cls,
         n_channels: int,
-        n_resonances: Union[int, sp.Symbol],
+        n_poles: Union[int, sp.Symbol],
         parametrize: bool = True,
         **kwargs: Any,
     ) -> sp.Matrix:
@@ -57,7 +57,7 @@ class RelativisticKMatrix(TMatrix):
     def formulate(
         cls,
         n_channels: int,
-        n_resonances: int,
+        n_poles: int,
         parametrize: bool = True,
         **kwargs: Any,
     ) -> sp.Matrix:
@@ -65,7 +65,7 @@ class RelativisticKMatrix(TMatrix):
 
         Args:
             n_channels: Number of coupled channels.
-            n_resonances: Number of poles.
+            n_poles: Number of poles.
             parametrize: Set to `False` if don't want to parametrize and
                 only get symbols for the matrix multiplication of
                 :math:`\boldsymbol{K}` and :math:`\boldsymbol{\rho}`.
@@ -96,7 +96,7 @@ class RelativisticKMatrix(TMatrix):
                     m_a=m_a,
                     m_b=m_b,
                     residue_constant=sp.IndexedBase("gamma"),
-                    n_resonances=n_resonances,
+                    n_poles=n_poles,
                     pole_id=sp.Symbol("R", integer=True, positive=True),
                     angular_momentum=kwargs.get("angular_momentum", 0),
                     meson_radius=kwargs.get("meson_radius", 1),
@@ -122,7 +122,7 @@ class RelativisticKMatrix(TMatrix):
         m_a: sp.IndexedBase,
         m_b: sp.IndexedBase,
         residue_constant: sp.IndexedBase,
-        n_resonances: Union[int, sp.Symbol],
+        n_poles: Union[int, sp.Symbol],
         pole_id: Union[int, sp.Symbol],
         angular_momentum: Union[int, sp.Symbol] = 0,
         meson_radius: Union[int, sp.Symbol] = 1,
@@ -146,7 +146,7 @@ class RelativisticKMatrix(TMatrix):
         g_i = residue_function(pole_id, i)
         g_j = residue_function(pole_id, j)
         parametrization = (g_i * g_j) / (pole_position[pole_id] ** 2 - s)
-        return sp.Sum(parametrization, (pole_id, 1, n_resonances))
+        return sp.Sum(parametrization, (pole_id, 1, n_poles))
 
 
 class NonRelativisticKMatrix(TMatrix):
@@ -161,7 +161,7 @@ class NonRelativisticKMatrix(TMatrix):
     def formulate(
         cls,
         n_channels: int,
-        n_resonances: int,
+        n_poles: int,
         parametrize: bool = True,
         **kwargs: Any,
     ) -> sp.Matrix:
@@ -177,7 +177,7 @@ class NonRelativisticKMatrix(TMatrix):
                     pole_position=sp.IndexedBase("m"),
                     pole_width=sp.IndexedBase("Gamma"),
                     residue_constant=sp.IndexedBase("gamma"),
-                    n_resonances=n_resonances,
+                    n_poles=n_poles,
                     pole_id=sp.Symbol("R", integer=True, positive=True),
                 )
                 for i in range(n_channels)
@@ -193,7 +193,7 @@ class NonRelativisticKMatrix(TMatrix):
         pole_position: sp.IndexedBase,
         pole_width: sp.IndexedBase,
         residue_constant: sp.IndexedBase,
-        n_resonances: Union[int, sp.Symbol],
+        n_poles: Union[int, sp.Symbol],
         pole_id: Union[int, sp.Symbol],
     ) -> sp.Expr:
         def residue_function(pole_id: int, i: int) -> sp.Expr:
@@ -204,7 +204,7 @@ class NonRelativisticKMatrix(TMatrix):
         g_i = residue_function(pole_id, i)
         g_j = residue_function(pole_id, j)
         parametrization = (g_i * g_j) / (pole_position[pole_id] ** 2 - s)
-        return sp.Sum(parametrization, (pole_id, 1, n_resonances))
+        return sp.Sum(parametrization, (pole_id, 1, n_poles))
 
 
 class NonRelativisticPVector(TMatrix):
@@ -222,7 +222,7 @@ class NonRelativisticPVector(TMatrix):
     def formulate(
         cls,
         n_channels: int,
-        n_resonances: int,
+        n_poles: int,
         parametrize: bool = True,
         **kwargs: Any,
     ) -> sp.Matrix:
@@ -243,7 +243,7 @@ class NonRelativisticPVector(TMatrix):
                     pole_position=pole_position,
                     pole_width=pole_width,
                     residue_constant=residue_constant,
-                    n_resonances=n_resonances,
+                    n_poles=n_poles,
                     pole_id=pole_id,
                 )
                 for i in range(n_channels)
@@ -258,7 +258,7 @@ class NonRelativisticPVector(TMatrix):
                     pole_width=pole_width,
                     residue_constant=residue_constant,
                     beta_constant=sp.IndexedBase("beta"),
-                    n_resonances=n_resonances,
+                    n_poles=n_poles,
                     pole_id=pole_id,
                 )
                 for i in range(n_channels)
@@ -273,7 +273,7 @@ class NonRelativisticPVector(TMatrix):
         pole_width: sp.IndexedBase,
         residue_constant: sp.IndexedBase,
         beta_constant: sp.IndexedBase,
-        n_resonances: Union[int, sp.Symbol],
+        n_poles: Union[int, sp.Symbol],
         pole_id: Union[int, sp.Symbol],
     ) -> sp.Expr:
         beta = beta_constant[pole_id]
@@ -281,7 +281,7 @@ class NonRelativisticPVector(TMatrix):
         mass = pole_position[pole_id]
         width = pole_width[pole_id, i]
         parametrization = beta * gamma * mass * width / (mass ** 2 - s)
-        return sp.Sum(parametrization, (pole_id, 1, n_resonances))
+        return sp.Sum(parametrization, (pole_id, 1, n_poles))
 
 
 def _create_rho_matrix(n_channels: int) -> sp.Matrix:

--- a/tests/dynamics/test_kmatrix.py
+++ b/tests/dynamics/test_kmatrix.py
@@ -15,7 +15,7 @@ class TestNonRelativisticKMatrix:
     )
     def test_breit_wigner(self, n_channels: int):
         k_matrix = NonRelativisticKMatrix.formulate(
-            n_resonances=1, n_channels=n_channels
+            n_poles=1, n_channels=n_channels
         )
         breit_wigner = k_matrix[0, 0].doit().simplify()
         breit_wigner = substitute_indexed_symbols(breit_wigner)
@@ -28,9 +28,7 @@ class TestNonRelativisticKMatrix:
         assert str(breit_wigner) == fR"-m1*w1/(-m1**2 + {factor}I*m1*w1 + s)"
 
     def test_interference_single_channel(self):
-        k_matrix = NonRelativisticKMatrix.formulate(
-            n_resonances=2, n_channels=1
-        )
+        k_matrix = NonRelativisticKMatrix.formulate(n_poles=2, n_channels=1)
         expr = k_matrix[0, 0].doit()
         expr = substitute_indexed_symbols(expr)
         expr = _remove_residue_constants(expr)


### PR DESCRIPTION
All arguments named `n_resonances` have been renamed `n_poles`. The formulations in the theory section for the _K_-matrix now also prefer "pole" over "resonance".