### PR TITLE
fix: set minimum sympy version to 1.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ setup_requires =
 install_requires =
     attrs >=20.1.0  # on_setattr
     qrules ==0.9.*
-    sympy
+    sympy >=1.8  # module sympy.printing.numpy
     typing-extensions; python_version <"3.8.0"
 packages = find:
 package_dir =


### PR DESCRIPTION
Google Colab comes with SymPy v1.7, which doesn't have the module `sympy.printing.numpy`. So at least SymPy v1.8 is required.