### PR TITLE
feat: implement RelativisticBreitWignerBuilder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         # basic
-        target: 70% # can't go below this percentage
+        target: 75% # can't go below this percentage
         threshold: 1% # allow drops by this percentage
         base: auto
         # advanced

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -440,10 +440,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from ampform.dynamics import PhaseSpaceFactor  # optional\n",
     "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "\n",
     "initial_state_particle = reaction.initial_state[-1]\n",
-    "bw_builder = RelativisticBreitWignerBuilder(form_factor=True)\n",
+    "bw_builder = RelativisticBreitWignerBuilder(\n",
+    "    form_factor=True,\n",
+    "    phsp_factor=PhaseSpaceFactor,  # optional\n",
+    ")\n",
     "for name in reaction.get_intermediate_particles().names:\n",
     "    model_builder.set_dynamics(name, bw_builder)"
    ]

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -429,7 +429,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To set dynamics for specific resonances, use {meth}`.set_dynamics` on the same {class}`.HelicityAmplitudeBuilder` instance.  You can set the dynamics to be any kind of {class}`~sympy.core.expr.Expr`, as long as you keep track of which {class}`~sympy.core.symbol.Symbol` names you use. AmpForm does provide a few common {mod}`.dynamics` functions however, which can be constructed as {class}`~sympy.core.expr.Expr` with the correct {class}`~sympy.core.symbol.Symbol` names using {meth}`.set_dynamics`. This function takes specific {mod}`.dynamics.builder` functions, such as {func}`.create_relativistic_breit_wigner`, which would create a {func}`.relativistic_breit_wigner` for a specific resonance. Here's an example for a relativistic Breit-Wigner _with form factor_ for the intermediate resonances and use a Blatt-Weisskopf barrier factor for the production decay:"
+    "To set dynamics for specific resonances, use {meth}`.set_dynamics` on the same {class}`.HelicityAmplitudeBuilder` instance.  You can set the dynamics to be any kind of {class}`~sympy.core.expr.Expr`, as long as you keep track of which {class}`~sympy.core.symbol.Symbol` names you use (see {doc}`/usage/dynamics/custom`).\n",
+    "\n",
+    "AmpForm does provide a few common {mod}`.dynamics` functions, which can be constructed as {class}`~sympy.core.expr.Expr` with the correct {class}`~sympy.core.symbol.Symbol` names using {meth}`.set_dynamics`. This function takes specific {mod}`.dynamics.builder` functions and classes, such as {class}`.RelativisticBreitWignerBuilder`, which can create {func}`.relativistic_breit_wigner` functions for specific resonances. Here's an example for a relativistic Breit-Wigner _with form factor_ for the intermediate resonances and use a Blatt-Weisskopf barrier factor for the production decay:"
    ]
   },
   {
@@ -438,11 +440,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ampform.dynamics.builder import create_relativistic_breit_wigner_with_ff\n",
+    "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "\n",
     "initial_state_particle = reaction.initial_state[-1]\n",
+    "bw_builder = RelativisticBreitWignerBuilder(form_factor=True)\n",
     "for name in reaction.get_intermediate_particles().names:\n",
-    "    model_builder.set_dynamics(name, create_relativistic_breit_wigner_with_ff)"
+    "    model_builder.set_dynamics(name, bw_builder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this {class}`.RelativisticBreitWignerBuilder` can also be initialized with a different {class}`.PhaseSpaceFactorProtocol`. This allows us to insert different phase space factors (see {doc}`/usage/dynamics/analytic-continuation` and {func}`.create_analytic_breit_wigner`)."
    ]
   },
   {

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -443,7 +443,6 @@
     "from ampform.dynamics import PhaseSpaceFactor  # optional\n",
     "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "\n",
-    "initial_state_particle = reaction.initial_state[-1]\n",
     "bw_builder = RelativisticBreitWignerBuilder(\n",
     "    form_factor=True,\n",
     "    phsp_factor=PhaseSpaceFactor,  # optional\n",

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -30,6 +30,7 @@ else:
 
 @implement_doit_method
 class BlattWeisskopfSquared(UnevaluatedExpression):
+    # cspell:ignore pychyGekoppeltePartialwellenanalyseAnnihilationen
     r"""Blatt-Weisskopf function :math:`B_L^2(z)`, up to :math:`L \leq 8`.
 
     Args:

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -60,6 +60,7 @@ class ResonanceDynamicsBuilder(Protocol):
     def __call__(
         self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
     ) -> BuilderReturnType:
+        """Formulate a dynamics `~sympy.core.expr.Expr` for this resonance."""
         ...
 
 
@@ -127,6 +128,7 @@ class RelativisticBreitWignerBuilder:
     def __call__(
         self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
     ) -> BuilderReturnType:
+        """Build an relativistic Breit-Wigner expression."""
         if self.__with_form_factor:
             return self.__formulate_with_form_factor(resonance, variable_pool)
         return self.__formulate(resonance, variable_pool)

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -198,6 +198,9 @@ create_relativistic_breit_wigner = RelativisticBreitWignerBuilder(
 ).__call__
 """
 Create a `.relativistic_breit_wigner` for a two-body decay.
+
+This is a convenience function for a `RelativisticBreitWignerBuilder` _without_
+form factor.
 """
 
 create_relativistic_breit_wigner_with_ff = RelativisticBreitWignerBuilder(
@@ -206,6 +209,9 @@ create_relativistic_breit_wigner_with_ff = RelativisticBreitWignerBuilder(
 ).__call__
 """
 Create a `.relativistic_breit_wigner_with_ff` for a two-body decay.
+
+This is a convenience function for a `RelativisticBreitWignerBuilder` _with_
+form factor and a 'normal' `.PhaseSpaceFactor`.
 """
 
 create_analytic_breit_wigner = RelativisticBreitWignerBuilder(
@@ -214,6 +220,10 @@ create_analytic_breit_wigner = RelativisticBreitWignerBuilder(
 ).__call__
 """
 Create a `.relativistic_breit_wigner_with_ff` with analytic continuation.
+
+This is a convenience function for a `RelativisticBreitWignerBuilder` _with_
+form factor and a 'analytic' phase space factor (see
+`.PhaseSpaceFactorAnalytic`).
 
 .. seealso:: :doc:`/usage/dynamics/analytic-continuation`.
 """

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -100,38 +100,62 @@ def create_non_dynamic_with_ff(
     )
 
 
-def create_relativistic_breit_wigner(
-    resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
-) -> BuilderReturnType:
-    """Create a `.relativistic_breit_wigner` for a two-body decay."""
-    inv_mass = variable_pool.incoming_state_mass
-    res_mass = sp.Symbol(f"m_{resonance.name}")
-    res_width = sp.Symbol(f"Gamma_{resonance.name}")
-    expression = relativistic_breit_wigner(
-        s=inv_mass ** 2,
-        mass0=res_mass,
-        gamma0=res_width,
-    )
-    parameter_defaults = {
-        res_mass: resonance.mass,
-        res_width: resonance.width,
-    }
-    return expression, parameter_defaults
+class RelativisticBreitWignerBuilder:
+    """Factory for building a `.relativistic_breit_wigner_with_ff`.
 
+    The :meth:`__call__` of this builder complies with the
+    `.ResonanceDynamicsBuilder`, so instances of this class can be used in
+    :meth:`.set_dynamics`.
 
-def _make_relativistic_breit_wigner_with_ff(
-    phsp_factor: PhaseSpaceFactorProtocol,
-    docstring: str,
-) -> ResonanceDynamicsBuilder:
-    """Factory for `.relativistic_breit_wigner_with_ff`."""
+    Args:
+        form_factor: Formulate a relativistic Breit-Wigner function with form
+            factor, using :func:`.relativistic_breit_wigner_with_ff`.
+        phsp_factor: A class that complies with the
+            `.PhaseSpaceFactorProtocol`. Defaults to `.PhaseSpaceFactor`.
+    """
 
-    def dynamics_builder(
+    def __init__(
+        self,
+        form_factor: bool = False,
+        phsp_factor: Optional[PhaseSpaceFactorProtocol] = None,
+    ) -> None:
+        if phsp_factor is None:
+            phsp_factor = PhaseSpaceFactor
+        self.__phsp_factor = phsp_factor
+        self.__with_form_factor = form_factor
+
+    def __call__(
+        self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
+    ) -> BuilderReturnType:
+        if self.__with_form_factor:
+            return self.__formulate_with_form_factor(resonance, variable_pool)
+        return self.__formulate(resonance, variable_pool)
+
+    @staticmethod
+    def __formulate(
         resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
+    ) -> BuilderReturnType:
+        inv_mass = variable_pool.incoming_state_mass
+        res_mass = sp.Symbol(f"m_{resonance.name}")
+        res_width = sp.Symbol(f"Gamma_{resonance.name}")
+        expression = relativistic_breit_wigner(
+            s=inv_mass ** 2,
+            mass0=res_mass,
+            gamma0=res_width,
+        )
+        parameter_defaults = {
+            res_mass: resonance.mass,
+            res_width: resonance.width,
+        }
+        return expression, parameter_defaults
+
+    def __formulate_with_form_factor(
+        self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
     ) -> BuilderReturnType:
         if variable_pool.angular_momentum is None:
             raise ValueError(
-                "Angular momentum is not defined but is required in the form"
-                " factor!"
+                "Angular momentum is not defined but is required in the"
+                " form factor!"
             )
 
         inv_mass = variable_pool.incoming_state_mass
@@ -150,7 +174,7 @@ def _make_relativistic_breit_wigner_with_ff(
             m_b=product2_inv_mass,
             angular_momentum=angular_momentum,
             meson_radius=meson_radius,
-            phsp_factor=phsp_factor,
+            phsp_factor=self.__phsp_factor,
         )
         parameter_defaults = {
             res_mass: resonance.mass,
@@ -159,21 +183,28 @@ def _make_relativistic_breit_wigner_with_ff(
         }
         return expression, parameter_defaults
 
-    dynamics_builder.__doc__ = docstring
-    return dynamics_builder
 
+create_relativistic_breit_wigner = RelativisticBreitWignerBuilder(
+    form_factor=False
+).__call__
+"""
+Create a `.relativistic_breit_wigner` for a two-body decay.
+"""
 
-create_relativistic_breit_wigner_with_ff = _make_relativistic_breit_wigner_with_ff(
+create_relativistic_breit_wigner_with_ff = RelativisticBreitWignerBuilder(
+    form_factor=True,
     phsp_factor=PhaseSpaceFactor,
-    docstring=(
-        "Create a `.relativistic_breit_wigner_with_ff` for a two-body decay."
-    ),
-)
-create_analytic_breit_wigner = _make_relativistic_breit_wigner_with_ff(
+).__call__
+"""
+Create a `.relativistic_breit_wigner_with_ff` for a two-body decay.
+"""
+
+create_analytic_breit_wigner = RelativisticBreitWignerBuilder(
+    form_factor=True,
     phsp_factor=PhaseSpaceFactorAnalytic,
-    docstring="""
+).__call__
+"""
 Create a `.relativistic_breit_wigner_with_ff` with analytic continuation.
 
 .. seealso:: :doc:`/usage/dynamics/analytic-continuation`.
-""",
-)
+"""

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -163,14 +163,11 @@ def _make_relativistic_breit_wigner_with_ff(
     return dynamics_builder
 
 
-__DOCSTRING = (
-    "Create a `.relativistic_breit_wigner_with_ff` for a two-body decay."
-)
-create_relativistic_breit_wigner_with_ff = (
-    _make_relativistic_breit_wigner_with_ff(
-        phsp_factor=PhaseSpaceFactor,
-        docstring=__DOCSTRING,
-    )
+create_relativistic_breit_wigner_with_ff = _make_relativistic_breit_wigner_with_ff(
+    phsp_factor=PhaseSpaceFactor,
+    docstring=(
+        "Create a `.relativistic_breit_wigner_with_ff` for a two-body decay."
+    ),
 )
 create_analytic_breit_wigner = _make_relativistic_breit_wigner_with_ff(
     phsp_factor=PhaseSpaceFactorAnalytic,

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -43,7 +43,14 @@ class TwoBodyKinematicVariableSet:
 
 
 BuilderReturnType = Tuple[sp.Expr, Dict[sp.Symbol, float]]
-"""Type that a `.ResonanceDynamicsBuilder` should return."""
+"""Type that a `.ResonanceDynamicsBuilder` should return.
+
+The first element in this `tuple` is the `sympy.Expr <sympy.core.expr.Expr>`
+that describes the dynamics for the resonance. The second element are suggested
+parameter values (see :attr:`.parameter_defaults`) for the
+`~sympy.core.symbol.Symbol` instances that appear in the `sympy.Expr
+<sympy.core.expr.Expr>`.
+"""
 
 
 class ResonanceDynamicsBuilder(Protocol):

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ allowlist_externals =
     pytest
 commands =
     pytest {posargs:tests} \
-        --cov-fail-under=80 \
+        --cov-fail-under=75 \
         --cov-report=html \
         --cov-report=xml \
         --cov=ampform


### PR DESCRIPTION
Closes #205 

This adds a new class, [`RelativisticBreitWignerBuilder`](https://ampform--206.org.readthedocs.build/en/206/api/ampform.dynamics.builder.html#ampform.dynamics.builder.RelativisticBreitWignerBuilder), which makes it possible to insert different kinds of [`PhaseSpaceFactorProtocol`](https://ampform.readthedocs.io/en/0.12.1/api/ampform.dynamics.html#ampform.dynamics.PhaseSpaceFactorProtocol)s into [`set_dynamics()`](https://ampform.readthedocs.io/en/0.12.x/api/ampform.helicity.html#ampform.helicity.HelicityAmplitudeBuilder.set_dynamics). See [here](https://ampform--206.org.readthedocs.build/en/206/usage/amplitude.html#set-dynamics) how to use.

Essentially, this class is an extension of builder functions such as [`create_relativistic_breit_wigner_with_ff()`](https://ampform.readthedocs.io/en/0.12.x/api/ampform.dynamics.builder.html#ampform.dynamics.builder.create_relativistic_breit_wigner_with_ff) that were used previously.

Note that this builder class will become more important in #151, which introduces yet another phase space factor.