### PR TITLE
docs: link to correct version on Binder/Colab

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,16 +214,25 @@ def get_version(package_name: str) -> str:
 
 
 intersphinx_mapping = {
-    "attrs": ("https://www.attrs.org/en/stable", None),
+    "attrs": (f"https://www.attrs.org/en/{get_version('attrs')}", None),
     "compwa-org": ("https://compwa-org.readthedocs.io/en/stable", None),
-    "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "ipywidgets": (
+        f"https://ipywidgets.readthedocs.io/en/{get_version('ipywidgets')}",
+        None,
+    ),
+    "matplotlib": (
+        f"https://matplotlib.org/{get_version('matplotlib')}",
+        None,
+    ),
     "mpl_interactions": (
         f"https://mpl-interactions.readthedocs.io/en/{get_version('mpl-interactions')}",
         None,
     ),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "pandas": (
+        f"https://pandas.pydata.org/pandas-docs/{get_version('pandas')}",
+        None,
+    ),
     "pwa": ("https://pwa.readthedocs.io", None),
     "python": ("https://docs.python.org/3", None),
     "qrules": (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,14 +32,14 @@ from pybtex.style.template import (
 
 # -- Project information -----------------------------------------------------
 project = "AmpForm"
-package = "ampform"
-repo_name = "ampform"
+PACKAGE = "ampform"
+REPO_NAME = "ampform"
 copyright = "2020, ComPWA"  # noqa: A001
 author = "Common Partial Wave Analysis"
 
-if os.path.exists(f"../src/{package}/version.py"):
-    __release = get_distribution(package).version
-    version = ".".join(__release.split(".")[:3])
+if os.path.exists(f"../src/{PACKAGE}/version.py"):
+    __RELEASE = get_distribution(PACKAGE).version
+    version = ".".join(__RELEASE.split(".")[:3])
 
 
 # -- Fetch logo --------------------------------------------------------------
@@ -51,16 +51,16 @@ def fetch_logo(url: str, output_path: str) -> None:
         stream.write(online_content.content)
 
 
-logo_path = "_static/logo.svg"
+LOGO_PATH = "_static/logo.svg"
 try:
     fetch_logo(
         url="https://raw.githubusercontent.com/ComPWA/ComPWA/04e5199/doc/images/logo.svg",
-        output_path=logo_path,
+        output_path=LOGO_PATH,
     )
 except requests.exceptions.ConnectionError:
     pass
-if os.path.exists(logo_path):
-    html_logo = logo_path
+if os.path.exists(LOGO_PATH):
+    html_logo = LOGO_PATH
 
 # -- Generate API ------------------------------------------------------------
 sys.path.insert(0, os.path.abspath("."))
@@ -75,8 +75,8 @@ subprocess.call(
     " ".join(
         [
             "sphinx-apidoc",
-            f"../src/{package}/",
-            f"../src/{package}/version.py",
+            f"../src/{PACKAGE}/",
+            f"../src/{PACKAGE}/version.py",
             "-o api/",
             "--force",
             "--no-toc",
@@ -98,7 +98,7 @@ source_suffix = {
 # The master toctree document.
 master_doc = "index"
 modindex_common_prefix = [
-    f"{package}.",
+    f"{PACKAGE}.",
 ]
 
 extensions = [
@@ -145,13 +145,13 @@ autodoc_default_options = {
         ]
     ),
 }
-autodoc_insert_signature_linebreaks = False
+AUTODOC_INSERT_SIGNATURE_LINEBREAKS = False
 graphviz_output_format = "svg"
 html_copy_source = True  # needed for download notebook button
 html_css_files = [
     "custom.css",
 ]
-if autodoc_insert_signature_linebreaks:
+if AUTODOC_INSERT_SIGNATURE_LINEBREAKS:
     html_css_files.append("linebreaks-api.css")
 html_favicon = "_static/favicon.ico"
 html_show_copyright = False
@@ -161,7 +161,7 @@ html_sourcelink_suffix = ""
 html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
 html_theme_options = {
-    "repository_url": f"https://github.com/ComPWA/{repo_name}",
+    "repository_url": f"https://github.com/ComPWA/{REPO_NAME}",
     "repository_branch": "stable",
     "path_to_docs": "docs",
     "use_download_button": True,
@@ -178,10 +178,10 @@ html_theme_options = {
     "theme_dev_mode": True,
 }
 html_title = "AmpForm"
+panels_add_bootstrap_css = False  # remove panels css to get wider main content
 pygments_style = "sphinx"
 todo_include_todos = False
 viewcode_follow_imported_members = True
-panels_add_bootstrap_css = False  # remove panels css to get wider main content
 
 # Cross-referencing configuration
 default_role = "py:obj"
@@ -199,15 +199,15 @@ CONSTRAINTS_PATH = f"../.constraints/py{PYTHON_VERSION}.txt"
 with open(CONSTRAINTS_PATH) as stream:
     CONSTRAINTS = stream.read()
 RELEASES = {}
-for line in CONSTRAINTS.split("\n"):
-    line = line.split("#")[0]  # remove comments
-    line = line.strip()
-    if not line:
+for LINE in CONSTRAINTS.split("\n"):
+    LINE = LINE.split("#")[0]  # remove comments
+    LINE = LINE.strip()
+    if not LINE:
         continue
-    package, version = tuple(line.split("=="))
-    package = package.strip()
-    version = version.strip()
-    RELEASES[package] = version
+    PACKAGE, VERSION = tuple(LINE.split("=="))
+    PACKAGE = PACKAGE.strip()
+    VERSION = VERSION.strip()
+    RELEASES[PACKAGE] = VERSION
 
 intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable", None),
@@ -279,7 +279,7 @@ myst_enable_extensions = [
     "substitution",
 ]
 BINDER_LINK = (
-    f"https://mybinder.org/v2/gh/ComPWA/{repo_name}/stable?filepath=docs/usage"
+    f"https://mybinder.org/v2/gh/ComPWA/{REPO_NAME}/stable?filepath=docs/usage"
 )
 myst_substitutions = {
     "run_interactive": f"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,11 @@ REPO_NAME = "ampform"
 copyright = "2020, ComPWA"  # noqa: A001
 author = "Common Partial Wave Analysis"
 
+# https://docs.readthedocs.io/en/stable/builds.html
+BRANCH = os.environ.get("READTHEDOCS_VERSION", default="stable")
+if BRANCH == "latest":
+    BRANCH = "main"
+
 if os.path.exists(f"../src/{PACKAGE}/version.py"):
     __RELEASE = get_distribution(PACKAGE).version
     version = ".".join(__RELEASE.split(".")[:3])
@@ -162,7 +167,7 @@ html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": f"https://github.com/ComPWA/{REPO_NAME}",
-    "repository_branch": "stable",
+    "repository_branch": BRANCH,
     "path_to_docs": "docs",
     "use_download_button": True,
     "use_edit_page_button": True,
@@ -293,17 +298,16 @@ myst_enable_extensions = [
     "smartquotes",
     "substitution",
 ]
-BINDER_LINK = (
-    f"https://mybinder.org/v2/gh/ComPWA/{REPO_NAME}/stable?filepath=docs/usage"
-)
+BINDER_LINK = f"https://mybinder.org/v2/gh/ComPWA/{REPO_NAME}/{BRANCH}?filepath=docs/usage"
 myst_substitutions = {
+    "branch": BRANCH,
     "run_interactive": f"""
 ```{{margin}}
 Run this notebook [on Binder]({BINDER_LINK}) or
 {{ref}}`locally on Jupyter Lab <compwa-org:develop:Jupyter Notebooks>` to
 interactively modify the parameters.
 ```
-"""
+""",
 }
 myst_update_mathjax = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -41,6 +42,8 @@ author = "Common Partial Wave Analysis"
 BRANCH = os.environ.get("READTHEDOCS_VERSION", default="stable")
 if BRANCH == "latest":
     BRANCH = "main"
+if re.match(r"^\d+$", BRANCH):  # PR preview
+    BRANCH = "stable"
 
 if os.path.exists(f"../src/{PACKAGE}/version.py"):
     __RELEASE = get_distribution(PACKAGE).version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,21 +193,25 @@ nitpick_ignore = [
     ("py:class", "typing_extensions.Protocol"),
 ]
 
+
 # Intersphinx settings
-PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-CONSTRAINTS_PATH = f"../.constraints/py{PYTHON_VERSION}.txt"
-with open(CONSTRAINTS_PATH) as stream:
-    CONSTRAINTS = stream.read()
-RELEASES = {}
-for LINE in CONSTRAINTS.split("\n"):
-    LINE = LINE.split("#")[0]  # remove comments
-    LINE = LINE.strip()
-    if not LINE:
-        continue
-    PACKAGE, VERSION = tuple(LINE.split("=="))
-    PACKAGE = PACKAGE.strip()
-    VERSION = VERSION.strip()
-    RELEASES[PACKAGE] = VERSION
+def get_version(package_name: str) -> str:
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    constraints_path = f"../.constraints/py{python_version}.txt"
+    with open(constraints_path) as stream:
+        constraints = stream.read()
+    for line in constraints.split("\n"):
+        line = line.split("#")[0]  # remove comments
+        line = line.strip()
+        if not line.startswith(package_name):
+            continue
+        if not line:
+            continue
+        _, installed_version, *_ = tuple(line.split("=="))
+        installed_version = installed_version.strip()
+        return installed_version
+    return "stable"
+
 
 intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable", None),
@@ -215,14 +219,17 @@ intersphinx_mapping = {
     "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "mpl_interactions": (
-        f"https://mpl-interactions.readthedocs.io/en/{RELEASES['mpl-interactions']}",
+        f"https://mpl-interactions.readthedocs.io/en/{get_version('mpl-interactions')}",
         None,
     ),
     "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "pwa": ("https://pwa.readthedocs.io", None),
     "python": ("https://docs.python.org/3", None),
-    "qrules": (f"https://qrules.readthedocs.io/en/{RELEASES['qrules']}", None),
+    "qrules": (
+        f"https://qrules.readthedocs.io/en/{get_version('qrules')}",
+        None,
+    ),
     "sympy": ("https://docs.sympy.org/latest", None),
     "tensorwaves": ("https://tensorwaves.readthedocs.io/en/stable", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,7 +240,6 @@ intersphinx_mapping = {
         None,
     ),
     "sympy": ("https://docs.sympy.org/latest", None),
-    "tensorwaves": ("https://tensorwaves.readthedocs.io/en/stable", None),
 }
 
 # Settings for autosectionlabel

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,9 @@ model with some formalism, like the helicity formalism.
 - **Convert to several computational back-ends**<br> The amplitude models can
   easily be converted to computational back-ends like
   [JAX](https://jax.readthedocs.io), [TensorFlow](https://www.tensorflow.org),
-  and [NumPy](https://numpy.org). The {doc}`TensorWaves <tensorwaves:index>`
-  package facilitates this and also provides tools to generate toy Monte Carlo
-  data samples.
+  and [NumPy](https://numpy.org). The
+  [TensorWaves](https://tensorwaves.rtfd.io) package facilitates this and also
+  provides tools to generate toy Monte Carlo data samples.
 
 - **Use your favorite Python packages**<br> All this functionality is offered
   in an open and transparent style (see {doc}`API </api/ampform>`), so that you

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,14 @@
 
 ```
 
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
 [![10.5281/zenodo.5526648](https://zenodo.org/badge/doi/10.5281/zenodo.5526648.svg)](https://doi.org/10.5281/zenodo.5526648)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/ampform)](https://pypi.org/project/ampform)
-[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ComPWA/ampform/blob/stable)
-[![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ComPWA/ampform/stable?filepath=docs/usage)
+{{ '[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ComPWA/ampform/blob/{})'.format(branch) }}
+{{ '[![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ComPWA/ampform/{}?filepath=docs/usage)'.format(branch) }}
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
 
 :::{margin}
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ description =
 changedir = docs
 allowlist_externals =
     make
+passenv =
+    READTHEDOCS_VERSION
 commands =
     make html
 
@@ -44,6 +46,7 @@ allowlist_externals =
     sphinx-autobuild
 passenv =
     EXECUTE_NB
+    READTHEDOCS_VERSION
     TERM
 commands =
     sphinx-autobuild \
@@ -72,6 +75,8 @@ commands =
 [testenv:docnb]
 description =
     Build documentation through Sphinx WITH output of Jupyter notebooks
+passenv =
+    READTHEDOCS_VERSION
 setenv =
     EXECUTE_NB = "yes"
 changedir = docs
@@ -120,7 +125,5 @@ description =
     Run all notebooks with pytest
 allowlist_externals =
     pytest
-passenv =
-    EXECUTE_NB
 commands =
     pytest {posargs:docs} --nb-test-files


### PR DESCRIPTION
Branch name in `conf.py` is now extracted [from Read the Docs](https://docs.readthedocs.io/en/stable/builds.html) if possible. This way, all Binder/Colab links lead to the corresponding branch or tag of the repo.