### PR TITLE
refactor: hide name attribute from UnevaluatedExpr

### DIFF
--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -186,7 +186,7 @@ class PhaseSpaceFactor(UnevaluatedExpression):
         s, m_a, _ = self.args
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(m_a))
-        name = R"\rho" + subscript if self.name is None else self.name
+        name = R"\rho" + subscript if self._name is None else self._name
         return fR"{name}\left({s}\right)"
 
 
@@ -221,7 +221,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
         s, m_a, _ = self.args
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(m_a))
-        name = R"\hat{\rho}" + subscript if self.name is None else self.name
+        name = R"\hat{\rho}" + subscript if self._name is None else self._name
         return fR"{name}\left({s}\right)"
 
 
@@ -254,7 +254,9 @@ class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(m_a))
         name = (
-            R"\rho^\mathrm{ac}" + subscript if self.name is None else self.name
+            R"\rho^\mathrm{ac}" + subscript
+            if self._name is None
+            else self._name
         )
         return fR"{name}\left({s}\right)"
 
@@ -285,7 +287,9 @@ class PhaseSpaceFactorComplex(UnevaluatedExpression):
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(m_a))
         name = (
-            R"\rho^\mathrm{c}" + subscript if self.name is None else self.name
+            R"\rho^\mathrm{c}" + subscript
+            if self._name is None
+            else self._name
         )
         return fR"{name}\left({s}\right)"
 
@@ -357,7 +361,7 @@ class CoupledWidth(UnevaluatedExpression):
         expr._assumptions = cls.default_assumptions
         expr._mhash = None
         expr._args = args
-        expr.name = None
+        expr._name = None
         expr.phsp_factor = PhaseSpaceFactor
         if evaluate:
             return expr.evaluate()
@@ -366,7 +370,7 @@ class CoupledWidth(UnevaluatedExpression):
     def __getnewargs__(self) -> tuple:
         # Pickling support, see
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L124-L126
-        return (*self.args, self.name, self.phsp_factor)
+        return (*self.args, self._name, self.phsp_factor)
 
     def evaluate(self) -> sp.Expr:
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius = self.args
@@ -386,7 +390,7 @@ class CoupledWidth(UnevaluatedExpression):
         s, _, width, *_ = self.args
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(width))
-        name = fR"\Gamma{subscript}" if self.name is None else self.name
+        name = fR"\Gamma{subscript}" if self._name is None else self._name
         return fR"{name}\left({s}\right)"
 
 
@@ -425,7 +429,7 @@ class BreakupMomentumSquared(UnevaluatedExpression):
         s, m_a, _ = self.args
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(m_a))
-        name = "q^2" + subscript if self.name is None else self.name
+        name = "q^2" + subscript if self._name is None else self._name
         return fR"{name}\left({s}\right)"
 
 

--- a/src/ampform/sympy.py
+++ b/src/ampform/sympy.py
@@ -19,8 +19,9 @@ class UnevaluatedExpression(sp.Expr):
     """
 
     # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L74-L77
-    __slots__: Tuple[str] = ("name",)
-    name: Optional[str]
+    __slots__: Tuple[str] = ("_name",)
+    _name: Optional[str]
+    """Optional instance attribute that can be used in LaTeX representations."""
 
     def __new__(  # pylint: disable=unused-argument
         cls, *args: Any, name: Optional[str] = None, **hints: Any
@@ -30,13 +31,13 @@ class UnevaluatedExpression(sp.Expr):
         obj._args = args
         obj._assumptions = cls.default_assumptions
         obj._mhash = None
-        obj.name = name
+        obj._name = name
         return obj
 
     def __getnewargs__(self) -> tuple:
         # Pickling support, see
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L124-L126
-        return (*self.args, self.name)
+        return (*self.args, self._name)
 
     @abstractmethod
     def evaluate(self) -> sp.Expr:
@@ -47,8 +48,8 @@ class UnevaluatedExpression(sp.Expr):
         """Provide a mathematical Latex representation for notebooks."""
         args = tuple(map(printer._print, self.args))
         name = self.__class__.__name__
-        if self.name is not None:
-            name = self.name
+        if self._name is not None:
+            name = self._name
         return f"{name}{args}"
 
 


### PR DESCRIPTION
The `name` instance attribute for classes that derive from `UnevaluatedExpression` not really meant to be part of the interface and clogs the API:

![image](https://user-images.githubusercontent.com/29308176/131313444-6fc67e4a-b67b-42e2-adc1-14f7e42eb75c.png)
