### PR TITLE
feat: order components and parameter defaults

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,6 @@ autodoc_default_options = {
     "special-members": ", ".join(
         [
             "__call__",
-            "__eq__",
             "__getitem__",
         ]
     ),

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -112,16 +112,34 @@ class HelicityModel:
 
     @property
     def components(self) -> typing.OrderedDict[str, sp.Expr]:
+        """A mapping for identifying main components in the :attr:`expression`.
+
+        Keys are the component names (`str`), formatted as LaTeX, and values
+        are sub-expressions in the main :attr:`expression`. The mapping is an
+        `~collections.OrderedDict` that orders the component names
+        alphabetically with `natural sort order
+        <https://en.wikipedia.org/wiki/Natural_sort_order>`_.
+        """
         return self._components
 
     @property
     def parameter_defaults(
         self,
     ) -> typing.OrderedDict[sp.Symbol, ParameterValue]:
+        """A mapping of suggested parameter values.
+
+        Keys are `~sympy.core.symbol.Symbol` instances from the main
+        :attr:`expression` that should be interpreted as parameters (as opposed
+        to variables). The symbols are ordered alphabetically by name with
+        `natural sort order
+        <https://en.wikipedia.org/wiki/Natural_sort_order>`_. Values have been
+        extracted from the input `~qrules.transition.ReactionInfo`.
+        """
         return self._parameter_defaults
 
     @property
     def adapter(self) -> HelicityAdapter:
+        """Adapter for converting four-momenta to kinematic variables."""
         return self._adapter
 
     def sum_components(  # noqa: R701

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -1,10 +1,9 @@
 """Generate an amplitude model with the helicity formalism."""
 
+import collections
 import logging
 import operator
 import re
-import typing
-from collections import OrderedDict, defaultdict
 from difflib import get_close_matches
 from functools import reduce
 from typing import (
@@ -49,21 +48,26 @@ from .naming import (
     generate_transition_label,
 )
 
+try:
+    from typing import OrderedDict
+except ImportError:
+    from typing_extensions import OrderedDict  # type: ignore
+
 ParameterValue = Union[float, complex, int]
 
 
 def _order_component_mapping(
     mapping: Mapping[str, ParameterValue]
-) -> typing.OrderedDict[str, ParameterValue]:
-    return OrderedDict(
+) -> OrderedDict[str, ParameterValue]:
+    return collections.OrderedDict(
         [(key, mapping[key]) for key in sorted(mapping, key=_natural_sorting)]
     )
 
 
 def _order_symbol_mapping(
     mapping: Mapping[sp.Symbol, sp.Expr]
-) -> typing.OrderedDict[sp.Symbol, sp.Expr]:
-    return OrderedDict(
+) -> OrderedDict[sp.Symbol, sp.Expr]:
+    return collections.OrderedDict(
         [
             (symbol, mapping[symbol])
             for symbol in sorted(
@@ -93,10 +97,10 @@ class HelicityModel:
     _expression: sp.Expr = attr.ib(
         validator=attr.validators.instance_of(sp.Expr)
     )
-    _parameter_defaults: typing.OrderedDict[
-        sp.Symbol, ParameterValue
-    ] = attr.ib(converter=_order_symbol_mapping)
-    _components: typing.OrderedDict[str, sp.Expr] = attr.ib(
+    _parameter_defaults: OrderedDict[sp.Symbol, ParameterValue] = attr.ib(
+        converter=_order_symbol_mapping
+    )
+    _components: OrderedDict[str, sp.Expr] = attr.ib(
         converter=_order_component_mapping
     )
     _adapter: HelicityAdapter = attr.ib(
@@ -111,7 +115,7 @@ class HelicityModel:
         return self._expression
 
     @property
-    def components(self) -> typing.OrderedDict[str, sp.Expr]:
+    def components(self) -> OrderedDict[str, sp.Expr]:
         """A mapping for identifying main components in the :attr:`expression`.
 
         Keys are the component names (`str`), formatted as LaTeX, and values
@@ -123,9 +127,7 @@ class HelicityModel:
         return self._components
 
     @property
-    def parameter_defaults(
-        self,
-    ) -> typing.OrderedDict[sp.Symbol, ParameterValue]:
+    def parameter_defaults(self) -> OrderedDict[sp.Symbol, ParameterValue]:
         """A mapping of suggested parameter values.
 
         Keys are `~sympy.core.symbol.Symbol` instances from the main
@@ -561,7 +563,7 @@ def group_transitions(
             Tuple[Tuple[str, float], ...],
         ],
         List[StateTransition],
-    ] = defaultdict(list)
+    ] = collections.defaultdict(list)
     for transition in transitions:
         initial_state = sorted(
             (


### PR DESCRIPTION
`HelicityModel.components` and `HelicityModel.parameter_defaults` are now ordered alphabetically, so that you can also get them by index. ([Not entirely straight-forward](https://stackoverflow.com/a/10058239/13219025), but at least now it's guaranteed that the items are orderd.)