### PR TITLE
feat: set CoupledWidth name through constructor

### DIFF
--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -348,6 +348,7 @@ class CoupledWidth(UnevaluatedExpression):
         angular_momentum: sp.Symbol,
         meson_radius: sp.Symbol,
         phsp_factor: Optional[PhaseSpaceFactorProtocol] = None,
+        name: Optional[str] = None,
         evaluate: bool = False,
     ) -> "CoupledWidth":
         args = sp.sympify(
@@ -361,7 +362,7 @@ class CoupledWidth(UnevaluatedExpression):
         expr._assumptions = cls.default_assumptions
         expr._mhash = None
         expr._args = args
-        expr._name = None
+        expr._name = name
         expr.phsp_factor = phsp_factor
         if evaluate:
             return expr.evaluate()
@@ -370,7 +371,7 @@ class CoupledWidth(UnevaluatedExpression):
     def __getnewargs__(self) -> tuple:
         # Pickling support, see
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L124-L126
-        return (*self.args, self.phsp_factor)
+        return (*self.args, self.phsp_factor, self._name)
 
     def evaluate(self) -> sp.Expr:
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius = self.args

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -370,7 +370,7 @@ class CoupledWidth(UnevaluatedExpression):
     def __getnewargs__(self) -> tuple:
         # Pickling support, see
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L124-L126
-        return (*self.args, self._name, self.phsp_factor)
+        return (*self.args, self.phsp_factor)
 
     def evaluate(self) -> sp.Expr:
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius = self.args

--- a/tests/dynamics/test_sympy.py
+++ b/tests/dynamics/test_sympy.py
@@ -2,15 +2,18 @@ import pickle
 
 import sympy as sp
 
-from ampform.dynamics import BlattWeisskopfSquared
+from ampform.dynamics import (
+    BlattWeisskopfSquared,
+    CoupledWidth,
+    PhaseSpaceFactorAnalytic,
+)
 from ampform.sympy import UnevaluatedExpression
 
 
 class TestUnevaluatedExpression:
     @staticmethod
     def test_pickle():
-        z = sp.Symbol("z")
-        angular_momentum = sp.Symbol("L", integer=True)
+        s, m0, w0, m_a, angular_momentum, z = sp.symbols("s m0 Gamma0 m_a L z")
 
         # Pickle simple SymPy expression
         expr = z * angular_momentum
@@ -24,8 +27,23 @@ class TestUnevaluatedExpression:
         imported_expr = pickle.loads(pickled_obj)
         assert expr == imported_expr
 
-        # Pickle class derived from UnevaluatedExpression
+        # Pickle classes derived from UnevaluatedExpression
         expr = BlattWeisskopfSquared(angular_momentum, z=z)
+        pickled_obj = pickle.dumps(expr)
+        imported_expr = pickle.loads(pickled_obj)
+        assert expr == imported_expr
+
+        expr = CoupledWidth(
+            s=s,
+            mass0=m0,
+            gamma0=w0,
+            m_a=m_a,
+            m_b=m_a,
+            angular_momentum=0,
+            meson_radius=1,
+            phsp_factor=PhaseSpaceFactorAnalytic,
+            name="Gamma_1",
+        )
         pickled_obj = pickle.dumps(expr)
         imported_expr = pickle.loads(pickled_obj)
         assert expr == imported_expr

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -63,8 +63,10 @@ class TestCoupledWidth:
             angular_momentum=angular_momentum,
             meson_radius=d,
             phsp_factor=PhaseSpaceFactorAnalytic,
+            name="Gamma_1",
         )
         assert width.phsp_factor is PhaseSpaceFactorAnalytic
+        assert width._name == "Gamma_1"
 
 
 def test_generate(


### PR DESCRIPTION
`CoupledWidth._name` can now be set through the constructor, just like other classes that derive from `UnevaluatedExpression`.