### PR TITLE
refactor: rename CoupledWidth

### DIFF
--- a/docs/extend_docstrings.py
+++ b/docs/extend_docstrings.py
@@ -22,7 +22,7 @@ import sympy as sp
 from ampform.dynamics import (
     BlattWeisskopfSquared,
     BreakupMomentumSquared,
-    CoupledWidth,
+    EnergyDependentWidth,
     PhaseSpaceFactor,
     PhaseSpaceFactorAbs,
     PhaseSpaceFactorAnalytic,
@@ -91,10 +91,10 @@ def render_complex_sqrt() -> None:
     )
 
 
-def render_coupled_width() -> None:
+def render_energy_dependent_width() -> None:
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b = sp.symbols("s m0 Gamma0 m_a m_b")
-    width = CoupledWidth(
+    width = EnergyDependentWidth(
         s=s,
         mass0=m0,
         gamma0=w0,
@@ -106,13 +106,13 @@ def render_coupled_width() -> None:
     latex = sp.multiline_latex(width, width.evaluate(), environment="eqnarray")
     latex = textwrap.indent(latex, prefix=8 * " ")
     update_docstring(
-        CoupledWidth,
+        EnergyDependentWidth,
         fR"""
     With that in mind, the "mass-dependent" width in a
     `.relativistic_breit_wigner_with_ff` becomes:
 
     .. math::
-        :label: CoupledWidth
+        :label: EnergyDependentWidth
 
         {latex}
 
@@ -309,7 +309,7 @@ def render_relativistic_breit_wigner_with_ff() -> None:
     .. math:: {sp.latex(rel_bw_with_ff)}
         :label: relativistic_breit_wigner_with_ff
 
-    where :math:`\Gamma(s)` is defined by :eq:`CoupledWidth`, :math:`B_L^2` is
+    where :math:`\Gamma(s)` is defined by :eq:`EnergyDependentWidth`, :math:`B_L^2` is
     defined by :eq:`BlattWeisskopfSquared`, and :math:`q^2` is defined by
     :eq:`BreakupMomentumSquared`.
     """,

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -378,7 +378,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, $\\Gamma(m)$ is the {class}`.CoupledWidth` (also called running width or mass-dependent width), defined as:"
+    "Here, $\\Gamma(m)$ is the {class}`.EnergyDependentWidth` (also called running width or mass-dependent width), defined as:"
    ]
   },
   {
@@ -389,10 +389,10 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import CoupledWidth\n",
+    "from ampform.dynamics import EnergyDependentWidth\n",
     "\n",
     "L = sp.Symbol(\"L\", integer=True)\n",
-    "width = CoupledWidth(\n",
+    "width = EnergyDependentWidth(\n",
     "    s=s,\n",
     "    mass0=m0,\n",
     "    gamma0=w0,\n",

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Analytic continuation allows one to handle resonances just below threshold ($m_0 < m_a + m_b$  in Eq. {eq}`relativistic_breit_wigner_with_ff`). In practice, this entails using a specific function for $\\rho$ in Eq. {eq}`CoupledWidth`."
+    "Analytic continuation allows one to handle resonances just below threshold ($m_0 < m_a + m_b$  in Eq. {eq}`relativistic_breit_wigner_with_ff`). In practice, this entails using a specific function for $\\rho$ in Eq. {eq}`EnergyDependentWidth`."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The 'normal' {class}`.PhaseSpaceFactor` (the denominator makes the difference to {eq}`CoupledWidth`!):"
+    "The 'normal' {class}`.PhaseSpaceFactor` (the denominator makes the difference to {eq}`EnergyDependentWidth`!):"
    ]
   },
   {

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -480,9 +480,9 @@
     "\\end{eqnarray}\n",
     "$$ (residue function)\n",
     "\n",
-    "with $\\gamma_{R,i}$ some _real_ constants and $\\Gamma^0_{R,i}$ the **partial width** of each pole. In the Lorentz-invariant form, the fixed width $\\Gamma^0$ is replaced by an \"energy dependent\" {class}`.CoupledWidth` $\\Gamma(s)$.[^phase-space-factor-normalization] The **width** for each pole can be computed as $\\Gamma^0_R = \\sum_i\\Gamma^0_{R,i}$.\n",
+    "with $\\gamma_{R,i}$ some _real_ constants and $\\Gamma^0_{R,i}$ the **partial width** of each pole. In the Lorentz-invariant form, the fixed width $\\Gamma^0$ is replaced by an \"energy dependent\" {class}`.EnergyDependentWidth` $\\Gamma(s)$.[^phase-space-factor-normalization] The **width** for each pole can be computed as $\\Gamma^0_R = \\sum_i\\Gamma^0_{R,i}$.\n",
     "\n",
-    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.CoupledWidth` as in {pdg-review}`2020; Resonances; p.6`, Eq. (49.21). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor at the pole position $m_R$. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_i(m_R)}$."
+    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.EnergyDependentWidth` as in {pdg-review}`2020; Resonances; p.6`, Eq. (49.21). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor at the pole position $m_R$. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_i(m_R)}$."
    ]
   },
   {
@@ -854,7 +854,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, as in {ref}`usage/dynamics/k-matrix:Non-relativistic K-matrix`, the $\\boldsymbol{K}$-matrix reduces to something of a {func}`.relativistic_breit_wigner`. This time, the width has been replaced by a {class}`.CoupledWidth` and some {class}`.PhaseSpaceFactor`s have been inserted that take care of the decay into two decay products:"
+    "Again, as in {ref}`usage/dynamics/k-matrix:Non-relativistic K-matrix`, the $\\boldsymbol{K}$-matrix reduces to something of a {func}`.relativistic_breit_wigner`. This time, the width has been replaced by a {class}`.EnergyDependentWidth` and some {class}`.PhaseSpaceFactor`s have been inserted that take care of the decay into two decay products:"
    ]
   },
   {

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -149,7 +149,7 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
 
 
 class PhaseSpaceFactorProtocol(Protocol):
-    """Protocol that is used by `.CoupledWidth`.
+    """Protocol that is used by `.EnergyDependentWidth`.
 
     Use this `~typing.Protocol` when defining other implementations of a phase
     space factor. Compare for instance `.PhaseSpaceFactor` and
@@ -319,7 +319,7 @@ def _phase_space_factor_denominator(s: sp.Symbol) -> sp.Expr:
 
 
 @implement_doit_method
-class CoupledWidth(UnevaluatedExpression):
+class EnergyDependentWidth(UnevaluatedExpression):
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
     See :pdg-review:`2020; Resonances; p.6` and
@@ -351,7 +351,7 @@ class CoupledWidth(UnevaluatedExpression):
         phsp_factor: Optional[PhaseSpaceFactorProtocol] = None,
         name: Optional[str] = None,
         evaluate: bool = False,
-    ) -> "CoupledWidth":
+    ) -> "EnergyDependentWidth":
         args = sp.sympify(
             (s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius)
         )
