### PR TITLE
fix: simplify implement_doit_method decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,13 @@ exclude = '''
 '''
 
 [tool.isort]
+line_length = 79
 profile = "black"
 src_paths = [
     "src",
     "tests",
 ]
-line_length = 79
+known_third_party = "THIRDPARTY,sympy"
 
 [tool.nbqa.addopts]
 flake8 = [

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -11,10 +11,10 @@ import re
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Union
 
+import sympy as sp
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter
 
-import sympy as sp
 from ampform.sympy import (
     UnevaluatedExpression,
     create_expression,

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -11,10 +11,10 @@ import re
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Union
 
-import sympy as sp
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter
 
+import sympy as sp
 from ampform.sympy import (
     UnevaluatedExpression,
     create_expression,
@@ -29,7 +29,7 @@ else:
     from typing_extensions import Protocol
 
 
-@implement_doit_method()
+@implement_doit_method
 class BlattWeisskopfSquared(UnevaluatedExpression):
     r"""Blatt-Weisskopf function :math:`B_L^2(z)`, up to :math:`L \leq 8`.
 
@@ -163,7 +163,7 @@ class PhaseSpaceFactorProtocol(Protocol):
         ...
 
 
-@implement_doit_method()
+@implement_doit_method
 class PhaseSpaceFactor(UnevaluatedExpression):
     """Standard phase-space factor, using :func:`BreakupMomentumSquared`.
 
@@ -191,7 +191,7 @@ class PhaseSpaceFactor(UnevaluatedExpression):
         return fR"{name}\left({s}\right)"
 
 
-@implement_doit_method()
+@implement_doit_method
 class PhaseSpaceFactorAbs(UnevaluatedExpression):
     r"""Phase space factor square root over the absolute value.
 
@@ -226,7 +226,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
         return fR"{name}\left({s}\right)"
 
 
-@implement_doit_method()
+@implement_doit_method
 class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
     """Analytic continuation for the :func:`PhaseSpaceFactor`.
 
@@ -262,7 +262,7 @@ class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
         return fR"{name}\left({s}\right)"
 
 
-@implement_doit_method()
+@implement_doit_method
 class PhaseSpaceFactorComplex(UnevaluatedExpression):
     """Phase-space factor with `.ComplexSqrt`.
 
@@ -318,7 +318,7 @@ def _phase_space_factor_denominator(s: sp.Symbol) -> sp.Expr:
     return 8 * sp.pi * sp.sqrt(s)
 
 
-@implement_doit_method()
+@implement_doit_method
 class CoupledWidth(UnevaluatedExpression):
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
@@ -396,7 +396,7 @@ class CoupledWidth(UnevaluatedExpression):
         return fR"{name}\left({s}\right)"
 
 
-@implement_doit_method()
+@implement_doit_method
 class BreakupMomentumSquared(UnevaluatedExpression):
     r"""Squared value of the two-body break-up momentum.
 

--- a/src/ampform/sympy.py
+++ b/src/ampform/sympy.py
@@ -6,9 +6,8 @@ import functools
 from abc import abstractmethod
 from typing import Any, Callable, Optional, Tuple, Type
 
-from sympy.printing.latex import LatexPrinter
-
 import sympy as sp
+from sympy.printing.latex import LatexPrinter
 
 
 class UnevaluatedExpression(sp.Expr):


### PR DESCRIPTION
The `@implement_doit_method` decorator was using one inline function layer too many. So now you have to write 

```python
@implement_doit_method
class MyExpr(UnevaluatedExpression):
    ...
```

instead of

```python
@implement_doit_method()
class MyExpr(UnevaluatedExpression):
    ...
```