### PR TITLE
fix: put TypeGuard under TYPE_CHECKING

### DIFF
--- a/docs/abbreviate_signature.py
+++ b/docs/abbreviate_signature.py
@@ -17,15 +17,9 @@ from sphinx.environment import BuildEnvironment
 
 def replace_link(text: str) -> str:
     replacements = {
-        "SupportsIndex": "typing.SupportsIndex",
-        "a set-like object providing a view on D's items": "typing.ItemsView",
-        "a set-like object providing a view on D's keys": "typing.KeysView",
-        "an object providing a view on D's values": "typing.ValuesView",
-        "typing_extensions.Protocol": "typing.Protocol",
-        # OrderedDict typing from collections,
-        # see https://readthedocs.org/projects/ampform/builds/14828756
         "sp.Expr": "sympy.core.expr.Expr",
         "sp.Symbol": "sympy.core.symbol.Symbol",
+        "typing_extensions.Protocol": "typing.Protocol",
     }
     for old, new in replacements.items():
         if text == old:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,7 +202,6 @@ nitpick_ignore = [
         "py:class",
         "sympy.tensor.array.expressions.array_expressions.ArraySymbol",
     ),
-    ("py:class", "typing_extensions.Protocol"),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,6 +202,7 @@ nitpick_ignore = [
         "py:class",
         "sympy.tensor.array.expressions.array_expressions.ArraySymbol",
     ),
+    ("py:class", "typing_extensions.Protocol"),
 ]
 
 

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -19,6 +19,7 @@ import logging
 import sys
 from collections import abc
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -40,10 +41,11 @@ try:
 except ImportError:
     PrettyPrinter = Any
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import TypeGuard
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard  # pylint: disable=no-name-in-module
+    else:
+        from typing_extensions import TypeGuard
 
 
 Slider = Union[FloatSlider, IntSlider]
@@ -219,7 +221,9 @@ class SliderKwargs(abc.Mapping):
                 slider.step = step_size
 
 
-def _is_min_max(range_def: RangeDefinition) -> TypeGuard[Tuple[float, float]]:
+def _is_min_max(
+    range_def: RangeDefinition,
+) -> "TypeGuard[Tuple[float, float]]":
     if len(range_def) == 2:
         return True
     return False
@@ -227,7 +231,7 @@ def _is_min_max(range_def: RangeDefinition) -> TypeGuard[Tuple[float, float]]:
 
 def _is_min_max_step(
     range_def: RangeDefinition,
-) -> TypeGuard[Tuple[float, float, Union[float, int]]]:
+) -> "TypeGuard[Tuple[float, float, Union[float, int]]]":
     if len(range_def) == 3:
         return True
     return False


### PR DESCRIPTION
`TypeGuard` requires `typing-extensions` v3.10, which is not available to TensorFlow <2.7. With this PR, it is only required when doing style checks.