### PR TITLE
refactor: improve helicity angle notation

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -257,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta = sp.Symbol(\"theta_1+2\", real=True)\n",
+    "theta = sp.Symbol(\"theta_12\", real=True)\n",
     "expr = model_no_dynamics.kinematic_variables[theta]\n",
     "expr.doit()"
    ]

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As can be seen, the expression contains several {class}`~sympy.core.symbol.Symbol`s. Some of these represent (kinematic) **variables**, such as the helicity angles $\\phi_{1+2}$ and $\\theta_{1+2}$ (see {func}`.get_helicity_angle_label` for the meaning of their subscripts). Others will later on be interpreted **parameters** when fitting the model to data.\n",
+    "As can be seen, the expression contains several {class}`~sympy.core.symbol.Symbol`s. Some of these represent (kinematic) **variables**, such as the helicity angles $\\phi_{12}$ and $\\theta_{12}$ (see {func}`.get_helicity_angle_label` for the meaning of their subscripts). Others will later on be interpreted **parameters** when fitting the model to data.\n",
     "\n",
     "The {class}`.HelicityModel` comes with expressions for these {attr}`~.HelicityModel.kinematic_variables`, so that it's possible to compute them from 4-momentum data."
    ]

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -449,11 +449,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
    "source": [
-    "```{autolink-skip}\n",
-    "```"
+    "%matplotlib widget"
    ]
   },
   {
@@ -469,7 +477,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import mpl_interactions.ipyplot as iplt\n",
     "\n",

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -367,8 +367,8 @@
     "        \"Gamma_f(0)(1500)\": (0.01, 1, n_steps),\n",
     "        \"m_1\": (0.01, 1, n_steps),\n",
     "        \"m_2\": (0.01, 1, n_steps),\n",
-    "        \"phi_1+2\": (0, 2 * np.pi, 40),\n",
-    "        \"theta_1+2\": (-np.pi, np.pi, 40),\n",
+    "        \"phi_12\": (0, 2 * np.pi, 40),\n",
+    "        \"theta_12\": (-np.pi, np.pi, 40),\n",
     "    }\n",
     ")"
    ]
@@ -392,8 +392,8 @@
     "sliders.set_values(model.parameter_defaults)\n",
     "sliders.set_values(\n",
     "    {  # symbol names\n",
-    "        \"phi_1+2\": 0,\n",
-    "        \"theta_1+2\": np.pi / 2,\n",
+    "        \"phi_12\": 0,\n",
+    "        \"theta_12\": np.pi / 2,\n",
     "    },\n",
     "    # argument names\n",
     "    m_1=pdg[\"pi0\"].mass,\n",