@@ -467,7 +467,7 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
         angular_momentum, z=q_squared * meson_radius ** 2
     )
     form_factor = sp.sqrt(ff_squared)
-    mass_dependent_width = CoupledWidth(
+    mass_dependent_width = EnergyDependentWidth(
         s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius, phsp_factor
     )
     return (mass0 * gamma0 * form_factor) / (

--- a/src/ampform/dynamics/kmatrix.py
+++ b/src/ampform/dynamics/kmatrix.py
@@ -18,7 +18,7 @@ import sympy as sp
 from ampform.dynamics import (
     BlattWeisskopfSquared,
     BreakupMomentumSquared,
-    CoupledWidth,
+    EnergyDependentWidth,
     PhaseSpaceFactor,
     PhaseSpaceFactorProtocol,
 )
@@ -133,7 +133,7 @@ class RelativisticKMatrix(TMatrix):
         def residue_function(pole_id: int, i: int) -> sp.Expr:
             return residue_constant[pole_id, i] * sp.sqrt(
                 pole_position[pole_id]
-                * CoupledWidth(
+                * EnergyDependentWidth(
                     s=s,
                     mass0=pole_position[pole_id],
                     gamma0=pole_width[pole_id, i],

--- a/tests/dynamics/test_sympy.py
+++ b/tests/dynamics/test_sympy.py
@@ -4,7 +4,7 @@ import sympy as sp
 
 from ampform.dynamics import (
     BlattWeisskopfSquared,
-    CoupledWidth,
+    EnergyDependentWidth,
     PhaseSpaceFactorAnalytic,
 )
 from ampform.sympy import UnevaluatedExpression
@@ -33,7 +33,7 @@ class TestUnevaluatedExpression:
         imported_expr = pickle.loads(pickled_obj)
         assert expr == imported_expr
 
-        expr = CoupledWidth(
+        expr = EnergyDependentWidth(
             s=s,
             mass0=m0,
             gamma0=w0,

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -10,7 +10,7 @@ from sympy import preorder_traversal
 from ampform.dynamics import (
     BlattWeisskopfSquared,
     ComplexSqrt,
-    CoupledWidth,
+    EnergyDependentWidth,
     PhaseSpaceFactor,
     PhaseSpaceFactorAnalytic,
 )
@@ -34,12 +34,12 @@ class TestBlattWeisskopfSquared:
         )
 
 
-class TestCoupledWidth:
+class TestEnergyDependentWidth:
     @staticmethod
     def test_init():
         angular_momentum = sp.Symbol("L", integer=True)
         s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d", real=True)
-        width = CoupledWidth(
+        width = EnergyDependentWidth(
             s=s,
             mass0=m0,
             gamma0=w0,
@@ -54,7 +54,7 @@ class TestCoupledWidth:
         assert width.phsp_factor is PhaseSpaceFactor
         assert width._name is None
 
-        width = CoupledWidth(
+        width = EnergyDependentWidth(
             s=s,
             mass0=m0,
             gamma0=w0,


### PR DESCRIPTION
`CoupledWidth` was a bit confusing. More common terms are mass/energy dependent width or running width.

_This PR should be merged later on (or in an epic branch), so that it can be released in v0.12.0 (interface change)._