### PR TITLE
fix: use sympy printer module_imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,7 @@
   "python.linting.pylintEnabled": true,
   "python.linting.pylintUseMinimalCheckers": false,
   "python.testing.nosetestsEnabled": false,
-  "python.testing.pytestArgs": ["--color=no", "--no-cov"],
+  "python.testing.pytestArgs": ["--color=no", "--no-cov", "-vv"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "rewrap.wrappingColumn": 79,

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -429,11 +429,7 @@ class ArrayMultiplication(sp.Expr):
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
         def multiply(matrix: sp.Expr, vector: sp.Expr) -> str:
-            return (
-                'einsum("ij...,j...",'
-                f" transpose({matrix}, axes=(1, 2, 0)),"
-                f" transpose({vector}))"
-            )
+            return f'einsum("...ij,...j->...i", {matrix}, {vector})'
 
         def recursive_multiply(tensors: Sequence[sp.Expr]) -> str:
             if len(tensors) < 2:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -411,7 +411,7 @@ class ArrayAxisSum(sp.Expr):
         return fR"\sum_{{\mathrm{{axis{axis}}}}}{{{array}}}"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        printer.module_imports["numpy"].add("sum")
+        printer.module_imports[printer._module].add("sum")
         array = printer._print(self.array)
         axis = printer._print(self.axis)
         return f"sum({array}, axis={axis})"
@@ -442,7 +442,7 @@ class ArrayMultiplication(sp.Expr):
                 return multiply(tensors[0], tensors[1])
             return multiply(tensors[0], recursive_multiply(tensors[1:]))
 
-        printer.module_imports["numpy"].update({"einsum", "transpose"})
+        printer.module_imports[printer._module].update({"einsum", "transpose"})
         tensors = list(map(printer._print, self.args))
         if len(tensors) == 0:
             return ""
@@ -474,7 +474,7 @@ class BoostZ(sp.Expr):
         return fR"\boldsymbol{{B_z}}\left({beta}\right)"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        printer.module_imports["numpy"].update(
+        printer.module_imports[printer._module].update(
             {"array", "ones", "zeros", "sqrt"}
         )
         beta = printer._print(self.beta)
@@ -515,7 +515,7 @@ class RotationY(sp.Expr):
         return fR"\boldsymbol{{R_y}}\left({angle}\right)"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        printer.module_imports["numpy"].update(
+        printer.module_imports[printer._module].update(
             {"array", "cos", "ones", "zeros", "sin"}
         )
         angle = printer._print(self.angle)
@@ -555,7 +555,7 @@ class RotationZ(sp.Expr):
         return fR"\boldsymbol{{R_z}}\left({angle}\right)"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        printer.module_imports["numpy"].update(
+        printer.module_imports[printer._module].update(
             {"array", "cos", "ones", "zeros", "sin"}
         )
         angle = printer._print(self.angle)

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -489,7 +489,7 @@ class BoostZ(sp.Expr):
                 [{zeros}, {zeros}, {ones}, {zeros}],
                 [-{gamma} * {beta}, {zeros}, {zeros}, {gamma}],
             ]
-        ).transpose(2, 0, 1)"""
+        ).transpose((2, 0, 1))"""
 
 
 class RotationY(sp.Expr):
@@ -529,7 +529,7 @@ class RotationY(sp.Expr):
                 [{zeros}, {zeros}, {ones}, {zeros}],
                 [{zeros}, -sin({angle}), {zeros}, cos({angle})],
             ]
-        ).transpose(2, 0, 1)"""
+        ).transpose((2, 0, 1))"""
 
 
 class RotationZ(sp.Expr):
@@ -569,7 +569,7 @@ class RotationZ(sp.Expr):
                 [{zeros}, sin({angle}), cos({angle}), {zeros}],
                 [{zeros}, {zeros}, {zeros}, {ones}],
             ]
-        ).transpose(2, 0, 1)"""
+        ).transpose((2, 0, 1))"""
 
 
 class HasMomentum:

--- a/src/ampform/sympy/math.py
+++ b/src/ampform/sympy/math.py
@@ -21,7 +21,7 @@ class ComplexSqrt(sp.Expr):
 
     is_commutative = True
 
-    def __new__(cls, x: sp.Expr, *args: Any, **kwargs: Any) -> sp.Expr:
+    def __new__(cls, x: sp.Expr, *args: Any, **kwargs: Any) -> "ComplexSqrt":
         x = sp.sympify(x)
         expr = sp.Expr.__new__(cls, x, *args, **kwargs)
         if hasattr(x, "free_symbols") and not x.free_symbols:

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -63,17 +63,7 @@ class TestArrayMultiplication:
             numpy_code, mode=black.Mode(line_length=70)
         )
         expected = """\
-            einsum(
-                "ij...,j...",
-                transpose(beta, axes=(1, 2, 0)),
-                transpose(
-                    einsum(
-                        "ij...,j...",
-                        transpose(theta, axes=(1, 2, 0)),
-                        transpose(p),
-                    )
-                ),
-            )
+        einsum("...ij,...j->...i", beta, einsum("...ij,...j->...i", theta, p))
         """
         assert numpy_code == dedent(expected)
 


### PR DESCRIPTION
Classes like `ArrayAxisSum` were specifically using statements like
```python
printer.module_imports["numpy"].add("sum")
```
This is problematic in TensorWaves, which would like to see `"jnp"` and `"tnp"` there (the NumPy interfaces of JAX and TensorFlow). This PR makes this possible.

Another major improvements: `einsum` in `ArrayMultiplication` is used in such a way that `transpose` is not necessary anymore. In addition, an ellipsis return statement is specificied (`"...ij,...j->...i"` instead of `"...ij,...j"`), which [`tf.einsum`](https://www.tensorflow.org/api_docs/python/tf/einsum) requires.