@@ -568,6 +568,10 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -449,6 +449,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{autolink-skip}\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -610,40 +610,39 @@ def get_helicity_angle_label(
     >>> for i in topology.intermediate_edge_ids | topology.outgoing_edge_ids:
     ...     phi_label, theta_label = get_helicity_angle_label(topology, i)
     ...     print(f"{i}: '{phi_label}'")
-    0: 'phi_0,0+3+4'
-    1: 'phi_1,1+2'
-    2: 'phi_2,1+2'
-    3: 'phi_3,3+4,0+3+4'
-    4: 'phi_4,3+4,0+3+4'
-    5: 'phi_0+3+4'
-    6: 'phi_1+2'
-    7: 'phi_3+4,0+3+4'
+    0: 'phi_0,034'
+    1: 'phi_1,12'
+    2: 'phi_2,12'
+    3: 'phi_3,34,034'
+    4: 'phi_4,34,034'
+    5: 'phi_034'
+    6: 'phi_12'
+    7: 'phi_34,034'
     >>> topology = topologies[1]
     >>> for i in topology.intermediate_edge_ids | topology.outgoing_edge_ids:
     ...     phi_label, theta_label = get_helicity_angle_label(topology, i)
     ...     print(f"{i}: '{phi_label}'")
-    0: 'phi_0,0+1'
-    1: 'phi_1,0+1'
-    2: 'phi_2,2+3+4'
-    3: 'phi_3,3+4,2+3+4'
-    4: 'phi_4,3+4,2+3+4'
-    5: 'phi_0+1'
-    6: 'phi_2+3+4'
-    7: 'phi_3+4,2+3+4'
+    0: 'phi_0,01'
+    1: 'phi_1,01'
+    2: 'phi_2,234'
+    3: 'phi_3,34,234'
+    4: 'phi_4,34,234'
+    5: 'phi_01'
+    6: 'phi_234'
+    7: 'phi_34,234'
 
     Some labels explained:
 
-    - :code:`phi_1+2`: **edge 6** on the *left* topology, because for this
+    - :code:`phi_12`: **edge 6** on the *left* topology, because for this
       topology, we have :math:`p_6=p_1+p_2`.
-    - :code:`phi_2+3+4`: **edge 6** *right*, because for this topology,
+    - :code:`phi_234`: **edge 6** *right*, because for this topology,
       :math:`p_6=p_2+p_3+p_4`.
-    - :code:`phi_1,1+2`: **edge 1** *left*, because 1 decays from
+    - :code:`phi_1,12`: **edge 1** *left*, because 1 decays from
       :math:`p_6=p_1+p_2`.
-    - :code:`phi_1,0+1`: **edge 1** *right*, because it decays from
+    - :code:`phi_1,01`: **edge 1** *right*, because it decays from
       :math:`p_5=p_0+p_1`.
-    - :code:`phi_4,3+4,2+3+4`: **edge 4** *right*, because it decays from edge
-      7 (:math:`p_7=p_3+p_4`), which comes from edge 6
-      (:math:`p_7=p_2+p_3+p_4`).
+    - :code:`phi_4,34,234`: **edge 4** *right*, because it decays from edge 7
+      (:math:`p_7=p_3+p_4`), which comes from edge 6 (:math:`p_7=p_2+p_3+p_4`).
 
     As noted, the top-most parent (initial state) is not listed in the label.
     """
@@ -657,7 +656,7 @@ def get_helicity_angle_label(
             attached_final_state_ids = determine_attached_final_state(
                 topology, state_id
             )
-            label = "+".join(map(str, attached_final_state_ids))
+            label = "".join(map(str, attached_final_state_ids))
         if edge.originating_node_id is not None:
             incoming_state_ids = topology.get_edge_ids_ingoing_to_node(
                 edge.originating_node_id

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -486,7 +486,7 @@ def compute_helicity_angles(
     >>> topology = topologies[0]
     >>> four_momenta = create_four_momentum_symbols(topology)
     >>> angles = compute_helicity_angles(four_momenta, topology)
-    >>> angles["theta_1+2"]
+    >>> angles["theta_12"]
     Theta(p1 + p2)
     """
     if topology.outgoing_edge_ids != set(four_momenta):
@@ -610,26 +610,26 @@ def get_helicity_angle_label(
     >>> for i in topology.intermediate_edge_ids | topology.outgoing_edge_ids:
     ...     phi_label, theta_label = get_helicity_angle_label(topology, i)
     ...     print(f"{i}: '{phi_label}'")
-    0: 'phi_0,034'
-    1: 'phi_1,12'
-    2: 'phi_2,12'
-    3: 'phi_3,34,034'
-    4: 'phi_4,34,034'
+    0: 'phi_0^034'
+    1: 'phi_1^12'
+    2: 'phi_2^12'
+    3: 'phi_3^34,034'
+    4: 'phi_4^34,034'
     5: 'phi_034'
     6: 'phi_12'
-    7: 'phi_34,034'
+    7: 'phi_34^034'
     >>> topology = topologies[1]
     >>> for i in topology.intermediate_edge_ids | topology.outgoing_edge_ids:
     ...     phi_label, theta_label = get_helicity_angle_label(topology, i)
     ...     print(f"{i}: '{phi_label}'")
-    0: 'phi_0,01'
-    1: 'phi_1,01'
-    2: 'phi_2,234'
-    3: 'phi_3,34,234'
-    4: 'phi_4,34,234'
+    0: 'phi_0^01'
+    1: 'phi_1^01'
+    2: 'phi_2^234'
+    3: 'phi_3^34,234'
+    4: 'phi_4^34,234'
     5: 'phi_01'
     6: 'phi_234'
-    7: 'phi_34,234'
+    7: 'phi_34^234'
 
     Some labels explained:
 
@@ -637,11 +637,11 @@ def get_helicity_angle_label(
       topology, we have :math:`p_6=p_1+p_2`.
     - :code:`phi_234`: **edge 6** *right*, because for this topology,
       :math:`p_6=p_2+p_3+p_4`.
-    - :code:`phi_1,12`: **edge 1** *left*, because 1 decays from
+    - :code:`phi_1^12`: **edge 1** *left*, because 1 decays from
       :math:`p_6=p_1+p_2`.
-    - :code:`phi_1,01`: **edge 1** *right*, because it decays from
+    - :code:`phi_1^01`: **edge 1** *right*, because it decays from
       :math:`p_5=p_0+p_1`.
-    - :code:`phi_4,34,234`: **edge 4** *right*, because it decays from edge 7
+    - :code:`phi_4^34,234`: **edge 4** *right*, because it decays from edge 7
       (:math:`p_7=p_3+p_4`), which comes from edge 6 (:math:`p_7=p_2+p_3+p_4`).
 
     As noted, the top-most parent (initial state) is not listed in the label.
@@ -667,7 +667,14 @@ def get_helicity_angle_label(
         return label
 
     label = recursive_label(topology, state_id)
-    return f"phi_{label}", f"theta_{label}"
+
+    index_groups = label.split(",")
+    subscript = index_groups[0]
+    suffix = f"_{subscript}"
+    if len(index_groups) > 1:
+        superscript = ",".join(index_groups[1:])
+        suffix += f"^{superscript}"
+    return f"phi{suffix}", f"theta{suffix}"
 
 
 def get_invariant_mass_label(topology: Topology, state_id: int) -> str:

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -146,7 +146,7 @@ class TestHelicityModel:
     ("node_id", "mass", "phi", "theta"),
     [
         (0, "m_012", "phi_12", "theta_12"),
-        (1, "m_12", "phi_1,12", "theta_1,12"),
+        (1, "m_12", "phi_1^12", "theta_1^12"),
     ],
 )
 def test_generate_kinematic_variables(
@@ -167,11 +167,11 @@ def test_generate_kinematic_variables(
     ("transition", "node_id", "expected"),
     [
         (0, 0, "WignerD(1, -1, 1, -phi_12, theta_12, 0)"),
-        (0, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
+        (0, 1, "WignerD(0, 0, 0, -phi_1^12, theta_1^12, 0)"),
         (1, 0, "WignerD(1, -1, -1, -phi_12, theta_12, 0)"),
-        (1, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
+        (1, 1, "WignerD(0, 0, 0, -phi_1^12, theta_1^12, 0)"),
         (2, 0, "WignerD(1, 1, 1, -phi_12, theta_12, 0)"),
-        (2, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
+        (2, 1, "WignerD(0, 0, 0, -phi_1^12, theta_1^12, 0)"),
     ],
 )
 def test_formulate_wigner_d(

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -145,8 +145,8 @@ class TestHelicityModel:
 @pytest.mark.parametrize(
     ("node_id", "mass", "phi", "theta"),
     [
-        (0, "m_012", "phi_1+2", "theta_1+2"),
-        (1, "m_12", "phi_1,1+2", "theta_1,1+2"),
+        (0, "m_012", "phi_12", "theta_12"),
+        (1, "m_12", "phi_1,12", "theta_1,12"),
     ],
 )
 def test_generate_kinematic_variables(
@@ -166,12 +166,12 @@ def test_generate_kinematic_variables(
 @pytest.mark.parametrize(
     ("transition", "node_id", "expected"),
     [
-        (0, 0, "WignerD(1, -1, 1, -phi_1+2, theta_1+2, 0)"),
-        (0, 1, "WignerD(0, 0, 0, -phi_1,1+2, theta_1,1+2, 0)"),
-        (1, 0, "WignerD(1, -1, -1, -phi_1+2, theta_1+2, 0)"),
-        (1, 1, "WignerD(0, 0, 0, -phi_1,1+2, theta_1,1+2, 0)"),
-        (2, 0, "WignerD(1, 1, 1, -phi_1+2, theta_1+2, 0)"),
-        (2, 1, "WignerD(0, 0, 0, -phi_1,1+2, theta_1,1+2, 0)"),
+        (0, 0, "WignerD(1, -1, 1, -phi_12, theta_12, 0)"),
+        (0, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
+        (1, 0, "WignerD(1, -1, -1, -phi_12, theta_12, 0)"),
+        (1, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
+        (2, 0, "WignerD(1, 1, 1, -phi_12, theta_12, 0)"),
+        (2, 1, "WignerD(0, 0, 0, -phi_1,12, theta_1,12, 0)"),
     ],
 )
 def test_formulate_wigner_d(

--- a/tests/symplot/test_symplot.py
+++ b/tests/symplot/test_symplot.py
@@ -30,14 +30,14 @@ class TestSliderKwargs:
                 "alpha": FloatSlider(
                     value=0.3, min=0.0, max=2.5, description=R"$\alpha$"
                 ),
-                R"\theta_1+2": FloatSlider(
-                    value=1.5, min=0.0, max=3.14, description=R"$\theta_{1+2}$"
+                R"\theta_12": FloatSlider(
+                    value=1.5, min=0.0, max=3.14, description=R"$\theta_{12}$"
                 ),
             },
             arg_to_symbol={
                 "n": "n",
                 "alpha": "alpha",
-                "Dummy": R"\theta_1+2",
+                "Dummy": R"\theta_12",
             },
         )
 
@@ -53,11 +53,11 @@ class TestSliderKwargs:
         assert alpha_slider.value == 0.3
         assert alpha_slider.description == R"$\alpha$"
 
-        theta_slider = slider_kwargs[sp.Symbol(R"\theta_1+2", real=True)]
+        theta_slider = slider_kwargs[sp.Symbol(R"\theta_12", real=True)]
         assert theta_slider is not None
         assert isinstance(theta_slider, FloatSlider)
         assert theta_slider.max == 3.14
-        assert theta_slider.description == R"$\theta_{1+2}$"
+        assert theta_slider.description == R"$\theta_{12}$"
         assert slider_kwargs["Dummy"] == theta_slider
 
         error_message_pattern = r"is neither an argument nor a symbol name"
@@ -159,7 +159,7 @@ class TestSliderKwargs:
         assert sliders["Dummy"].value == 2
 
         # Using a symbol mapping
-        n, alpha, theta = sp.symbols(R"n, alpha, \theta_1+2")
+        n, alpha, theta = sp.symbols(R"n, alpha, \theta_12")
         sliders.set_values({n: 5, alpha: 2.1, theta: 1.57})
         assert sliders["n"].value == 5
         assert sliders["alpha"].value == 2.1

--- a/tests/test_angular_distributions.py
+++ b/tests/test_angular_distributions.py
@@ -93,20 +93,20 @@ class TestEpemToDmD0Pip:
                 1,
             ),
             (  # cos(theta') distribution from D2*
-                "theta_1,12",
+                "theta_1^12",
                 1
-                - (2 * sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2 - 1)
+                - (2 * sp.cos(sp.Symbol("theta_1^12", real=True)) ** 2 - 1)
                 ** 2,
             ),
             (  # phi' distribution of the D2* decay
-                "phi_1,12",
-                3 - 2 * sp.sin(sp.Symbol("phi_1,12", real=True)) ** 2,
+                "phi_1^12",
+                3 - 2 * sp.sin(sp.Symbol("phi_1^12", real=True)) ** 2,
             ),
             (  # 2d distribution of the D2* decay
-                ["theta_1,12", "phi_1,12"],
-                (1 - sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2)
-                * (sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2)
-                * (2 + sp.cos(2 * sp.Symbol("phi_1,12", real=True))),
+                ["theta_1^12", "phi_1^12"],
+                (1 - sp.cos(sp.Symbol("theta_1^12", real=True)) ** 2)
+                * (sp.cos(sp.Symbol("theta_1^12", real=True)) ** 2)
+                * (2 + sp.cos(2 * sp.Symbol("phi_1^12", real=True))),
             ),
         ],
     )
@@ -117,9 +117,9 @@ class TestEpemToDmD0Pip:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,12",
+            "phi_1^12",
             "theta_12",
-            "theta_1,12",
+            "theta_1^12",
         }
 
         if isinstance(angular_variables, str):
@@ -188,16 +188,16 @@ class TestD1ToD0PiPi:
                 * sp.cos(sp.Symbol("theta_12", real=True)) ** 2,
             ),
             (  # theta distribution from D*
-                "theta_1,12",
+                "theta_1^12",
                 1
                 - sp.Rational(3, 4)
-                * sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2,
+                * sp.cos(sp.Symbol("theta_1^12", real=True)) ** 2,
             ),
             (  # phi distribution of the D* decay
-                "phi_1,12",
+                "phi_1^12",
                 1
                 - sp.Rational(4, 9)
-                * sp.cos(2 * sp.Symbol("phi_1,12", real=True)),
+                * sp.cos(2 * sp.Symbol("phi_1^12", real=True)),
             ),
         ],
     )
@@ -208,9 +208,9 @@ class TestD1ToD0PiPi:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,12",
+            "phi_1^12",
             "theta_12",
-            "theta_1,12",
+            "theta_1^12",
         }
 
         if isinstance(angular_variables, str):

--- a/tests/test_angular_distributions.py
+++ b/tests/test_angular_distributions.py
@@ -85,28 +85,28 @@ class TestEpemToDmD0Pip:
         ("angular_variables", "expected_distribution_function"),
         [
             (  # cos(theta) distribution from epem decay
-                "theta_1+2",
-                1 + sp.cos(sp.Symbol("theta_1+2", real=True)) ** 2,
+                "theta_12",
+                1 + sp.cos(sp.Symbol("theta_12", real=True)) ** 2,
             ),
             (  # phi distribution of the epem decay
-                "phi_1+2",
+                "phi_12",
                 1,
             ),
             (  # cos(theta') distribution from D2*
-                "theta_1,1+2",
+                "theta_1,12",
                 1
-                - (2 * sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2 - 1)
+                - (2 * sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2 - 1)
                 ** 2,
             ),
             (  # phi' distribution of the D2* decay
-                "phi_1,1+2",
-                3 - 2 * sp.sin(sp.Symbol("phi_1,1+2", real=True)) ** 2,
+                "phi_1,12",
+                3 - 2 * sp.sin(sp.Symbol("phi_1,12", real=True)) ** 2,
             ),
             (  # 2d distribution of the D2* decay
-                ["theta_1,1+2", "phi_1,1+2"],
-                (1 - sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2)
-                * (sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2)
-                * (2 + sp.cos(2 * sp.Symbol("phi_1,1+2", real=True))),
+                ["theta_1,12", "phi_1,12"],
+                (1 - sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2)
+                * (sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2)
+                * (2 + sp.cos(2 * sp.Symbol("phi_1,12", real=True))),
             ),
         ],
     )
@@ -117,9 +117,9 @@ class TestEpemToDmD0Pip:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,1+2",
-            "theta_1+2",
-            "theta_1,1+2",
+            "phi_1,12",
+            "theta_12",
+            "theta_1,12",
         }
 
         if isinstance(angular_variables, str):
@@ -182,22 +182,22 @@ class TestD1ToD0PiPi:
         ("angular_variables", "expected_distribution_function"),
         [
             (  # theta distribution from D1 decay
-                "theta_1+2",
+                "theta_12",
                 sp.Rational(5, 4)
                 + sp.Rational(3, 4)
-                * sp.cos(sp.Symbol("theta_1+2", real=True)) ** 2,
+                * sp.cos(sp.Symbol("theta_12", real=True)) ** 2,
             ),
             (  # theta distribution from D*
-                "theta_1,1+2",
+                "theta_1,12",
                 1
                 - sp.Rational(3, 4)
-                * sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2,
+                * sp.cos(sp.Symbol("theta_1,12", real=True)) ** 2,
             ),
             (  # phi distribution of the D* decay
-                "phi_1,1+2",
+                "phi_1,12",
                 1
                 - sp.Rational(4, 9)
-                * sp.cos(2 * sp.Symbol("phi_1,1+2", real=True)),
+                * sp.cos(2 * sp.Symbol("phi_1,12", real=True)),
             ),
         ],
     )
@@ -208,9 +208,9 @@ class TestD1ToD0PiPi:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,1+2",
-            "theta_1+2",
-            "theta_1,1+2",
+            "phi_1,12",
+            "theta_12",
+            "theta_1,12",
         }
 
         if isinstance(angular_variables, str):

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -157,7 +157,7 @@ class TestTheta:
     ("angle_name", "expected_values"),
     [
         (
-            "phi_1+2+3",
+            "phi_123",
             np.array(
                 [
                     2.79758,
@@ -174,7 +174,7 @@ class TestTheta:
             ),
         ),
         (
-            "theta_1+2+3",
+            "theta_123",
             np.arccos(
                 [
                     -0.914298,
@@ -191,7 +191,7 @@ class TestTheta:
             ),
         ),
         (
-            "phi_2+3,1+2+3",
+            "phi_23,123",
             np.array(
                 [
                     1.04362,
@@ -208,7 +208,7 @@ class TestTheta:
             ),
         ),
         (
-            "theta_2+3,1+2+3",
+            "theta_23,123",
             np.arccos(
                 [
                     -0.772533,
@@ -225,7 +225,7 @@ class TestTheta:
             ),
         ),
         (
-            "phi_2,2+3,1+2+3",
+            "phi_2,23,123",
             np.array(
                 [  # WARNING: subsystem solution (ComPWA) results in pi differences
                     -2.77203 + np.pi,
@@ -242,7 +242,7 @@ class TestTheta:
             ),
         ),
         (
-            "theta_2,2+3,1+2+3",
+            "theta_2,23,123",
             np.arccos(
                 [
                     0.460324,

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -191,7 +191,7 @@ class TestTheta:
             ),
         ),
         (
-            "phi_23,123",
+            "phi_23^123",
             np.array(
                 [
                     1.04362,
@@ -208,7 +208,7 @@ class TestTheta:
             ),
         ),
         (
-            "theta_23,123",
+            "theta_23^123",
             np.arccos(
                 [
                     -0.772533,
@@ -225,7 +225,7 @@ class TestTheta:
             ),
         ),
         (
-            "phi_2,23,123",
+            "phi_2^23,123",
             np.array(
                 [  # WARNING: subsystem solution (ComPWA) results in pi differences
                     -2.77203 + np.pi,
@@ -242,7 +242,7 @@ class TestTheta:
             ),
         ),
         (
-            "theta_2,23,123",
+            "theta_2^23,123",
             np.arccos(
                 [
                     0.460324,


### PR DESCRIPTION
Closes #208 

Compare [old notation](https://ampform.readthedocs.io/en/0.12.2/api/ampform.kinematics.html#ampform.kinematics.get_helicity_angle_label) and [new notation](https://ampform--209.org.readthedocs.build/en/209/api/ampform.kinematics.html#ampform.kinematics.get_helicity_angle_label).