### PR TITLE
fix: import OrderedDict from collections

### DIFF
--- a/docs/abbreviate_signature.py
+++ b/docs/abbreviate_signature.py
@@ -28,6 +28,10 @@ def replace_link(text: str) -> str:
         "numpy.typing._dtype_like._DTypeDict": "numpy.typing.DTypeLike",
         "numpy.typing._dtype_like._SupportsDType": "numpy.typing.DTypeLike",
         "typing_extensions.Protocol": "typing.Protocol",
+        # OrderedDict typing from collections,
+        # see https://readthedocs.org/projects/ampform/builds/14828756
+        "sp.Expr": "sympy.core.expr.Expr",
+        "sp.Symbol": "sympy.core.symbol.Symbol",
     }
     for old, new in replacements.items():
         if text == old:

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -50,6 +50,7 @@ from .naming import (
 )
 
 ParameterValue = Union[float, complex, int]
+"""Allowed value types for parameters."""
 
 
 def _order_component_mapping(

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -4,6 +4,7 @@ import collections
 import logging
 import operator
 import re
+from collections import OrderedDict
 from difflib import get_close_matches
 from functools import reduce
 from typing import (
@@ -48,17 +49,12 @@ from .naming import (
     generate_transition_label,
 )
 
-try:
-    from typing import OrderedDict
-except ImportError:
-    from typing_extensions import OrderedDict  # type: ignore
-
 ParameterValue = Union[float, complex, int]
 
 
 def _order_component_mapping(
     mapping: Mapping[str, ParameterValue]
-) -> OrderedDict[str, ParameterValue]:
+) -> "OrderedDict[str, ParameterValue]":
     return collections.OrderedDict(
         [(key, mapping[key]) for key in sorted(mapping, key=_natural_sorting)]
     )
@@ -66,7 +62,7 @@ def _order_component_mapping(
 
 def _order_symbol_mapping(
     mapping: Mapping[sp.Symbol, sp.Expr]
-) -> OrderedDict[sp.Symbol, sp.Expr]:
+) -> "OrderedDict[sp.Symbol, sp.Expr]":
     return collections.OrderedDict(
         [
             (symbol, mapping[symbol])
@@ -97,10 +93,10 @@ class HelicityModel:
     _expression: sp.Expr = attr.ib(
         validator=attr.validators.instance_of(sp.Expr)
     )
-    _parameter_defaults: OrderedDict[sp.Symbol, ParameterValue] = attr.ib(
+    _parameter_defaults: "OrderedDict[sp.Symbol, ParameterValue]" = attr.ib(
         converter=_order_symbol_mapping
     )
-    _components: OrderedDict[str, sp.Expr] = attr.ib(
+    _components: "OrderedDict[str, sp.Expr]" = attr.ib(
         converter=_order_component_mapping
     )
     _adapter: HelicityAdapter = attr.ib(
@@ -115,7 +111,7 @@ class HelicityModel:
         return self._expression
 
     @property
-    def components(self) -> OrderedDict[str, sp.Expr]:
+    def components(self) -> "OrderedDict[str, sp.Expr]":
         """A mapping for identifying main components in the :attr:`expression`.
 
         Keys are the component names (`str`), formatted as LaTeX, and values
@@ -127,7 +123,7 @@ class HelicityModel:
         return self._components
 
     @property
-    def parameter_defaults(self) -> OrderedDict[sp.Symbol, ParameterValue]:
+    def parameter_defaults(self) -> "OrderedDict[sp.Symbol, ParameterValue]":
         """A mapping of suggested parameter values.
 
         Keys are `~sympy.core.symbol.Symbol` instances from the main


### PR DESCRIPTION
Previously, `OrderedDict` was imported from `typing-extensions`. This seems to work better for typing than `collections.OrderedDict`, but is only available in `typing-extensions==3.10.*`, see e.g.
https://github.com/ComPWA/tensorwaves/pull/327/checks?check_run_id=3717304158

Setting `typing-extensions>=3.10` as a lower limit however causes problems downstream for packages that use TensorFlow, see e.g. https://github.com/ComPWA/tensorwaves/pull/317

For now, it's therefore better to use collections.OrderedDict instead, so that there is no need to restrict typing-extensions.