### PR TITLE
docs: clean up API of kinematics module

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -145,55 +145,6 @@ def extend_EnergyDependentWidth() -> None:
     )
 
 
-def extend_formulate_wigner_d() -> None:
-    from ampform.helicity import formulate_wigner_d
-
-    _append_to_docstring(
-        formulate_wigner_d,
-        __get_graphviz_state_transition_example("helicity"),
-    )
-
-
-def extend_formulate_clebsch_gordan_coefficients() -> None:
-    from ampform.helicity import formulate_clebsch_gordan_coefficients
-
-    _append_to_docstring(
-        formulate_clebsch_gordan_coefficients,
-        __get_graphviz_state_transition_example(
-            formalism="canonical-helicity", transition_number=1
-        ),
-    )
-
-
-def __get_graphviz_state_transition_example(
-    formalism: str, transition_number: int = 0
-) -> str:
-    reaction = qrules.generate_transitions(
-        initial_state=[("J/psi(1S)", [+1])],
-        final_state=[("gamma", [-1]), "f(0)(980)"],
-        formalism=formalism,
-    )
-    transition = reaction.transitions[transition_number]
-    new_interaction = attr.evolve(
-        transition.interactions[0],
-        parity_prefactor=None,
-    )
-    interactions = dict(transition.interactions)
-    interactions[0] = new_interaction
-    transition = attr.evolve(transition, interactions=interactions)
-    dot = qrules.io.asdot(
-        transition,
-        render_initial_state_id=True,
-        render_node=True,
-    )
-    for state_id in [0, 1, -1]:
-        dot = dot.replace(
-            f'label="{state_id}: ',
-            f'label="{state_id+2}: ',
-        )
-    return _graphviz_to_image(dot, indent=4, options={"align": "center"})
-
-
 def extend_Energy_and_FourMomentumXYZ() -> None:
     from ampform.kinematics import (
         Energy,
@@ -216,39 +167,6 @@ def extend_Energy_and_FourMomentumXYZ() -> None:
     _extend(FourMomentumX)
     _extend(FourMomentumY)
     _extend(FourMomentumZ)
-
-
-def extend_get_helicity_angle_label() -> None:
-    from ampform.kinematics import get_helicity_angle_label
-
-    topologies = qrules.topology.create_isobar_topologies(5)
-    dot0, dot1, *_ = tuple(
-        map(lambda t: qrules.io.asdot(t, render_resonance_id=True), topologies)
-    )
-    graphviz0 = _graphviz_to_image(
-        dot0,
-        indent=6,
-        caption=":code:`topologies[0]`",
-        label="one-to-five-topology-0",
-    )
-    graphviz1 = _graphviz_to_image(
-        dot1,
-        indent=6,
-        caption=":code:`topologies[1]`",
-        label="one-to-five-topology-1",
-    )
-    _append_to_docstring(
-        get_helicity_angle_label,
-        f"""
-
-    .. panels::
-      :body: text-center
-      {graphviz0}
-
-      ---
-      {graphviz1}
-    """,
-    )
 
 
 def extend_InvariantMass() -> None:
@@ -325,50 +243,6 @@ def extend_Phi() -> None:
     _append_latex_doit_definition(expr)
 
 
-def extend_relativistic_breit_wigner() -> None:
-    from ampform.dynamics import relativistic_breit_wigner
-
-    s, m0, w0 = sp.symbols("s m0 Gamma0")
-    rel_bw = relativistic_breit_wigner(s, m0, w0)
-    _append_to_docstring(
-        relativistic_breit_wigner,
-        f"""
-    .. math:: {sp.latex(rel_bw)}
-        :label: relativistic_breit_wigner
-    """,
-    )
-
-
-def extend_relativistic_breit_wigner_with_ff() -> None:
-    from ampform.dynamics import relativistic_breit_wigner_with_ff
-
-    L = sp.Symbol("L", integer=True)
-    s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d")
-    rel_bw_with_ff = relativistic_breit_wigner_with_ff(
-        s=s,
-        mass0=m0,
-        gamma0=w0,
-        m_a=m_a,
-        m_b=m_b,
-        angular_momentum=L,
-        meson_radius=d,
-    )
-    _append_to_docstring(
-        relativistic_breit_wigner_with_ff,
-        fR"""
-    The general form of a relativistic Breit-Wigner with Blatt-Weisskopf form
-    factor is:
-
-    .. math:: {sp.latex(rel_bw_with_ff)}
-        :label: relativistic_breit_wigner_with_ff
-
-    where :math:`\Gamma(s)` is defined by :eq:`EnergyDependentWidth`, :math:`B_L^2` is
-    defined by :eq:`BlattWeisskopfSquared`, and :math:`q^2` is defined by
-    :eq:`BreakupMomentumSquared`.
-    """,
-    )
-
-
 def extend_RotationY() -> None:
     from ampform.kinematics import RotationY
 
@@ -437,6 +311,132 @@ def extend_ThreeMomentumNorm() -> None:
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
     _append_latex_doit_definition(expr, deep=False)
+
+
+def extend_formulate_clebsch_gordan_coefficients() -> None:
+    from ampform.helicity import formulate_clebsch_gordan_coefficients
+
+    _append_to_docstring(
+        formulate_clebsch_gordan_coefficients,
+        __get_graphviz_state_transition_example(
+            formalism="canonical-helicity", transition_number=1
+        ),
+    )
+
+
+def extend_formulate_wigner_d() -> None:
+    from ampform.helicity import formulate_wigner_d
+
+    _append_to_docstring(
+        formulate_wigner_d,
+        __get_graphviz_state_transition_example("helicity"),
+    )
+
+
+def __get_graphviz_state_transition_example(
+    formalism: str, transition_number: int = 0
+) -> str:
+    reaction = qrules.generate_transitions(
+        initial_state=[("J/psi(1S)", [+1])],
+        final_state=[("gamma", [-1]), "f(0)(980)"],
+        formalism=formalism,
+    )
+    transition = reaction.transitions[transition_number]
+    new_interaction = attr.evolve(
+        transition.interactions[0],
+        parity_prefactor=None,
+    )
+    interactions = dict(transition.interactions)
+    interactions[0] = new_interaction
+    transition = attr.evolve(transition, interactions=interactions)
+    dot = qrules.io.asdot(
+        transition,
+        render_initial_state_id=True,
+        render_node=True,
+    )
+    for state_id in [0, 1, -1]:
+        dot = dot.replace(
+            f'label="{state_id}: ',
+            f'label="{state_id+2}: ',
+        )
+    return _graphviz_to_image(dot, indent=4, options={"align": "center"})
+
+
+def extend_get_helicity_angle_label() -> None:
+    from ampform.kinematics import get_helicity_angle_label
+
+    topologies = qrules.topology.create_isobar_topologies(5)
+    dot0, dot1, *_ = tuple(
+        map(lambda t: qrules.io.asdot(t, render_resonance_id=True), topologies)
+    )
+    graphviz0 = _graphviz_to_image(
+        dot0,
+        indent=6,
+        caption=":code:`topologies[0]`",
+        label="one-to-five-topology-0",
+    )
+    graphviz1 = _graphviz_to_image(
+        dot1,
+        indent=6,
+        caption=":code:`topologies[1]`",
+        label="one-to-five-topology-1",
+    )
+    _append_to_docstring(
+        get_helicity_angle_label,
+        f"""
+
+    .. panels::
+      :body: text-center
+      {graphviz0}
+
+      ---
+      {graphviz1}
+    """,
+    )
+
+
+def extend_relativistic_breit_wigner() -> None:
+    from ampform.dynamics import relativistic_breit_wigner
+
+    s, m0, w0 = sp.symbols("s m0 Gamma0")
+    rel_bw = relativistic_breit_wigner(s, m0, w0)
+    _append_to_docstring(
+        relativistic_breit_wigner,
+        f"""
+    .. math:: {sp.latex(rel_bw)}
+        :label: relativistic_breit_wigner
+    """,
+    )
+
+
+def extend_relativistic_breit_wigner_with_ff() -> None:
+    from ampform.dynamics import relativistic_breit_wigner_with_ff
+
+    L = sp.Symbol("L", integer=True)
+    s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d")
+    rel_bw_with_ff = relativistic_breit_wigner_with_ff(
+        s=s,
+        mass0=m0,
+        gamma0=w0,
+        m_a=m_a,
+        m_b=m_b,
+        angular_momentum=L,
+        meson_radius=d,
+    )
+    _append_to_docstring(
+        relativistic_breit_wigner_with_ff,
+        fR"""
+    The general form of a relativistic Breit-Wigner with Blatt-Weisskopf form
+    factor is:
+
+    .. math:: {sp.latex(rel_bw_with_ff)}
+        :label: relativistic_breit_wigner_with_ff
+
+    where :math:`\Gamma(s)` is defined by :eq:`EnergyDependentWidth`, :math:`B_L^2` is
+    defined by :eq:`BlattWeisskopfSquared`, and :math:`q^2` is defined by
+    :eq:`BreakupMomentumSquared`.
+    """,
+    )
 
 
 def _append_latex_doit_definition(

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -71,24 +71,17 @@ def extend_BoostZ() -> None:
         :label: BoostZ
     """,
     )
-    b = sp.Symbol("b")
-    printer = NumPyPrinter()
-    numpy_code = BoostZ(b)._numpycode(printer)
-    import_statements = __print_imports(printer)
     _append_to_docstring(
         BoostZ,
-        f"""
+        """
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
     a computational backend and it should operate on four-momentum arrays of
     rank-2. As such, this boost matrix becomes a **rank-3** matrix. When using
     `NumPy <https://numpy.org>`_ as backend, the computation looks as follows:
-
-    .. code::
-
-        {import_statements}
-        {numpy_code}
     """,
     )
+    b = sp.Symbol("b")
+    _append_code_rendering(BoostZ(b))
 
 
 def extend_BreakupMomentumSquared() -> None:
@@ -277,24 +270,17 @@ def extend_RotationZ() -> None:
         :label: RotationZ
     """,
     )
-    a = sp.Symbol("a")
-    printer = NumPyPrinter()
-    numpy_code = RotationZ(a)._numpycode(printer)
-    import_statements = __print_imports(printer)
     _append_to_docstring(
         RotationZ,
-        f"""
+        """
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
     a computational backend and it should operate on four-momentum arrays of
     rank-2. As such, this boost matrix becomes a **rank-3** matrix. When using
     `NumPy <https://numpy.org>`_ as backend, the computation looks as follows:
-
-    .. code-block::
-
-        {import_statements}
-        {numpy_code}
     """,
     )
+    a = sp.Symbol("a")
+    _append_code_rendering(RotationZ(a))
 
 
 def extend_Theta() -> None:
@@ -435,6 +421,21 @@ def extend_relativistic_breit_wigner_with_ff() -> None:
     where :math:`\Gamma(s)` is defined by :eq:`EnergyDependentWidth`, :math:`B_L^2` is
     defined by :eq:`BlattWeisskopfSquared`, and :math:`q^2` is defined by
     :eq:`BreakupMomentumSquared`.
+    """,
+    )
+
+
+def _append_code_rendering(expr: sp.Expr) -> None:
+    printer = NumPyPrinter()
+    numpy_code = expr._numpycode(printer)
+    import_statements = __print_imports(printer)
+    _append_to_docstring(
+        type(expr),
+        f"""
+    .. code::
+
+        {import_statements}
+        {numpy_code}
     """,
     )
 

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -40,6 +40,8 @@ from ampform.kinematics import (
     FourMomentumX,
     FourMomentumY,
     FourMomentumZ,
+    RotationY,
+    RotationZ,
     get_helicity_angle_label,
 )
 from ampform.sympy._array_expressions import ArraySymbol
@@ -364,6 +366,56 @@ def render_relativistic_breit_wigner_with_ff() -> None:
     where :math:`\Gamma(s)` is defined by :eq:`EnergyDependentWidth`, :math:`B_L^2` is
     defined by :eq:`BlattWeisskopfSquared`, and :math:`q^2` is defined by
     :eq:`BreakupMomentumSquared`.
+    """,
+    )
+
+
+def render_rotation_y() -> None:
+    angle = sp.Symbol("alpha")
+    expr = RotationY(angle)
+    update_docstring(
+        RotationY,
+        f"""\n
+    The **matrix** for a rotation over angle :math:`\\alpha` around the
+    :math:`y`-axis operating on `FourMomentumSymbol` looks like:
+
+    .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
+        :label: RotationY
+
+    See `RotationZ` for the computational code.
+    """,
+    )
+
+
+def render_rotation_z() -> None:
+    angle = sp.Symbol("alpha")
+    expr = RotationZ(angle)
+    update_docstring(
+        RotationZ,
+        f"""\n
+    The **matrix** for a rotation over angle :math:`\\alpha` around the
+    :math:`y`-axis operating on `FourMomentumSymbol` looks like:
+
+    .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
+        :label: RotationZ
+    """,
+    )
+    a = sp.Symbol("a")
+    printer = NumPyPrinter()
+    numpy_code = RotationZ(a)._numpycode(printer)
+    import_statements = __print_imports(printer)
+    update_docstring(
+        RotationZ,
+        f"""
+    In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
+    a computational backend and it should operate on four-momentum arrays of
+    rank-2. As such, this boost matrix becomes a **rank-3** matrix. When using
+    `NumPy <https://numpy.org>`_ as backend, the computation looks as follows:
+
+    .. code-block::
+
+        {import_statements}
+        {numpy_code}
     """,
     )
 

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -24,6 +24,30 @@ from ampform.sympy._array_expressions import ArraySymbol
 logging.getLogger().setLevel(logging.ERROR)
 
 
+def extend_docstrings() -> None:
+    script_name = __file__.rsplit("/", maxsplit=1)[-1]
+    script_name = ".".join(script_name.split(".")[:-1])
+    definitions = dict(globals())
+    for name, definition in definitions.items():
+        module = inspect.getmodule(definition)
+        if module is None:
+            continue
+        if module.__name__ not in {"__main__", script_name}:
+            continue
+        if not inspect.isfunction(definition):
+            continue
+        if not name.startswith("extend_"):
+            continue
+        if name == "extend_docstrings":
+            continue
+        function_arguments = inspect.signature(definition).parameters
+        if len(function_arguments):
+            raise ValueError(
+                f"Local function {name} should not have a signature"
+            )
+        definition()
+
+
 def extend_blatt_weisskopf() -> None:
     from ampform.dynamics import BlattWeisskopfSquared
 
@@ -455,30 +479,6 @@ def __print_imports(printer: NumPyPrinter) -> str:
         imported_items = ", ".join(sorted(items))
         code += f"from {module} import {imported_items}\n"
     return code
-
-
-def extend_docstrings() -> None:
-    script_name = __file__.rsplit("/", maxsplit=1)[-1]
-    script_name = ".".join(script_name.split(".")[:-1])
-    definitions = dict(globals())
-    for name, definition in definitions.items():
-        module = inspect.getmodule(definition)
-        if module is None:
-            continue
-        if module.__name__ not in {"__main__", script_name}:
-            continue
-        if not inspect.isfunction(definition):
-            continue
-        if not name.startswith("extend_"):
-            continue
-        if name == "extend_docstrings":
-            continue
-        function_arguments = inspect.signature(definition).parameters
-        if len(function_arguments):
-            raise ValueError(
-                f"Local function {name} should not have a signature"
-            )
-        definition()
 
 
 _GRAPHVIZ_COUNTER = 0

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -57,22 +57,22 @@ def extend_BlattWeisskopfSquared() -> None:
     _append_latex_doit_definition(expr, deep=True, full_width=True)
 
 
-def extend_BoostZ() -> None:
-    from ampform.kinematics import BoostZ
+def extend_BoostZMatrix() -> None:
+    from ampform.kinematics import BoostZMatrix
 
     beta = sp.Symbol("beta")
-    expr = BoostZ(beta)
+    expr = BoostZMatrix(beta)
     _append_to_docstring(
-        BoostZ,
+        BoostZMatrix,
         f"""\n
     This boost operates on a `FourMomentumSymbol` and looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
-        :label: BoostZ
+        :label: BoostZMatrix
     """,
     )
     _append_to_docstring(
-        BoostZ,
+        BoostZMatrix,
         """
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
     a computational backend and it should operate on four-momentum arrays of
@@ -81,7 +81,7 @@ def extend_BoostZ() -> None:
     """,
     )
     b = sp.Symbol("b")
-    _append_code_rendering(BoostZ(b))
+    _append_code_rendering(BoostZMatrix(b))
 
 
 def extend_BreakupMomentumSquared() -> None:
@@ -232,42 +232,42 @@ def extend_Phi() -> None:
     _append_latex_doit_definition(expr)
 
 
-def extend_RotationY() -> None:
-    from ampform.kinematics import RotationY
+def extend_RotationYMatrix() -> None:
+    from ampform.kinematics import RotationYMatrix
 
     angle = sp.Symbol("alpha")
-    expr = RotationY(angle)
+    expr = RotationYMatrix(angle)
     _append_to_docstring(
-        RotationY,
+        RotationYMatrix,
         f"""\n
     The matrix for a rotation over angle :math:`\\alpha` around the
     :math:`y`-axis operating on `FourMomentumSymbol` looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
-        :label: RotationY
+        :label: RotationYMatrix
 
-    See `RotationZ` for the computational code.
+    See `RotationZMatrix` for the computational code.
     """,
     )
 
 
-def extend_RotationZ() -> None:
-    from ampform.kinematics import RotationZ
+def extend_RotationZMatrix() -> None:
+    from ampform.kinematics import RotationZMatrix
 
     angle = sp.Symbol("alpha")
-    expr = RotationZ(angle)
+    expr = RotationZMatrix(angle)
     _append_to_docstring(
-        RotationZ,
+        RotationZMatrix,
         f"""\n
     The matrix for a rotation over angle :math:`\\alpha` around the
     :math:`z`-axis operating on `FourMomentumSymbol` looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
-        :label: RotationZ
+        :label: RotationZMatrix
     """,
     )
     _append_to_docstring(
-        RotationZ,
+        RotationZMatrix,
         """
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
     a computational backend and it should operate on four-momentum arrays of
@@ -276,7 +276,7 @@ def extend_RotationZ() -> None:
     """,
     )
     a = sp.Symbol("a")
-    _append_code_rendering(RotationZ(a))
+    _append_code_rendering(RotationZMatrix(a))
 
 
 def extend_Theta() -> None:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -34,7 +34,14 @@ from ampform.helicity import (
     formulate_clebsch_gordan_coefficients,
     formulate_wigner_d,
 )
-from ampform.kinematics import get_helicity_angle_label
+from ampform.kinematics import (
+    Energy,
+    FourMomentumX,
+    FourMomentumY,
+    FourMomentumZ,
+    get_helicity_angle_label,
+)
+from ampform.sympy._array_expressions import ArraySymbol
 from ampform.sympy.math import ComplexSqrt
 
 logging.getLogger().setLevel(logging.ERROR)
@@ -166,6 +173,23 @@ def __get_graphviz_state_transition_example(
             f'label="{state_id+2}: ',
         )
     return _graphviz_to_image(dot, indent=4, options={"align": "center"})
+
+
+def render_four_momentum_components() -> None:
+    def _render(component_class: Type[sp.Expr]) -> None:
+        p = ArraySymbol("p")
+        energy = component_class(p)
+        update_docstring(
+            component_class,
+            f"""\n
+            :math:`{sp.latex(energy)}={sp.latex(energy.doit())}`
+            """,
+        )
+
+    _render(Energy)
+    _render(FourMomentumX)
+    _render(FourMomentumY)
+    _render(FourMomentumZ)
 
 
 def render_get_helicity_angle_label() -> None:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -260,7 +260,7 @@ def extend_RotationZ() -> None:
         RotationZ,
         f"""\n
     The matrix for a rotation over angle :math:`\\alpha` around the
-    :math:`y`-axis operating on `FourMomentumSymbol` looks like:
+    :math:`z`-axis operating on `FourMomentumSymbol` looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
         :label: RotationZ

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -503,7 +503,7 @@ SCRIPT_NAME = __file__.rsplit("/", maxsplit=1)[-1]
 SCRIPT_NAME = ".".join(SCRIPT_NAME.split(".")[:-1])
 
 
-def insert_math() -> None:
+def extend_docstrings() -> None:
     definitions = dict(globals())
     for name, definition in definitions.items():
         module = inspect.getmodule(definition)
@@ -514,6 +514,8 @@ def insert_math() -> None:
         if not inspect.isfunction(definition):
             continue
         if not name.startswith("extend_"):
+            continue
+        if name == "extend_docstrings":
             continue
         function_arguments = inspect.signature(definition).parameters
         if len(function_arguments):

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -147,14 +147,10 @@ def extend_Energy_and_FourMomentumXYZ() -> None:
     )
 
     def _extend(component_class: Type[sp.Expr]) -> None:
+        _append_to_docstring(component_class, "\n\n")
         p = ArraySymbol("p")
-        energy = component_class(p)
-        _append_to_docstring(
-            component_class,
-            f"""\n
-            :math:`{sp.latex(energy)}={sp.latex(energy.doit())}`
-            """,
-        )
+        expr = component_class(p)
+        _append_latex_doit_definition(expr, inline=True)
 
     _extend(Energy)
     _extend(FourMomentumX)
@@ -296,7 +292,8 @@ def extend_ThreeMomentumNorm() -> None:
 
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
-    _append_latex_doit_definition(expr, deep=False)
+    _append_to_docstring(type(expr), "\n\n" + 4 * " ")
+    _append_latex_doit_definition(expr, deep=False, inline=True)
 
 
 def extend_formulate_clebsch_gordan_coefficients() -> None:
@@ -431,7 +428,7 @@ def _append_code_rendering(expr: sp.Expr) -> None:
     import_statements = __print_imports(printer)
     _append_to_docstring(
         type(expr),
-        f"""
+        f"""\n
     .. code::
 
         {import_statements}
@@ -441,8 +438,16 @@ def _append_code_rendering(expr: sp.Expr) -> None:
 
 
 def _append_latex_doit_definition(
-    expr: sp.Expr, deep: bool = False, full_width: bool = False
+    expr: sp.Expr,
+    deep: bool = False,
+    full_width: bool = False,
+    inline: bool = False,
 ) -> None:
+    if inline:
+        return _append_to_docstring(
+            type(expr),
+            f":math:`{sp.latex(expr)}={sp.latex(expr.doit(deep=deep))}`",
+        )
     latex = _create_latex_doit_definition(expr, deep)
     extras = ""
     if full_width:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -499,17 +499,15 @@ def __print_imports(printer: NumPyPrinter) -> str:
     return code
 
 
-SCRIPT_NAME = __file__.rsplit("/", maxsplit=1)[-1]
-SCRIPT_NAME = ".".join(SCRIPT_NAME.split(".")[:-1])
-
-
 def extend_docstrings() -> None:
+    script_name = __file__.rsplit("/", maxsplit=1)[-1]
+    script_name = ".".join(script_name.split(".")[:-1])
     definitions = dict(globals())
     for name, definition in definitions.items():
         module = inspect.getmodule(definition)
         if module is None:
             continue
-        if module.__name__ not in {"__main__", SCRIPT_NAME}:
+        if module.__name__ not in {"__main__", script_name}:
             continue
         if not inspect.isfunction(definition):
             continue

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -54,7 +54,7 @@ from ampform.sympy.math import ComplexSqrt
 logging.getLogger().setLevel(logging.ERROR)
 
 
-def render_blatt_weisskopf() -> None:
+def extend_blatt_weisskopf() -> None:
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
     expr = BlattWeisskopfSquared(L, z)
@@ -71,7 +71,7 @@ def render_blatt_weisskopf() -> None:
     )
 
 
-def render_boost_z() -> None:
+def extend_boost_z() -> None:
     beta = sp.Symbol("beta")
     expr = BoostZ(beta)
     _update_docstring(
@@ -103,7 +103,7 @@ def render_boost_z() -> None:
     )
 
 
-def render_breakup_momentum_squared() -> None:
+def extend_breakup_momentum_squared() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = BreakupMomentumSquared(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr, deep=True)
@@ -118,7 +118,7 @@ def render_breakup_momentum_squared() -> None:
     )
 
 
-def render_complex_sqrt() -> None:
+def extend_complex_sqrt() -> None:
     x = sp.Symbol("x", real=True)
     expr = ComplexSqrt(x)
     _update_docstring(
@@ -130,7 +130,7 @@ def render_complex_sqrt() -> None:
     )
 
 
-def render_energy_dependent_width() -> None:
+def extend_energy_dependent_width() -> None:
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b = sp.symbols("s m0 Gamma0 m_a m_b")
     expr = EnergyDependentWidth(
@@ -161,14 +161,14 @@ def render_energy_dependent_width() -> None:
     )
 
 
-def render_formulate_wigner_d() -> None:
+def extend_formulate_wigner_d() -> None:
     _update_docstring(
         formulate_wigner_d,
         __get_graphviz_state_transition_example("helicity"),
     )
 
 
-def render_formulate_clebsch_gordan_coefficients() -> None:
+def extend_formulate_clebsch_gordan_coefficients() -> None:
     _update_docstring(
         formulate_clebsch_gordan_coefficients,
         __get_graphviz_state_transition_example(
@@ -206,8 +206,8 @@ def __get_graphviz_state_transition_example(
     return _graphviz_to_image(dot, indent=4, options={"align": "center"})
 
 
-def render_four_momentum_components() -> None:
-    def _render(component_class: Type[sp.Expr]) -> None:
+def extend_four_momentum_components() -> None:
+    def _extend(component_class: Type[sp.Expr]) -> None:
         p = ArraySymbol("p")
         energy = component_class(p)
         _update_docstring(
@@ -217,13 +217,13 @@ def render_four_momentum_components() -> None:
             """,
         )
 
-    _render(Energy)
-    _render(FourMomentumX)
-    _render(FourMomentumY)
-    _render(FourMomentumZ)
+    _extend(Energy)
+    _extend(FourMomentumX)
+    _extend(FourMomentumY)
+    _extend(FourMomentumZ)
 
 
-def render_get_helicity_angle_label() -> None:
+def extend_get_helicity_angle_label() -> None:
     topologies = qrules.topology.create_isobar_topologies(5)
     dot0, dot1, *_ = tuple(
         map(lambda t: qrules.io.asdot(t, render_resonance_id=True), topologies)
@@ -254,7 +254,7 @@ def render_get_helicity_angle_label() -> None:
     )
 
 
-def render_invariant_mass() -> None:
+def extend_invariant_mass() -> None:
     p = ArraySymbol("p")
     expr = InvariantMass(p)
     latex = _create_latex_doit_definition(expr)
@@ -269,7 +269,7 @@ def render_invariant_mass() -> None:
     )
 
 
-def render_phase_space_factor() -> None:
+def extend_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
@@ -287,7 +287,7 @@ def render_phase_space_factor() -> None:
     )
 
 
-def render_phase_space_factor_abs() -> None:
+def extend_phase_space_factor_abs() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
@@ -305,7 +305,7 @@ def render_phase_space_factor_abs() -> None:
     )
 
 
-def render_phase_space_factor_analytic() -> None:
+def extend_phase_space_factor_analytic() -> None:
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
     expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
@@ -324,7 +324,7 @@ def render_phase_space_factor_analytic() -> None:
     )
 
 
-def render_phase_space_factor_complex() -> None:
+def extend_phase_space_factor_complex() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
@@ -342,7 +342,7 @@ def render_phase_space_factor_complex() -> None:
     )
 
 
-def render_phi() -> None:
+def extend_phi() -> None:
     p = ArraySymbol("p")
     expr = Phi(p)
     latex = _create_latex_doit_definition(expr)
@@ -357,7 +357,7 @@ def render_phi() -> None:
     )
 
 
-def render_relativistic_breit_wigner() -> None:
+def extend_relativistic_breit_wigner() -> None:
     s, m0, w0 = sp.symbols("s m0 Gamma0")
     rel_bw = relativistic_breit_wigner(s, m0, w0)
     _update_docstring(
@@ -369,7 +369,7 @@ def render_relativistic_breit_wigner() -> None:
     )
 
 
-def render_relativistic_breit_wigner_with_ff() -> None:
+def extend_relativistic_breit_wigner_with_ff() -> None:
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d")
     rel_bw_with_ff = relativistic_breit_wigner_with_ff(
@@ -397,7 +397,7 @@ def render_relativistic_breit_wigner_with_ff() -> None:
     )
 
 
-def render_rotation_y() -> None:
+def extend_rotation_y() -> None:
     angle = sp.Symbol("alpha")
     expr = RotationY(angle)
     _update_docstring(
@@ -414,7 +414,7 @@ def render_rotation_y() -> None:
     )
 
 
-def render_rotation_z() -> None:
+def extend_rotation_z() -> None:
     angle = sp.Symbol("alpha")
     expr = RotationZ(angle)
     _update_docstring(
@@ -447,7 +447,7 @@ def render_rotation_z() -> None:
     )
 
 
-def render_theta() -> None:
+def extend_theta() -> None:
     p = ArraySymbol("p")
     expr = Theta(p)
     latex = _create_latex_doit_definition(expr)
@@ -462,7 +462,7 @@ def render_theta() -> None:
     )
 
 
-def render_three_momentum_norm() -> None:
+def extend_three_momentum_norm() -> None:
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
     latex = _create_latex_doit_definition(expr)
@@ -513,7 +513,7 @@ def insert_math() -> None:
             continue
         if not inspect.isfunction(definition):
             continue
-        if not name.startswith("render_"):
+        if not name.startswith("extend_"):
             continue
         function_arguments = inspect.signature(definition).parameters
         if len(function_arguments):

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -54,19 +54,12 @@ from ampform.sympy.math import ComplexSqrt
 logging.getLogger().setLevel(logging.ERROR)
 
 
-def update_docstring(
-    class_type: Union[Callable, Type], appended_text: str
-) -> None:
-    assert class_type.__doc__ is not None
-    class_type.__doc__ += appended_text
-
-
 def render_blatt_weisskopf() -> None:
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
     expr = BlattWeisskopfSquared(L, z)
     latex = _create_latex_doit_definition(expr, deep=True)
-    update_docstring(
+    _update_docstring(
         BlattWeisskopfSquared,
         f"""
     .. math::
@@ -81,7 +74,7 @@ def render_blatt_weisskopf() -> None:
 def render_boost_z() -> None:
     beta = sp.Symbol("beta")
     expr = BoostZ(beta)
-    update_docstring(
+    _update_docstring(
         BoostZ,
         f"""\n
     This boost operates on a `FourMomentumSymbol` and looks like:
@@ -94,7 +87,7 @@ def render_boost_z() -> None:
     printer = NumPyPrinter()
     numpy_code = BoostZ(b)._numpycode(printer)
     import_statements = __print_imports(printer)
-    update_docstring(
+    _update_docstring(
         BoostZ,
         f"""
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
@@ -114,7 +107,7 @@ def render_breakup_momentum_squared() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = BreakupMomentumSquared(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr, deep=True)
-    update_docstring(
+    _update_docstring(
         BreakupMomentumSquared,
         f"""
     .. math::
@@ -128,7 +121,7 @@ def render_breakup_momentum_squared() -> None:
 def render_complex_sqrt() -> None:
     x = sp.Symbol("x", real=True)
     expr = ComplexSqrt(x)
-    update_docstring(
+    _update_docstring(
         ComplexSqrt,
         fR"""
     .. math:: {sp.latex(expr)} = {sp.latex(expr.evaluate())}
@@ -150,7 +143,7 @@ def render_energy_dependent_width() -> None:
         meson_radius=1,
     )
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         EnergyDependentWidth,
         fR"""
     With that in mind, the "mass-dependent" width in a
@@ -169,14 +162,14 @@ def render_energy_dependent_width() -> None:
 
 
 def render_formulate_wigner_d() -> None:
-    update_docstring(
+    _update_docstring(
         formulate_wigner_d,
         __get_graphviz_state_transition_example("helicity"),
     )
 
 
 def render_formulate_clebsch_gordan_coefficients() -> None:
-    update_docstring(
+    _update_docstring(
         formulate_clebsch_gordan_coefficients,
         __get_graphviz_state_transition_example(
             formalism="canonical-helicity", transition_number=1
@@ -217,7 +210,7 @@ def render_four_momentum_components() -> None:
     def _render(component_class: Type[sp.Expr]) -> None:
         p = ArraySymbol("p")
         energy = component_class(p)
-        update_docstring(
+        _update_docstring(
             component_class,
             f"""\n
             :math:`{sp.latex(energy)}={sp.latex(energy.doit())}`
@@ -247,7 +240,7 @@ def render_get_helicity_angle_label() -> None:
         caption=":code:`topologies[1]`",
         label="one-to-five-topology-1",
     )
-    update_docstring(
+    _update_docstring(
         get_helicity_angle_label,
         f"""
 
@@ -265,7 +258,7 @@ def render_invariant_mass() -> None:
     p = ArraySymbol("p")
     expr = InvariantMass(p)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         InvariantMass,
         f"""\n
     .. math::
@@ -280,7 +273,7 @@ def render_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         PhaseSpaceFactor,
         f"""
 
@@ -298,7 +291,7 @@ def render_phase_space_factor_abs() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         PhaseSpaceFactorAbs,
         fR"""
 
@@ -317,7 +310,7 @@ def render_phase_space_factor_analytic() -> None:
     expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
     rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
-    update_docstring(
+    _update_docstring(
         PhaseSpaceFactorAnalytic,
         fR"""
     .. math::
@@ -335,7 +328,7 @@ def render_phase_space_factor_complex() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         PhaseSpaceFactorComplex,
         fR"""
 
@@ -353,7 +346,7 @@ def render_phi() -> None:
     p = ArraySymbol("p")
     expr = Phi(p)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         Phi,
         f"""\n
     .. math::
@@ -367,7 +360,7 @@ def render_phi() -> None:
 def render_relativistic_breit_wigner() -> None:
     s, m0, w0 = sp.symbols("s m0 Gamma0")
     rel_bw = relativistic_breit_wigner(s, m0, w0)
-    update_docstring(
+    _update_docstring(
         relativistic_breit_wigner,
         f"""
     .. math:: {sp.latex(rel_bw)}
@@ -388,7 +381,7 @@ def render_relativistic_breit_wigner_with_ff() -> None:
         angular_momentum=L,
         meson_radius=d,
     )
-    update_docstring(
+    _update_docstring(
         relativistic_breit_wigner_with_ff,
         fR"""
     The general form of a relativistic Breit-Wigner with Blatt-Weisskopf form
@@ -407,7 +400,7 @@ def render_relativistic_breit_wigner_with_ff() -> None:
 def render_rotation_y() -> None:
     angle = sp.Symbol("alpha")
     expr = RotationY(angle)
-    update_docstring(
+    _update_docstring(
         RotationY,
         f"""\n
     The **matrix** for a rotation over angle :math:`\\alpha` around the
@@ -424,7 +417,7 @@ def render_rotation_y() -> None:
 def render_rotation_z() -> None:
     angle = sp.Symbol("alpha")
     expr = RotationZ(angle)
-    update_docstring(
+    _update_docstring(
         RotationZ,
         f"""\n
     The **matrix** for a rotation over angle :math:`\\alpha` around the
@@ -438,7 +431,7 @@ def render_rotation_z() -> None:
     printer = NumPyPrinter()
     numpy_code = RotationZ(a)._numpycode(printer)
     import_statements = __print_imports(printer)
-    update_docstring(
+    _update_docstring(
         RotationZ,
         f"""
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
@@ -458,7 +451,7 @@ def render_theta() -> None:
     p = ArraySymbol("p")
     expr = Theta(p)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         Theta,
         f"""\n
     .. math::
@@ -473,7 +466,7 @@ def render_three_momentum_norm() -> None:
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
     latex = _create_latex_doit_definition(expr)
-    update_docstring(
+    _update_docstring(
         ThreeMomentumNorm,
         f"""\n
     .. math::
@@ -482,6 +475,13 @@ def render_three_momentum_norm() -> None:
         {latex}
     """,
     )
+
+
+def _update_docstring(
+    class_type: Union[Callable, Type], appended_text: str
+) -> None:
+    assert class_type.__doc__ is not None
+    class_type.__doc__ += appended_text
 
 
 def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -58,13 +58,16 @@ def update_docstring(
 def render_blatt_weisskopf() -> None:
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
-    ff2 = BlattWeisskopfSquared(L, z)
+    expr = BlattWeisskopfSquared(L, z)
+    latex = _create_latex_doit_definition(expr, deep=True)
     update_docstring(
         BlattWeisskopfSquared,
         f"""
-    .. math:: {sp.latex(ff2)} = {sp.latex(ff2.doit())}
+    .. math::
         :label: BlattWeisskopfSquared
         :class: full-width
+
+        {latex}
     """,
     )
 
@@ -103,11 +106,8 @@ def render_boost_z() -> None:
 
 def render_breakup_momentum_squared() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
-    q_squared = BreakupMomentumSquared(s, m_a, m_b)
-    latex = sp.multiline_latex(
-        q_squared, q_squared.doit(), environment="eqnarray"
-    )
-    latex = textwrap.indent(latex, prefix=8 * " ")
+    expr = BreakupMomentumSquared(s, m_a, m_b)
+    latex = _create_latex_doit_definition(expr, deep=True)
     update_docstring(
         BreakupMomentumSquared,
         f"""
@@ -121,11 +121,11 @@ def render_breakup_momentum_squared() -> None:
 
 def render_complex_sqrt() -> None:
     x = sp.Symbol("x", real=True)
-    complex_sqrt = ComplexSqrt(x)
+    expr = ComplexSqrt(x)
     update_docstring(
         ComplexSqrt,
         fR"""
-    .. math:: {sp.latex(complex_sqrt)} = {sp.latex(complex_sqrt.evaluate())}
+    .. math:: {sp.latex(expr)} = {sp.latex(expr.evaluate())}
         :label: ComplexSqrt
     """,
     )
@@ -134,7 +134,7 @@ def render_complex_sqrt() -> None:
 def render_energy_dependent_width() -> None:
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b = sp.symbols("s m0 Gamma0 m_a m_b")
-    width = EnergyDependentWidth(
+    expr = EnergyDependentWidth(
         s=s,
         mass0=m0,
         gamma0=w0,
@@ -143,8 +143,7 @@ def render_energy_dependent_width() -> None:
         angular_momentum=L,
         meson_radius=1,
     )
-    latex = sp.multiline_latex(width, width.evaluate(), environment="eqnarray")
-    latex = textwrap.indent(latex, prefix=8 * " ")
+    latex = _create_latex_doit_definition(expr)
     update_docstring(
         EnergyDependentWidth,
         fR"""
@@ -258,9 +257,8 @@ def render_get_helicity_angle_label() -> None:
 
 def render_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
-    rho = PhaseSpaceFactor(s, m_a, m_b)
-    latex = sp.multiline_latex(rho, rho.evaluate(), environment="eqnarray")
-    latex = textwrap.indent(latex, prefix=8 * " ")
+    expr = PhaseSpaceFactor(s, m_a, m_b)
+    latex = _create_latex_doit_definition(expr)
     update_docstring(
         PhaseSpaceFactor,
         f"""
@@ -277,9 +275,8 @@ def render_phase_space_factor() -> None:
 
 def render_phase_space_factor_abs() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
-    rho = PhaseSpaceFactorAbs(s, m_a, m_b)
-    latex = sp.multiline_latex(rho, rho.evaluate(), environment="eqnarray")
-    latex = textwrap.indent(latex, prefix=8 * " ")
+    expr = PhaseSpaceFactorAbs(s, m_a, m_b)
+    latex = _create_latex_doit_definition(expr)
     update_docstring(
         PhaseSpaceFactorAbs,
         fR"""
@@ -296,10 +293,9 @@ def render_phase_space_factor_abs() -> None:
 
 def render_phase_space_factor_analytic() -> None:
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
-    rho = PhaseSpaceFactorAnalytic(s, m_a, m_b)
+    expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
+    latex = _create_latex_doit_definition(expr)
     rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
-    latex = sp.multiline_latex(rho, rho.evaluate(), environment="eqnarray")
-    latex = textwrap.indent(latex, prefix=8 * " ")
     update_docstring(
         PhaseSpaceFactorAnalytic,
         fR"""
@@ -316,9 +312,8 @@ def render_phase_space_factor_analytic() -> None:
 
 def render_phase_space_factor_complex() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
-    rho = PhaseSpaceFactorComplex(s, m_a, m_b)
-    latex = sp.multiline_latex(rho, rho.evaluate(), environment="eqnarray")
-    latex = textwrap.indent(latex, prefix=8 * " ")
+    expr = PhaseSpaceFactorComplex(s, m_a, m_b)
+    latex = _create_latex_doit_definition(expr)
     update_docstring(
         PhaseSpaceFactorComplex,
         fR"""
@@ -371,6 +366,13 @@ def render_relativistic_breit_wigner_with_ff() -> None:
     :eq:`BreakupMomentumSquared`.
     """,
     )
+
+
+def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:
+    latex = sp.multiline_latex(
+        expr, expr.doit(deep=deep), environment="eqnarray"
+    )
+    return textwrap.indent(latex, prefix=8 * " ")
 
 
 def __print_imports(printer: NumPyPrinter) -> str:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# pylint: disable=import-error,invalid-name,protected-access
+# pylint: disable=import-error,import-outside-toplevel,invalid-name,protected-access
 # pyright: reportMissingImports=false
 """Extend docstrings of the API.
 
@@ -19,42 +19,14 @@ import qrules
 import sympy as sp
 from sympy.printing.numpy import NumPyPrinter
 
-from ampform.dynamics import (
-    BlattWeisskopfSquared,
-    BreakupMomentumSquared,
-    EnergyDependentWidth,
-    PhaseSpaceFactor,
-    PhaseSpaceFactorAbs,
-    PhaseSpaceFactorAnalytic,
-    PhaseSpaceFactorComplex,
-    relativistic_breit_wigner,
-    relativistic_breit_wigner_with_ff,
-)
-from ampform.helicity import (
-    formulate_clebsch_gordan_coefficients,
-    formulate_wigner_d,
-)
-from ampform.kinematics import (
-    BoostZ,
-    Energy,
-    FourMomentumX,
-    FourMomentumY,
-    FourMomentumZ,
-    InvariantMass,
-    Phi,
-    RotationY,
-    RotationZ,
-    Theta,
-    ThreeMomentumNorm,
-    get_helicity_angle_label,
-)
 from ampform.sympy._array_expressions import ArraySymbol
-from ampform.sympy.math import ComplexSqrt
 
 logging.getLogger().setLevel(logging.ERROR)
 
 
 def extend_blatt_weisskopf() -> None:
+    from ampform.dynamics import BlattWeisskopfSquared
+
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
     expr = BlattWeisskopfSquared(L, z)
@@ -62,6 +34,8 @@ def extend_blatt_weisskopf() -> None:
 
 
 def extend_boost_z() -> None:
+    from ampform.kinematics import BoostZ
+
     beta = sp.Symbol("beta")
     expr = BoostZ(beta)
     _update_docstring(
@@ -94,12 +68,16 @@ def extend_boost_z() -> None:
 
 
 def extend_breakup_momentum_squared() -> None:
+    from ampform.dynamics import BreakupMomentumSquared
+
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = BreakupMomentumSquared(s, m_a, m_b)
     _append_latex_doit_definition(expr, deep=True)
 
 
 def extend_complex_sqrt() -> None:
+    from ampform.sympy.math import ComplexSqrt
+
     x = sp.Symbol("x", real=True)
     expr = ComplexSqrt(x)
     _update_docstring(
@@ -112,6 +90,8 @@ def extend_complex_sqrt() -> None:
 
 
 def extend_energy_dependent_width() -> None:
+    from ampform.dynamics import EnergyDependentWidth
+
     _update_docstring(
         EnergyDependentWidth,
         """
@@ -142,6 +122,8 @@ def extend_energy_dependent_width() -> None:
 
 
 def extend_formulate_wigner_d() -> None:
+    from ampform.helicity import formulate_wigner_d
+
     _update_docstring(
         formulate_wigner_d,
         __get_graphviz_state_transition_example("helicity"),
@@ -149,6 +131,8 @@ def extend_formulate_wigner_d() -> None:
 
 
 def extend_formulate_clebsch_gordan_coefficients() -> None:
+    from ampform.helicity import formulate_clebsch_gordan_coefficients
+
     _update_docstring(
         formulate_clebsch_gordan_coefficients,
         __get_graphviz_state_transition_example(
@@ -187,6 +171,13 @@ def __get_graphviz_state_transition_example(
 
 
 def extend_four_momentum_components() -> None:
+    from ampform.kinematics import (
+        Energy,
+        FourMomentumX,
+        FourMomentumY,
+        FourMomentumZ,
+    )
+
     def _extend(component_class: Type[sp.Expr]) -> None:
         p = ArraySymbol("p")
         energy = component_class(p)
@@ -204,6 +195,8 @@ def extend_four_momentum_components() -> None:
 
 
 def extend_get_helicity_angle_label() -> None:
+    from ampform.kinematics import get_helicity_angle_label
+
     topologies = qrules.topology.create_isobar_topologies(5)
     dot0, dot1, *_ = tuple(
         map(lambda t: qrules.io.asdot(t, render_resonance_id=True), topologies)
@@ -235,12 +228,16 @@ def extend_get_helicity_angle_label() -> None:
 
 
 def extend_invariant_mass() -> None:
+    from ampform.kinematics import InvariantMass
+
     p = ArraySymbol("p")
     expr = InvariantMass(p)
     _append_latex_doit_definition(expr)
 
 
 def extend_phase_space_factor() -> None:
+    from ampform.dynamics import PhaseSpaceFactor
+
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
     _append_latex_doit_definition(expr)
@@ -253,6 +250,8 @@ def extend_phase_space_factor() -> None:
 
 
 def extend_phase_space_factor_abs() -> None:
+    from ampform.dynamics import PhaseSpaceFactorAbs
+
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
     _append_latex_doit_definition(expr)
@@ -265,6 +264,8 @@ def extend_phase_space_factor_abs() -> None:
 
 
 def extend_phase_space_factor_analytic() -> None:
+    from ampform.dynamics import PhaseSpaceFactorAbs, PhaseSpaceFactorAnalytic
+
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
     expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
     _append_latex_doit_definition(expr)
@@ -279,6 +280,8 @@ def extend_phase_space_factor_analytic() -> None:
 
 
 def extend_phase_space_factor_complex() -> None:
+    from ampform.dynamics import PhaseSpaceFactorComplex
+
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
     _append_latex_doit_definition(expr)
@@ -291,12 +294,16 @@ def extend_phase_space_factor_complex() -> None:
 
 
 def extend_phi() -> None:
+    from ampform.kinematics import Phi
+
     p = ArraySymbol("p")
     expr = Phi(p)
     _append_latex_doit_definition(expr)
 
 
 def extend_relativistic_breit_wigner() -> None:
+    from ampform.dynamics import relativistic_breit_wigner
+
     s, m0, w0 = sp.symbols("s m0 Gamma0")
     rel_bw = relativistic_breit_wigner(s, m0, w0)
     _update_docstring(
@@ -309,6 +316,8 @@ def extend_relativistic_breit_wigner() -> None:
 
 
 def extend_relativistic_breit_wigner_with_ff() -> None:
+    from ampform.dynamics import relativistic_breit_wigner_with_ff
+
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d")
     rel_bw_with_ff = relativistic_breit_wigner_with_ff(
@@ -337,6 +346,8 @@ def extend_relativistic_breit_wigner_with_ff() -> None:
 
 
 def extend_rotation_y() -> None:
+    from ampform.kinematics import RotationY
+
     angle = sp.Symbol("alpha")
     expr = RotationY(angle)
     _update_docstring(
@@ -354,6 +365,8 @@ def extend_rotation_y() -> None:
 
 
 def extend_rotation_z() -> None:
+    from ampform.kinematics import RotationZ
+
     angle = sp.Symbol("alpha")
     expr = RotationZ(angle)
     _update_docstring(
@@ -387,12 +400,16 @@ def extend_rotation_z() -> None:
 
 
 def extend_theta() -> None:
+    from ampform.kinematics import Theta
+
     p = ArraySymbol("p")
     expr = Theta(p)
     _append_latex_doit_definition(expr)
 
 
 def extend_three_momentum_norm() -> None:
+    from ampform.kinematics import ThreeMomentumNorm
+
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
     _append_latex_doit_definition(expr, deep=False)

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -294,6 +294,7 @@ def extend_ThreeMomentumNorm() -> None:
     expr = ThreeMomentumNorm(p)
     _append_to_docstring(type(expr), "\n\n" + 4 * " ")
     _append_latex_doit_definition(expr, deep=False, inline=True)
+    _append_code_rendering(expr)
 
 
 def extend_formulate_clebsch_gordan_coefficients() -> None:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -58,17 +58,7 @@ def extend_blatt_weisskopf() -> None:
     L = sp.Symbol("L", integer=True)
     z = sp.Symbol("z", real=True)
     expr = BlattWeisskopfSquared(L, z)
-    latex = _create_latex_doit_definition(expr, deep=True)
-    _update_docstring(
-        BlattWeisskopfSquared,
-        f"""
-    .. math::
-        :label: BlattWeisskopfSquared
-        :class: full-width
-
-        {latex}
-    """,
-    )
+    _append_latex_doit_definition(expr, deep=True, full_width=True)
 
 
 def extend_boost_z() -> None:
@@ -106,16 +96,7 @@ def extend_boost_z() -> None:
 def extend_breakup_momentum_squared() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = BreakupMomentumSquared(s, m_a, m_b)
-    latex = _create_latex_doit_definition(expr, deep=True)
-    _update_docstring(
-        BreakupMomentumSquared,
-        f"""
-    .. math::
-        :label: BreakupMomentumSquared
-
-        {latex}
-    """,
-    )
+    _append_latex_doit_definition(expr, deep=True)
 
 
 def extend_complex_sqrt() -> None:
@@ -131,6 +112,13 @@ def extend_complex_sqrt() -> None:
 
 
 def extend_energy_dependent_width() -> None:
+    _update_docstring(
+        EnergyDependentWidth,
+        """
+    With that in mind, the "mass-dependent" width in a
+    `.relativistic_breit_wigner_with_ff` becomes:
+    """,
+    )
     L = sp.Symbol("L", integer=True)
     s, m0, w0, m_a, m_b = sp.symbols("s m0 Gamma0 m_a m_b")
     expr = EnergyDependentWidth(
@@ -142,18 +130,10 @@ def extend_energy_dependent_width() -> None:
         angular_momentum=L,
         meson_radius=1,
     )
-    latex = _create_latex_doit_definition(expr)
+    _append_latex_doit_definition(expr)
     _update_docstring(
         EnergyDependentWidth,
-        fR"""
-    With that in mind, the "mass-dependent" width in a
-    `.relativistic_breit_wigner_with_ff` becomes:
-
-    .. math::
-        :label: EnergyDependentWidth
-
-        {latex}
-
+        R"""
     where :math:`B_L^2` is defined by :eq:`BlattWeisskopfSquared`, :math:`q` is
     defined by :eq:`BreakupMomentumSquared`, and :math:`\rho` is (by default)
     defined by :eq:`PhaseSpaceFactor`.
@@ -257,31 +237,16 @@ def extend_get_helicity_angle_label() -> None:
 def extend_invariant_mass() -> None:
     p = ArraySymbol("p")
     expr = InvariantMass(p)
-    latex = _create_latex_doit_definition(expr)
-    _update_docstring(
-        InvariantMass,
-        f"""\n
-    .. math::
-        :label: InvariantMass
-
-        {latex}
-    """,
-    )
+    _append_latex_doit_definition(expr)
 
 
 def extend_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
-    latex = _create_latex_doit_definition(expr)
+    _append_latex_doit_definition(expr)
     _update_docstring(
         PhaseSpaceFactor,
-        f"""
-
-    .. math::
-        :label: PhaseSpaceFactor
-
-        {latex}
-
+        """
     with :math:`q^2` defined as :eq:`BreakupMomentumSquared`.
     """,
     )
@@ -290,16 +255,10 @@ def extend_phase_space_factor() -> None:
 def extend_phase_space_factor_abs() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
-    latex = _create_latex_doit_definition(expr)
+    _append_latex_doit_definition(expr)
     _update_docstring(
         PhaseSpaceFactorAbs,
-        fR"""
-
-    .. math::
-        :label: PhaseSpaceFactorAbs
-
-        {latex}
-
+        """
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
     """,
     )
@@ -308,16 +267,11 @@ def extend_phase_space_factor_abs() -> None:
 def extend_phase_space_factor_analytic() -> None:
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
     expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
-    latex = _create_latex_doit_definition(expr)
+    _append_latex_doit_definition(expr)
     rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
     _update_docstring(
         PhaseSpaceFactorAnalytic,
-        fR"""
-    .. math::
-        :label: PhaseSpaceFactorAnalytic
-
-        {latex}
-
+        f"""
     with :math:`{sp.latex(rho_hat)}` defined by `.PhaseSpaceFactorAbs`
     :eq:`PhaseSpaceFactorAbs`.
     """,
@@ -327,16 +281,10 @@ def extend_phase_space_factor_analytic() -> None:
 def extend_phase_space_factor_complex() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
-    latex = _create_latex_doit_definition(expr)
+    _append_latex_doit_definition(expr)
     _update_docstring(
         PhaseSpaceFactorComplex,
-        fR"""
-
-    .. math::
-        :label: PhaseSpaceFactorComplex
-
-        {latex}
-
+        """
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
     """,
     )
@@ -345,16 +293,7 @@ def extend_phase_space_factor_complex() -> None:
 def extend_phi() -> None:
     p = ArraySymbol("p")
     expr = Phi(p)
-    latex = _create_latex_doit_definition(expr)
-    _update_docstring(
-        Phi,
-        f"""\n
-    .. math::
-        :label: Phi
-
-        {latex}
-    """,
-    )
+    _append_latex_doit_definition(expr)
 
 
 def extend_relativistic_breit_wigner() -> None:
@@ -450,38 +389,33 @@ def extend_rotation_z() -> None:
 def extend_theta() -> None:
     p = ArraySymbol("p")
     expr = Theta(p)
-    latex = _create_latex_doit_definition(expr)
-    _update_docstring(
-        Theta,
-        f"""\n
-    .. math::
-        :label: Theta
-
-        {latex}
-    """,
-    )
+    _append_latex_doit_definition(expr)
 
 
 def extend_three_momentum_norm() -> None:
     p = ArraySymbol("p")
     expr = ThreeMomentumNorm(p)
-    latex = _create_latex_doit_definition(expr)
-    _update_docstring(
-        ThreeMomentumNorm,
+    _append_latex_doit_definition(expr, deep=False)
+
+
+def _append_latex_doit_definition(
+    expr: sp.Expr, deep: bool = False, full_width: bool = False
+) -> None:
+    latex = _create_latex_doit_definition(expr, deep)
+    extras = ""
+    if full_width:
+        extras = """
+        :class: full-width
+        """
+    return _update_docstring(
+        type(expr),
         f"""\n
     .. math::
-        :label: ThreeMomentumNorm
+        :label: {type(expr).__name__}{extras}
 
         {latex}
     """,
     )
-
-
-def _update_docstring(
-    class_type: Union[Callable, Type], appended_text: str
-) -> None:
-    assert class_type.__doc__ is not None
-    class_type.__doc__ += appended_text
 
 
 def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:
@@ -489,6 +423,13 @@ def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:
         expr, expr.doit(deep=deep), environment="eqnarray"
     )
     return textwrap.indent(latex, prefix=8 * " ")
+
+
+def _update_docstring(
+    class_type: Union[Callable, Type], appended_text: str
+) -> None:
+    assert class_type.__doc__ is not None
+    class_type.__doc__ += appended_text
 
 
 def __print_imports(printer: NumPyPrinter) -> str:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -240,7 +240,7 @@ def extend_RotationY() -> None:
     _append_to_docstring(
         RotationY,
         f"""\n
-    The **matrix** for a rotation over angle :math:`\\alpha` around the
+    The matrix for a rotation over angle :math:`\\alpha` around the
     :math:`y`-axis operating on `FourMomentumSymbol` looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}
@@ -259,7 +259,7 @@ def extend_RotationZ() -> None:
     _append_to_docstring(
         RotationZ,
         f"""\n
-    The **matrix** for a rotation over angle :math:`\\alpha` around the
+    The matrix for a rotation over angle :math:`\\alpha` around the
     :math:`y`-axis operating on `FourMomentumSymbol` looks like:
 
     .. math:: {sp.latex(expr)} = {sp.latex(expr.as_explicit())}

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -62,7 +62,7 @@ def extend_boost_z() -> None:
 
     beta = sp.Symbol("beta")
     expr = BoostZ(beta)
-    _update_docstring(
+    _append_to_docstring(
         BoostZ,
         f"""\n
     This boost operates on a `FourMomentumSymbol` and looks like:
@@ -75,7 +75,7 @@ def extend_boost_z() -> None:
     printer = NumPyPrinter()
     numpy_code = BoostZ(b)._numpycode(printer)
     import_statements = __print_imports(printer)
-    _update_docstring(
+    _append_to_docstring(
         BoostZ,
         f"""
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
@@ -104,7 +104,7 @@ def extend_complex_sqrt() -> None:
 
     x = sp.Symbol("x", real=True)
     expr = ComplexSqrt(x)
-    _update_docstring(
+    _append_to_docstring(
         ComplexSqrt,
         fR"""
     .. math:: {sp.latex(expr)} = {sp.latex(expr.evaluate())}
@@ -116,7 +116,7 @@ def extend_complex_sqrt() -> None:
 def extend_energy_dependent_width() -> None:
     from ampform.dynamics import EnergyDependentWidth
 
-    _update_docstring(
+    _append_to_docstring(
         EnergyDependentWidth,
         """
     With that in mind, the "mass-dependent" width in a
@@ -135,7 +135,7 @@ def extend_energy_dependent_width() -> None:
         meson_radius=1,
     )
     _append_latex_doit_definition(expr)
-    _update_docstring(
+    _append_to_docstring(
         EnergyDependentWidth,
         R"""
     where :math:`B_L^2` is defined by :eq:`BlattWeisskopfSquared`, :math:`q` is
@@ -148,7 +148,7 @@ def extend_energy_dependent_width() -> None:
 def extend_formulate_wigner_d() -> None:
     from ampform.helicity import formulate_wigner_d
 
-    _update_docstring(
+    _append_to_docstring(
         formulate_wigner_d,
         __get_graphviz_state_transition_example("helicity"),
     )
@@ -157,7 +157,7 @@ def extend_formulate_wigner_d() -> None:
 def extend_formulate_clebsch_gordan_coefficients() -> None:
     from ampform.helicity import formulate_clebsch_gordan_coefficients
 
-    _update_docstring(
+    _append_to_docstring(
         formulate_clebsch_gordan_coefficients,
         __get_graphviz_state_transition_example(
             formalism="canonical-helicity", transition_number=1
@@ -205,7 +205,7 @@ def extend_four_momentum_components() -> None:
     def _extend(component_class: Type[sp.Expr]) -> None:
         p = ArraySymbol("p")
         energy = component_class(p)
-        _update_docstring(
+        _append_to_docstring(
             component_class,
             f"""\n
             :math:`{sp.latex(energy)}={sp.latex(energy.doit())}`
@@ -237,7 +237,7 @@ def extend_get_helicity_angle_label() -> None:
         caption=":code:`topologies[1]`",
         label="one-to-five-topology-1",
     )
-    _update_docstring(
+    _append_to_docstring(
         get_helicity_angle_label,
         f"""
 
@@ -265,7 +265,7 @@ def extend_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
     _append_latex_doit_definition(expr)
-    _update_docstring(
+    _append_to_docstring(
         PhaseSpaceFactor,
         """
     with :math:`q^2` defined as :eq:`BreakupMomentumSquared`.
@@ -279,7 +279,7 @@ def extend_phase_space_factor_abs() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
     _append_latex_doit_definition(expr)
-    _update_docstring(
+    _append_to_docstring(
         PhaseSpaceFactorAbs,
         """
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
@@ -294,7 +294,7 @@ def extend_phase_space_factor_analytic() -> None:
     expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
     _append_latex_doit_definition(expr)
     rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
-    _update_docstring(
+    _append_to_docstring(
         PhaseSpaceFactorAnalytic,
         f"""
     with :math:`{sp.latex(rho_hat)}` defined by `.PhaseSpaceFactorAbs`
@@ -309,7 +309,7 @@ def extend_phase_space_factor_complex() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
     _append_latex_doit_definition(expr)
-    _update_docstring(
+    _append_to_docstring(
         PhaseSpaceFactorComplex,
         """
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
@@ -330,7 +330,7 @@ def extend_relativistic_breit_wigner() -> None:
 
     s, m0, w0 = sp.symbols("s m0 Gamma0")
     rel_bw = relativistic_breit_wigner(s, m0, w0)
-    _update_docstring(
+    _append_to_docstring(
         relativistic_breit_wigner,
         f"""
     .. math:: {sp.latex(rel_bw)}
@@ -353,7 +353,7 @@ def extend_relativistic_breit_wigner_with_ff() -> None:
         angular_momentum=L,
         meson_radius=d,
     )
-    _update_docstring(
+    _append_to_docstring(
         relativistic_breit_wigner_with_ff,
         fR"""
     The general form of a relativistic Breit-Wigner with Blatt-Weisskopf form
@@ -374,7 +374,7 @@ def extend_rotation_y() -> None:
 
     angle = sp.Symbol("alpha")
     expr = RotationY(angle)
-    _update_docstring(
+    _append_to_docstring(
         RotationY,
         f"""\n
     The **matrix** for a rotation over angle :math:`\\alpha` around the
@@ -393,7 +393,7 @@ def extend_rotation_z() -> None:
 
     angle = sp.Symbol("alpha")
     expr = RotationZ(angle)
-    _update_docstring(
+    _append_to_docstring(
         RotationZ,
         f"""\n
     The **matrix** for a rotation over angle :math:`\\alpha` around the
@@ -407,7 +407,7 @@ def extend_rotation_z() -> None:
     printer = NumPyPrinter()
     numpy_code = RotationZ(a)._numpycode(printer)
     import_statements = __print_imports(printer)
-    _update_docstring(
+    _append_to_docstring(
         RotationZ,
         f"""
     In `TensorWaves <https://tensorwaves.rtfd.io>`_, this class is expressed in
@@ -448,7 +448,7 @@ def _append_latex_doit_definition(
         extras = """
         :class: full-width
         """
-    return _update_docstring(
+    return _append_to_docstring(
         type(expr),
         f"""\n
     .. math::
@@ -466,7 +466,7 @@ def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:
     return textwrap.indent(latex, prefix=8 * " ")
 
 
-def _update_docstring(
+def _append_to_docstring(
     class_type: Union[Callable, Type], appended_text: str
 ) -> None:
     assert class_type.__doc__ is not None

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -48,7 +48,7 @@ def extend_docstrings() -> None:
         definition()
 
 
-def extend_blatt_weisskopf() -> None:
+def extend_BlattWeisskopfSquared() -> None:
     from ampform.dynamics import BlattWeisskopfSquared
 
     L = sp.Symbol("L", integer=True)
@@ -57,7 +57,7 @@ def extend_blatt_weisskopf() -> None:
     _append_latex_doit_definition(expr, deep=True, full_width=True)
 
 
-def extend_boost_z() -> None:
+def extend_BoostZ() -> None:
     from ampform.kinematics import BoostZ
 
     beta = sp.Symbol("beta")
@@ -91,7 +91,7 @@ def extend_boost_z() -> None:
     )
 
 
-def extend_breakup_momentum_squared() -> None:
+def extend_BreakupMomentumSquared() -> None:
     from ampform.dynamics import BreakupMomentumSquared
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
@@ -99,7 +99,7 @@ def extend_breakup_momentum_squared() -> None:
     _append_latex_doit_definition(expr, deep=True)
 
 
-def extend_complex_sqrt() -> None:
+def extend_ComplexSqrt() -> None:
     from ampform.sympy.math import ComplexSqrt
 
     x = sp.Symbol("x", real=True)
@@ -113,7 +113,7 @@ def extend_complex_sqrt() -> None:
     )
 
 
-def extend_energy_dependent_width() -> None:
+def extend_EnergyDependentWidth() -> None:
     from ampform.dynamics import EnergyDependentWidth
 
     _append_to_docstring(
@@ -194,7 +194,7 @@ def __get_graphviz_state_transition_example(
     return _graphviz_to_image(dot, indent=4, options={"align": "center"})
 
 
-def extend_four_momentum_components() -> None:
+def extend_Energy_and_FourMomentumXYZ() -> None:
     from ampform.kinematics import (
         Energy,
         FourMomentumX,
@@ -251,7 +251,7 @@ def extend_get_helicity_angle_label() -> None:
     )
 
 
-def extend_invariant_mass() -> None:
+def extend_InvariantMass() -> None:
     from ampform.kinematics import InvariantMass
 
     p = ArraySymbol("p")
@@ -259,7 +259,7 @@ def extend_invariant_mass() -> None:
     _append_latex_doit_definition(expr)
 
 
-def extend_phase_space_factor() -> None:
+def extend_PhaseSpaceFactor() -> None:
     from ampform.dynamics import PhaseSpaceFactor
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
@@ -273,7 +273,7 @@ def extend_phase_space_factor() -> None:
     )
 
 
-def extend_phase_space_factor_abs() -> None:
+def extend_PhaseSpaceFactorAbs() -> None:
     from ampform.dynamics import PhaseSpaceFactorAbs
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
@@ -287,7 +287,7 @@ def extend_phase_space_factor_abs() -> None:
     )
 
 
-def extend_phase_space_factor_analytic() -> None:
+def extend_PhaseSpaceFactorAnalytic() -> None:
     from ampform.dynamics import PhaseSpaceFactorAbs, PhaseSpaceFactorAnalytic
 
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
@@ -303,7 +303,7 @@ def extend_phase_space_factor_analytic() -> None:
     )
 
 
-def extend_phase_space_factor_complex() -> None:
+def extend_PhaseSpaceFactorComplex() -> None:
     from ampform.dynamics import PhaseSpaceFactorComplex
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
@@ -317,7 +317,7 @@ def extend_phase_space_factor_complex() -> None:
     )
 
 
-def extend_phi() -> None:
+def extend_Phi() -> None:
     from ampform.kinematics import Phi
 
     p = ArraySymbol("p")
@@ -369,7 +369,7 @@ def extend_relativistic_breit_wigner_with_ff() -> None:
     )
 
 
-def extend_rotation_y() -> None:
+def extend_RotationY() -> None:
     from ampform.kinematics import RotationY
 
     angle = sp.Symbol("alpha")
@@ -388,7 +388,7 @@ def extend_rotation_y() -> None:
     )
 
 
-def extend_rotation_z() -> None:
+def extend_RotationZ() -> None:
     from ampform.kinematics import RotationZ
 
     angle = sp.Symbol("alpha")
@@ -423,7 +423,7 @@ def extend_rotation_z() -> None:
     )
 
 
-def extend_theta() -> None:
+def extend_Theta() -> None:
     from ampform.kinematics import Theta
 
     p = ArraySymbol("p")
@@ -431,7 +431,7 @@ def extend_theta() -> None:
     _append_latex_doit_definition(expr)
 
 
-def extend_three_momentum_norm() -> None:
+def extend_ThreeMomentumNorm() -> None:
     from ampform.kinematics import ThreeMomentumNorm
 
     p = ArraySymbol("p")

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -40,8 +40,12 @@ from ampform.kinematics import (
     FourMomentumX,
     FourMomentumY,
     FourMomentumZ,
+    InvariantMass,
+    Phi,
     RotationY,
     RotationZ,
+    Theta,
+    ThreeMomentumNorm,
     get_helicity_angle_label,
 )
 from ampform.sympy._array_expressions import ArraySymbol
@@ -257,6 +261,21 @@ def render_get_helicity_angle_label() -> None:
     )
 
 
+def render_invariant_mass() -> None:
+    p = ArraySymbol("p")
+    expr = InvariantMass(p)
+    latex = _create_latex_doit_definition(expr)
+    update_docstring(
+        InvariantMass,
+        f"""\n
+    .. math::
+        :label: InvariantMass
+
+        {latex}
+    """,
+    )
+
+
 def render_phase_space_factor() -> None:
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
@@ -326,6 +345,21 @@ def render_phase_space_factor_complex() -> None:
         {latex}
 
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
+    """,
+    )
+
+
+def render_phi() -> None:
+    p = ArraySymbol("p")
+    expr = Phi(p)
+    latex = _create_latex_doit_definition(expr)
+    update_docstring(
+        Phi,
+        f"""\n
+    .. math::
+        :label: Phi
+
+        {latex}
     """,
     )
 
@@ -416,6 +450,36 @@ def render_rotation_z() -> None:
 
         {import_statements}
         {numpy_code}
+    """,
+    )
+
+
+def render_theta() -> None:
+    p = ArraySymbol("p")
+    expr = Theta(p)
+    latex = _create_latex_doit_definition(expr)
+    update_docstring(
+        Theta,
+        f"""\n
+    .. math::
+        :label: Theta
+
+        {latex}
+    """,
+    )
+
+
+def render_three_momentum_norm() -> None:
+    p = ArraySymbol("p")
+    expr = ThreeMomentumNorm(p)
+    latex = _create_latex_doit_definition(expr)
+    update_docstring(
+        ThreeMomentumNorm,
+        f"""\n
+    .. math::
+        :label: ThreeMomentumNorm
+
+        {latex}
     """,
     )
 

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -24,6 +24,8 @@ __REF_TYPE_SUBSTITUTIONS = {
     "None": "obj",
     "ParameterValue": "obj",
     "ampform.dynamics.builder.BuilderReturnType": "obj",
+    "ampform.kinematics.FourMomenta": "obj",
+    "ampform.kinematics.FourMomentumSymbol": "obj",
     "ampform.sympy.DecoratedClass": "obj",
     "symplot.RangeDefinition": "obj",
     "symplot.Slider": "obj",

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -24,6 +24,7 @@ __REF_TYPE_SUBSTITUTIONS = {
     "None": "obj",
     "ParameterValue": "obj",
     "ampform.dynamics.builder.BuilderReturnType": "obj",
+    "ampform.sympy.DecoratedClass": "obj",
     "symplot.RangeDefinition": "obj",
     "symplot.Slider": "obj",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ autodoc_default_options = {
             "doit",
             "evaluate",
             "is_commutative",
+            "precedence",
         ]
     ),
     "members": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,6 +137,7 @@ add_module_names = False
 autodoc_default_options = {
     "exclude-members": ", ".join(
         [
+            "as_explicit",
             "default_assumptions",
             "doit",
             "evaluate",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,8 @@ autodoc_default_options = {
 }
 autodoc_type_aliases = {
     "BuilderReturnType": "ampform.dynamics.builder.BuilderReturnType",
+    "FourMomenta": "ampform.kinematics.FourMomenta",
+    "FourMomentumSymbol": "ampform.kinematics.FourMomentumSymbol",
     "ParameterValue": "ampform.helicity.ParameterValue",
     "RangeDefinition": "symplot.RangeDefinition",
     "Slider": "symplot.Slider",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,6 +156,7 @@ autodoc_default_options = {
         ]
     ),
 }
+autodoc_member_order = "bysource"
 autodoc_type_aliases = {
     "BuilderReturnType": "ampform.dynamics.builder.BuilderReturnType",
     "FourMomenta": "ampform.kinematics.FourMomenta",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,11 +72,11 @@ if os.path.exists(LOGO_PATH):
 
 # -- Generate API ------------------------------------------------------------
 sys.path.insert(0, os.path.abspath("."))
-from _extend_docstrings import insert_math  # noqa: E402
+from _extend_docstrings import extend_docstrings  # noqa: E402
 from _relink_references import relink_references  # noqa: E402
 
+extend_docstrings()
 relink_references()
-insert_math()
 
 shutil.rmtree("api", ignore_errors=True)
 subprocess.call(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ autodoc_default_options = {
             "doit",
             "evaluate",
             "is_commutative",
+            "is_extended_real",
             "precedence",
         ]
     ),

--- a/docs/usage/formalism.ipynb
+++ b/docs/usage/formalism.ipynb
@@ -319,6 +319,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "See {func}`.formulate_wigner_d` and {func}`.formulate_clebsch_gordan_coefficients` for how these Wigner-$D$ functions and Clebsch-Gordan coefficients are computed for each node on a {class}`~qrules.transition.StateTransition`.\n",
+    "\n",
     "We can see this also from the original {class}`~qrules.transition.ReactionInfo` objects. Let's select only the {attr}`~qrules.transition.ReactionInfo.transitions` where the $a_1(1260)^+$ resonance has spin projection $-1$ (taken to be helicity $-1$ in the helicity formalism). We then see just one {class}`~qrules.transition.StateTransition` in the helicity basis and three transitions in the canonical basis:"
    ]
   },

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -308,7 +308,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
     def __formulate_sequential_decay(
         self, transition: StateTransition
     ) -> sp.Expr:
-        partial_decays: List[sp.Symbol] = [
+        partial_decays: List[sp.Expr] = [
             self._formulate_partial_decay(transition, node_id)
             for node_id in transition.topology.nodes
         ]

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -649,12 +649,6 @@ class RotationZ(sp.Expr):
         ).transpose((2, 0, 1))"""
 
 
-class HasMomentum:
-    @property
-    def momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]  # type: ignore[attr-defined]
-
-
 def _implement_latex_subscript(
     subscript: str,
 ) -> Callable[[Type[UnevaluatedExpression]], Type[UnevaluatedExpression]]:
@@ -662,9 +656,7 @@ def _implement_latex_subscript(
         decorated_class: Type[UnevaluatedExpression],
     ) -> Type[UnevaluatedExpression]:
         @functools.wraps(decorated_class.doit)
-        def _latex(
-            self: HasMomentum, printer: LatexPrinter, *args: Any
-        ) -> str:
+        def _latex(self: sp.Expr, printer: LatexPrinter, *args: Any) -> str:
             momentum = printer._print(self.momentum)
             if printer._needs_mul_brackets(self.momentum):
                 momentum = fR"\left({momentum}\right)"
@@ -680,11 +672,15 @@ def _implement_latex_subscript(
 
 @implement_doit_method
 @make_commutative
-class Energy(HasMomentum, UnevaluatedExpression):
+class Energy(UnevaluatedExpression):
     """Represents the energy-component of a `FourMomentumSymbol`."""
 
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         return ArraySlice(self.momentum, (slice(None), 0))
@@ -697,13 +693,17 @@ class Energy(HasMomentum, UnevaluatedExpression):
 @_implement_latex_subscript(subscript="x")
 @implement_doit_method
 @make_commutative
-class FourMomentumX(HasMomentum, UnevaluatedExpression):
+class FourMomentumX(UnevaluatedExpression):
     """Component :math:`x` of a `FourMomentumSymbol`."""
 
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "FourMomentumX":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         return ArraySlice(self.momentum, (slice(None), 1))
@@ -712,13 +712,17 @@ class FourMomentumX(HasMomentum, UnevaluatedExpression):
 @_implement_latex_subscript(subscript="y")
 @implement_doit_method
 @make_commutative
-class FourMomentumY(HasMomentum, UnevaluatedExpression):
+class FourMomentumY(UnevaluatedExpression):
     """Component :math:`y` of a `FourMomentumSymbol`."""
 
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "FourMomentumY":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         return ArraySlice(self.momentum, (slice(None), 2))
@@ -727,7 +731,7 @@ class FourMomentumY(HasMomentum, UnevaluatedExpression):
 @_implement_latex_subscript(subscript="z")
 @implement_doit_method
 @make_commutative
-class FourMomentumZ(HasMomentum, UnevaluatedExpression):
+class FourMomentumZ(UnevaluatedExpression):
     """Component :math:`z` of a `FourMomentumSymbol`."""
 
     def __new__(
@@ -735,19 +739,27 @@ class FourMomentumZ(HasMomentum, UnevaluatedExpression):
     ) -> "FourMomentumZ":
         return create_expression(cls, momentum, **hints)
 
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
     def evaluate(self) -> ArraySlice:
         return ArraySlice(self.momentum, (slice(None), 3))
 
 
 @implement_doit_method
 @make_commutative
-class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
+class ThreeMomentumNorm(UnevaluatedExpression):
     """Norm of the three-momentum of a `FourMomentumSymbol`."""
 
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "ThreeMomentumNorm":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         three_momentum = ArraySlice(
@@ -766,11 +778,15 @@ class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
 
 @implement_doit_method
 @make_commutative
-class InvariantMass(HasMomentum, UnevaluatedExpression):
+class InvariantMass(UnevaluatedExpression):
     """Invariant mass of a `FourMomentumSymbol`."""
 
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         p = self.momentum
@@ -783,11 +799,15 @@ class InvariantMass(HasMomentum, UnevaluatedExpression):
 
 @implement_doit_method
 @make_commutative
-class Phi(HasMomentum, UnevaluatedExpression):
+class Phi(UnevaluatedExpression):
     r"""Azimuthal angle :math:`\phi` of a `FourMomentumSymbol`."""
 
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Phi":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> sp.Expr:
         p = self.momentum
@@ -800,11 +820,15 @@ class Phi(HasMomentum, UnevaluatedExpression):
 
 @implement_doit_method
 @make_commutative
-class Theta(HasMomentum, UnevaluatedExpression):
+class Theta(UnevaluatedExpression):
     r"""Polar (elevation) angle :math:`\theta` of a `FourMomentumSymbol`."""
 
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Theta":
         return create_expression(cls, momentum, **hints)
+
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
 
     def evaluate(self) -> sp.Expr:
         p = self.momentum

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -514,11 +514,14 @@ class _ArrayMultiplication(sp.Expr):
 
 
 class BoostZ(sp.Expr):
+    """Represents a Lorentz boost **matrix** in the :math:`z`-direction."""
+
     def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZ":
         return create_expression(cls, beta, **kwargs)
 
     @property
     def beta(self) -> sp.Expr:
+        r"""Velocity in the :math:`z`-direction, :math:`\beta=p_z/E`."""
         return self.args[0]
 
     def as_explicit(self) -> sp.Expr:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -41,7 +41,7 @@ FourMomentumSymbols = Dict[int, ArraySymbol]
 
 
 # for numpy broadcasting
-ArraySlice = make_commutative()(ArraySlice)  # type: ignore[misc]
+ArraySlice = make_commutative(ArraySlice)  # type: ignore[misc]
 
 
 @attr.s(on_setattr=attr.setters.frozen)
@@ -410,7 +410,7 @@ def _strip_subscript_superscript(symbol: sp.Symbol) -> str:
     return name
 
 
-@make_commutative()
+@make_commutative
 class ArrayAxisSum(sp.Expr):
     array: ArraySymbol = property(lambda self: self.args[0])
     axis: Optional[int] = property(lambda self: self.args[1])  # type: ignore[assignment]
@@ -616,7 +616,7 @@ def implement_latex_subscript(
 
 
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class Energy(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
@@ -631,7 +631,7 @@ class Energy(HasMomentum, UnevaluatedExpression):
 
 @implement_latex_subscript(subscript="x")
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class FourMomentumX(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumX":
         return create_expression(cls, momentum, **hints)
@@ -642,7 +642,7 @@ class FourMomentumX(HasMomentum, UnevaluatedExpression):
 
 @implement_latex_subscript(subscript="y")
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class FourMomentumY(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumY":
         return create_expression(cls, momentum, **hints)
@@ -653,7 +653,7 @@ class FourMomentumY(HasMomentum, UnevaluatedExpression):
 
 @implement_latex_subscript(subscript="z")
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class FourMomentumZ(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumZ":
         return create_expression(cls, momentum, **hints)
@@ -663,7 +663,7 @@ class FourMomentumZ(HasMomentum, UnevaluatedExpression):
 
 
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
     def __new__(
         cls, momentum: ArraySymbol, **hints: Any
@@ -686,7 +686,7 @@ class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
 
 
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class InvariantMass(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
@@ -701,7 +701,7 @@ class InvariantMass(HasMomentum, UnevaluatedExpression):
 
 
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class Phi(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Phi":
         return create_expression(cls, momentum, **hints)
@@ -716,7 +716,7 @@ class Phi(HasMomentum, UnevaluatedExpression):
 
 
 @implement_doit_method
-@make_commutative()
+@make_commutative
 class Theta(HasMomentum, UnevaluatedExpression):
     def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Theta":
         return create_expression(cls, momentum, **hints)

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -51,7 +51,8 @@ r"""Array-`~sympy.core.symbol.Symbol` that represents an array of four-momenta.
 
 The array is assumed to be of shape :math:`n\times 4` with :math:`n` the number
 of events. The four-momenta are assumed to be in the order
-:math:`\left(E,\vec{p}\right)`.
+:math:`\left(E,\vec{p}\right)`. See also `Energy`, `FourMomentumX`,
+`FourMomentumY`, and `FourMomentumZ`.
 """
 FourMomenta = Dict[int, "FourMomentumSymbol"]
 """A mapping of state IDs to their corresponding `FourMomentumSymbol`."""
@@ -268,6 +269,23 @@ def get_invariant_mass_label(topology: Topology, state_id: int) -> str:
 def compute_helicity_angles(
     four_momenta: "FourMomenta", topology: Topology
 ) -> Dict[str, sp.Expr]:
+    """Formulate expressions for all helicity angles in a topology.
+
+    Formulate expressions (`~sympy.core.expr.Expr`) for all helicity angles
+    appearing in a given `~qrules.topology.Topology`. The expressions are given
+    in terms of `FourMomenta` The expressions returned as values in a
+    `dict`, where the keys are defined by :func:`get_helicity_angle_label`.
+
+    Example
+    -------
+    >>> from qrules.topology import create_isobar_topologies
+    >>> topologies = create_isobar_topologies(3)
+    >>> topology = topologies[0]
+    >>> four_momenta = create_four_momentum_symbols(topology)
+    >>> angles = compute_helicity_angles(four_momenta, topology)
+    >>> angles["theta_1+2"]
+    Theta(p1 + p2)
+    """
     if topology.outgoing_edge_ids != set(four_momenta):
         raise ValueError(
             f"Momentum IDs {set(four_momenta)} do not match "
@@ -654,6 +672,8 @@ def _implement_latex_subscript(
 @implement_doit_method
 @make_commutative
 class Energy(HasMomentum, UnevaluatedExpression):
+    """Represents the energy-component of a `FourMomentumSymbol`."""
+
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
 
@@ -669,6 +689,8 @@ class Energy(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumX(HasMomentum, UnevaluatedExpression):
+    """Component :math:`x` of a `FourMomentumSymbol`."""
+
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "FourMomentumX":
@@ -682,6 +704,8 @@ class FourMomentumX(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumY(HasMomentum, UnevaluatedExpression):
+    """Component :math:`y` of a `FourMomentumSymbol`."""
+
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "FourMomentumY":
@@ -695,6 +719,8 @@ class FourMomentumY(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumZ(HasMomentum, UnevaluatedExpression):
+    """Component :math:`z` of a `FourMomentumSymbol`."""
+
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "FourMomentumZ":
@@ -793,6 +819,13 @@ def _assert_two_body_decay(topology: Topology, node_id: int) -> None:
 
 
 def create_four_momentum_symbols(topology: Topology) -> "FourMomenta":
+    """Create a set of array-symbols for a `~qrules.topology.Topology`.
+
+    >>> from qrules.topology import create_isobar_topologies
+    >>> topologies = create_isobar_topologies(3)
+    >>> create_four_momentum_symbols(topologies[0])
+    {0: p0, 1: p1, 2: p2}
+    """
     n_final_states = len(topology.outgoing_edge_ids)
     return {i: ArraySymbol(f"p{i}") for i in range(n_final_states)}
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -673,8 +673,8 @@ def _implement_latex_subscript(
     ) -> Type[UnevaluatedExpression]:
         @functools.wraps(decorated_class.doit)
         def _latex(self: sp.Expr, printer: LatexPrinter, *args: Any) -> str:
-            momentum = printer._print(self.momentum)
-            if printer._needs_mul_brackets(self.momentum):
+            momentum = printer._print(self._momentum)
+            if printer._needs_mul_brackets(self._momentum):
                 momentum = fR"\left({momentum}\right)"
             else:
                 momentum = fR"{{{momentum}}}"
@@ -695,14 +695,14 @@ class Energy(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
-        return ArraySlice(self.momentum, (slice(None), 0))
+        return ArraySlice(self._momentum, (slice(None), 0))
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self.momentum)
+        momentum = printer._print(self._momentum)
         return fR"E\left({momentum}\right)"
 
 
@@ -718,11 +718,11 @@ class FourMomentumX(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
-        return ArraySlice(self.momentum, (slice(None), 1))
+        return ArraySlice(self._momentum, (slice(None), 1))
 
 
 @_implement_latex_subscript(subscript="y")
@@ -737,11 +737,11 @@ class FourMomentumY(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
-        return ArraySlice(self.momentum, (slice(None), 2))
+        return ArraySlice(self._momentum, (slice(None), 2))
 
 
 @_implement_latex_subscript(subscript="z")
@@ -756,11 +756,11 @@ class FourMomentumZ(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
-        return ArraySlice(self.momentum, (slice(None), 3))
+        return ArraySlice(self._momentum, (slice(None), 3))
 
 
 @implement_doit_method
@@ -774,18 +774,18 @@ class ThreeMomentumNorm(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
         three_momentum = ArraySlice(
-            self.momentum, (slice(None), slice(1, None))
+            self._momentum, (slice(None), slice(1, None))
         )
         norm_squared = _ArrayAxisSum(three_momentum ** 2, axis=1)
         return sp.sqrt(norm_squared)
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self.momentum)
+        momentum = printer._print(self._momentum)
         return fR"\left|\vec{{{momentum}}}\right|"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
@@ -801,15 +801,15 @@ class InvariantMass(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> ArraySlice:
-        p = self.momentum
+        p = self._momentum
         return ComplexSqrt(Energy(p) ** 2 - ThreeMomentumNorm(p) ** 2)
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self.momentum)
+        momentum = printer._print(self._momentum)
         return f"m_{{{momentum}}}"
 
 
@@ -822,15 +822,15 @@ class Phi(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> sp.Expr:
-        p = self.momentum
+        p = self._momentum
         return sp.atan2(FourMomentumY(p), FourMomentumX(p))
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self.momentum)
+        momentum = printer._print(self._momentum)
         return fR"\phi\left({momentum}\right)"
 
 
@@ -843,15 +843,15 @@ class Theta(UnevaluatedExpression):
         return create_expression(cls, momentum, **hints)
 
     @property
-    def momentum(self) -> "FourMomentumSymbol":
+    def _momentum(self) -> "FourMomentumSymbol":
         return self.args[0]
 
     def evaluate(self) -> sp.Expr:
-        p = self.momentum
+        p = self._momentum
         return sp.acos(FourMomentumZ(p) / ThreeMomentumNorm(p))
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self.momentum)
+        momentum = printer._print(self._momentum)
         return fR"\theta\left({momentum}\right)"
 
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -1,5 +1,5 @@
 # cspell:ignore einsum
-# pylint: disable=arguments-differ,protected-access,unused-argument
+# pylint: disable=arguments-differ,no-member,protected-access,unused-argument
 """Kinematics of an amplitude model in the helicity formalism."""
 
 import functools
@@ -367,10 +367,13 @@ def compute_invariant_masses(
 
 class _ArraySum(sp.Expr):
     precedence = PRECEDENCE["Add"]
-    terms: Tuple[sp.Basic, ...] = property(lambda self: self.args)  # type: ignore[assignment]
 
     def __new__(cls, *terms: sp.Basic, **hints: Any) -> "Energy":
         return create_expression(cls, *terms, **hints)
+
+    @property
+    def terms(self) -> Tuple[sp.Basic, ...]:
+        return self.args
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         if all(
@@ -429,15 +432,20 @@ def _strip_subscript_superscript(symbol: sp.Symbol) -> str:
 
 @make_commutative
 class _ArrayAxisSum(sp.Expr):
-    array: ArraySymbol = property(lambda self: self.args[0])
-    axis: Optional[int] = property(lambda self: self.args[1])  # type: ignore[assignment]
-
     def __new__(
         cls, array: ArraySymbol, axis: Optional[int] = None, **hints: Any
     ) -> "_ArrayAxisSum":
         if axis is not None and not isinstance(axis, (int, sp.Integer)):
             raise TypeError("Only single digits allowed for axis")
         return create_expression(cls, array, axis, **hints)
+
+    @property
+    def array(self) -> ArraySymbol:
+        return self.args[0]
+
+    @property
+    def axis(self) -> Optional[int]:
+        return self.args[1]
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         array = printer._print(self.array)
@@ -454,12 +462,14 @@ class _ArrayAxisSum(sp.Expr):
 
 
 class _ArrayMultiplication(sp.Expr):
-    tensors: List[sp.Expr] = property(lambda self: self.args)  # type: ignore[assignment]
-
     def __new__(
         cls, *tensors: sp.Expr, **hints: Any
     ) -> "_ArrayMultiplication":
         return create_expression(cls, *tensors, **hints)
+
+    @property
+    def tensors(self) -> List[sp.Expr]:
+        return self.args
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         tensors = map(printer._print, self.tensors)
@@ -486,10 +496,12 @@ class _ArrayMultiplication(sp.Expr):
 
 
 class BoostZ(sp.Expr):
-    beta: sp.Expr = property(lambda self: self.args[0])
-
     def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZ":
         return create_expression(cls, beta, **kwargs)
+
+    @property
+    def beta(self) -> sp.Expr:
+        return self.args[0]
 
     def as_explicit(self) -> sp.Expr:
         beta = self.beta
@@ -527,10 +539,12 @@ class BoostZ(sp.Expr):
 
 
 class RotationY(sp.Expr):
-    angle: sp.Expr = property(lambda self: self.args[0])
-
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationY":
         return create_expression(cls, angle, **hints)
+
+    @property
+    def angle(self) -> sp.Expr:
+        return self.args[0]
 
     def as_explicit(self) -> sp.Expr:
         angle = self.angle
@@ -567,10 +581,12 @@ class RotationY(sp.Expr):
 
 
 class RotationZ(sp.Expr):
-    angle: sp.Expr = property(lambda self: self.args[0])
-
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZ":
         return create_expression(cls, angle, **hints)
+
+    @property
+    def angle(self) -> sp.Expr:
+        return self.args[0]
 
     def as_explicit(self) -> sp.Expr:
         angle = self.args[0]
@@ -607,8 +623,9 @@ class RotationZ(sp.Expr):
 
 
 class HasMomentum:
-    # pylint: disable=no-member
-    momentum: ArraySymbol = property(lambda self: self.args[0])
+    @property
+    def momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]  # type: ignore[attr-defined]
 
 
 def _implement_latex_subscript(

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -1,6 +1,6 @@
 # cspell:ignore einsum
 # pylint: disable=arguments-differ,no-member,protected-access,unused-argument
-"""Kinematics of an amplitude model in the helicity formalism."""
+"""Classes and functions for relativistic four-momentum kinematics."""
 
 import functools
 import itertools

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -171,6 +171,175 @@ of events. The four-momenta are assumed to be in the order
 ArraySlice = make_commutative(ArraySlice)  # type: ignore[misc]
 
 
+@implement_doit_method
+@make_commutative
+class Energy(UnevaluatedExpression):
+    """Represents the energy-component of a `FourMomentumSymbol`."""
+
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        return ArraySlice(self._momentum, (slice(None), 0))
+
+    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+        momentum = printer._print(self._momentum)
+        return fR"E\left({momentum}\right)"
+
+
+@_implement_latex_subscript(subscript="x")
+@implement_doit_method
+@make_commutative
+class FourMomentumX(UnevaluatedExpression):
+    """Component :math:`x` of a `FourMomentumSymbol`."""
+
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumX":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        return ArraySlice(self._momentum, (slice(None), 1))
+
+
+@_implement_latex_subscript(subscript="y")
+@implement_doit_method
+@make_commutative
+class FourMomentumY(UnevaluatedExpression):
+    """Component :math:`y` of a `FourMomentumSymbol`."""
+
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumY":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        return ArraySlice(self._momentum, (slice(None), 2))
+
+
+@_implement_latex_subscript(subscript="z")
+@implement_doit_method
+@make_commutative
+class FourMomentumZ(UnevaluatedExpression):
+    """Component :math:`z` of a `FourMomentumSymbol`."""
+
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumZ":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        return ArraySlice(self._momentum, (slice(None), 3))
+
+
+@implement_doit_method
+@make_commutative
+class ThreeMomentumNorm(UnevaluatedExpression):
+    """Norm of the three-momentum of a `FourMomentumSymbol`."""
+
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "ThreeMomentumNorm":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        three_momentum = ArraySlice(
+            self._momentum, (slice(None), slice(1, None))
+        )
+        norm_squared = _ArrayAxisSum(three_momentum ** 2, axis=1)
+        return sp.sqrt(norm_squared)
+
+    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+        momentum = printer._print(self._momentum)
+        return fR"\left|\vec{{{momentum}}}\right|"
+
+    def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
+        return printer._print(self.evaluate())
+
+
+@implement_doit_method
+@make_commutative
+class InvariantMass(UnevaluatedExpression):
+    """Invariant mass of a `FourMomentumSymbol`."""
+
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> ArraySlice:
+        p = self._momentum
+        return ComplexSqrt(Energy(p) ** 2 - ThreeMomentumNorm(p) ** 2)
+
+    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+        momentum = printer._print(self._momentum)
+        return f"m_{{{momentum}}}"
+
+
+@implement_doit_method
+@make_commutative
+class Phi(UnevaluatedExpression):
+    r"""Azimuthal angle :math:`\phi` of a `FourMomentumSymbol`."""
+
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Phi":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> sp.Expr:
+        p = self._momentum
+        return sp.atan2(FourMomentumY(p), FourMomentumX(p))
+
+    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+        momentum = printer._print(self._momentum)
+        return fR"\phi\left({momentum}\right)"
+
+
+@implement_doit_method
+@make_commutative
+class Theta(UnevaluatedExpression):
+    r"""Polar (elevation) angle :math:`\theta` of a `FourMomentumSymbol`."""
+
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Theta":
+        return create_expression(cls, momentum, **hints)
+
+    @property
+    def _momentum(self) -> "FourMomentumSymbol":
+        return self.args[0]
+
+    def evaluate(self) -> sp.Expr:
+        p = self._momentum
+        return sp.acos(FourMomentumZ(p) / ThreeMomentumNorm(p))
+
+    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
+        momentum = printer._print(self._momentum)
+        return fR"\theta\left({momentum}\right)"
+
+
 def compute_helicity_angles(
     four_momenta: "FourMomenta", topology: Topology
 ) -> Dict[str, sp.Expr]:
@@ -661,175 +830,6 @@ class RotationZ(sp.Expr):
                 [{zeros}, {zeros}, {zeros}, {ones}],
             ]
         ).transpose((2, 0, 1))"""
-
-
-@implement_doit_method
-@make_commutative
-class Energy(UnevaluatedExpression):
-    """Represents the energy-component of a `FourMomentumSymbol`."""
-
-    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        return ArraySlice(self._momentum, (slice(None), 0))
-
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self._momentum)
-        return fR"E\left({momentum}\right)"
-
-
-@_implement_latex_subscript(subscript="x")
-@implement_doit_method
-@make_commutative
-class FourMomentumX(UnevaluatedExpression):
-    """Component :math:`x` of a `FourMomentumSymbol`."""
-
-    def __new__(
-        cls, momentum: "FourMomentumSymbol", **hints: Any
-    ) -> "FourMomentumX":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        return ArraySlice(self._momentum, (slice(None), 1))
-
-
-@_implement_latex_subscript(subscript="y")
-@implement_doit_method
-@make_commutative
-class FourMomentumY(UnevaluatedExpression):
-    """Component :math:`y` of a `FourMomentumSymbol`."""
-
-    def __new__(
-        cls, momentum: "FourMomentumSymbol", **hints: Any
-    ) -> "FourMomentumY":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        return ArraySlice(self._momentum, (slice(None), 2))
-
-
-@_implement_latex_subscript(subscript="z")
-@implement_doit_method
-@make_commutative
-class FourMomentumZ(UnevaluatedExpression):
-    """Component :math:`z` of a `FourMomentumSymbol`."""
-
-    def __new__(
-        cls, momentum: "FourMomentumSymbol", **hints: Any
-    ) -> "FourMomentumZ":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        return ArraySlice(self._momentum, (slice(None), 3))
-
-
-@implement_doit_method
-@make_commutative
-class ThreeMomentumNorm(UnevaluatedExpression):
-    """Norm of the three-momentum of a `FourMomentumSymbol`."""
-
-    def __new__(
-        cls, momentum: "FourMomentumSymbol", **hints: Any
-    ) -> "ThreeMomentumNorm":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        three_momentum = ArraySlice(
-            self._momentum, (slice(None), slice(1, None))
-        )
-        norm_squared = _ArrayAxisSum(three_momentum ** 2, axis=1)
-        return sp.sqrt(norm_squared)
-
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self._momentum)
-        return fR"\left|\vec{{{momentum}}}\right|"
-
-    def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        return printer._print(self.evaluate())
-
-
-@implement_doit_method
-@make_commutative
-class InvariantMass(UnevaluatedExpression):
-    """Invariant mass of a `FourMomentumSymbol`."""
-
-    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> ArraySlice:
-        p = self._momentum
-        return ComplexSqrt(Energy(p) ** 2 - ThreeMomentumNorm(p) ** 2)
-
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self._momentum)
-        return f"m_{{{momentum}}}"
-
-
-@implement_doit_method
-@make_commutative
-class Phi(UnevaluatedExpression):
-    r"""Azimuthal angle :math:`\phi` of a `FourMomentumSymbol`."""
-
-    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Phi":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> sp.Expr:
-        p = self._momentum
-        return sp.atan2(FourMomentumY(p), FourMomentumX(p))
-
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self._momentum)
-        return fR"\phi\left({momentum}\right)"
-
-
-@implement_doit_method
-@make_commutative
-class Theta(UnevaluatedExpression):
-    r"""Polar (elevation) angle :math:`\theta` of a `FourMomentumSymbol`."""
-
-    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Theta":
-        return create_expression(cls, momentum, **hints)
-
-    @property
-    def _momentum(self) -> "FourMomentumSymbol":
-        return self.args[0]
-
-    def evaluate(self) -> sp.Expr:
-        p = self._momentum
-        return sp.acos(FourMomentumZ(p) / ThreeMomentumNorm(p))
-
-    def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        momentum = printer._print(self._momentum)
-        return fR"\theta\left({momentum}\right)"
 
 
 def _assert_isobar_topology(topology: Topology) -> None:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -592,7 +592,7 @@ class HasMomentum:
     momentum: ArraySymbol = property(lambda self: self.args[0])
 
 
-def implement_latex_subscript(
+def _implement_latex_subscript(
     subscript: str,
 ) -> Callable[[Type[UnevaluatedExpression]], Type[UnevaluatedExpression]]:
     def decorator(
@@ -629,7 +629,7 @@ class Energy(HasMomentum, UnevaluatedExpression):
         return fR"E\left({momentum}\right)"
 
 
-@implement_latex_subscript(subscript="x")
+@_implement_latex_subscript(subscript="x")
 @implement_doit_method
 @make_commutative
 class FourMomentumX(HasMomentum, UnevaluatedExpression):
@@ -640,7 +640,7 @@ class FourMomentumX(HasMomentum, UnevaluatedExpression):
         return ArraySlice(self.momentum, (slice(None), 1))
 
 
-@implement_latex_subscript(subscript="y")
+@_implement_latex_subscript(subscript="y")
 @implement_doit_method
 @make_commutative
 class FourMomentumY(HasMomentum, UnevaluatedExpression):
@@ -651,7 +651,7 @@ class FourMomentumY(HasMomentum, UnevaluatedExpression):
         return ArraySlice(self.momentum, (slice(None), 2))
 
 
-@implement_latex_subscript(subscript="z")
+@_implement_latex_subscript(subscript="z")
 @implement_doit_method
 @make_commutative
 class FourMomentumZ(HasMomentum, UnevaluatedExpression):

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -154,7 +154,11 @@ def create_four_momentum_symbols(topology: Topology) -> "FourMomenta":
 
 
 FourMomenta = Dict[int, "FourMomentumSymbol"]
-"""A mapping of state IDs to their corresponding `FourMomentumSymbol`."""
+"""A mapping of state IDs to their corresponding `FourMomentumSymbol`.
+
+It's best to create a `dict` of `FourMomenta` with
+:func:`create_four_momentum_symbols`.
+"""
 FourMomentumSymbol: "TypeAlias" = ArraySymbol
 r"""Array-`~sympy.core.symbol.Symbol` that represents an array of four-momenta.
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -2,13 +2,11 @@
 # pylint: disable=arguments-differ,no-member,protected-access,unused-argument
 """Classes and functions for relativistic four-momentum kinematics."""
 
-import functools
 import itertools
 import sys
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -16,7 +14,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Type,
 )
 
 import attr
@@ -32,6 +29,7 @@ from sympy.printing.printer import Printer
 
 from ampform.sympy import (
     UnevaluatedExpression,
+    _implement_latex_subscript,
     create_expression,
     implement_doit_method,
     make_commutative,
@@ -663,27 +661,6 @@ class RotationZ(sp.Expr):
                 [{zeros}, {zeros}, {zeros}, {ones}],
             ]
         ).transpose((2, 0, 1))"""
-
-
-def _implement_latex_subscript(
-    subscript: str,
-) -> Callable[[Type[UnevaluatedExpression]], Type[UnevaluatedExpression]]:
-    def decorator(
-        decorated_class: Type[UnevaluatedExpression],
-    ) -> Type[UnevaluatedExpression]:
-        @functools.wraps(decorated_class.doit)
-        def _latex(self: sp.Expr, printer: LatexPrinter, *args: Any) -> str:
-            momentum = printer._print(self._momentum)
-            if printer._needs_mul_brackets(self._momentum):
-                momentum = fR"\left({momentum}\right)"
-            else:
-                momentum = fR"{{{momentum}}}"
-            return f"{momentum}_{subscript}"
-
-        decorated_class._latex = _latex  # type: ignore[assignment]
-        return decorated_class
-
-    return decorator
 
 
 @implement_doit_method

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -569,7 +569,7 @@ class RotationY(sp.Expr):
 class RotationZ(sp.Expr):
     angle: sp.Expr = property(lambda self: self.args[0])
 
-    def __new__(cls, angle: sp.Symbol, **hints: Any) -> "RotationZ":
+    def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZ":
         return create_expression(cls, angle, **hints)
 
     def as_explicit(self) -> sp.Expr:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -4,7 +4,9 @@
 
 import functools
 import itertools
+import sys
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -37,7 +39,22 @@ from ampform.sympy import (
 from ampform.sympy._array_expressions import ArraySlice, ArraySymbol
 from ampform.sympy.math import ComplexSqrt
 
-FourMomentumSymbols = Dict[int, ArraySymbol]
+if TYPE_CHECKING:
+    if sys.version_info < (3, 10):
+        from typing_extensions import TypeAlias
+    else:
+        from typing import TypeAlias
+
+
+FourMomentumSymbol: "TypeAlias" = ArraySymbol
+r"""Array-`~sympy.core.symbol.Symbol` that represents an array of four-momenta.
+
+The array is assumed to be of shape :math:`n\times 4` with :math:`n` the number
+of events. The four-momenta are assumed to be in the order
+:math:`\left(E,\vec{p}\right)`.
+"""
+FourMomenta = Dict[int, "FourMomentumSymbol"]
+"""A mapping of state IDs to their corresponding `FourMomentumSymbol`."""
 
 
 # for numpy broadcasting
@@ -249,7 +266,7 @@ def get_invariant_mass_label(topology: Topology, state_id: int) -> str:
 
 
 def compute_helicity_angles(
-    four_momenta: FourMomentumSymbols, topology: Topology
+    four_momenta: "FourMomenta", topology: Topology
 ) -> Dict[str, sp.Expr]:
     if topology.outgoing_edge_ids != set(four_momenta):
         raise ValueError(
@@ -258,7 +275,7 @@ def compute_helicity_angles(
         )
 
     def __recursive_helicity_angles(  # pylint: disable=too-many-locals
-        four_momenta: FourMomentumSymbols, node_id: int
+        four_momenta: FourMomenta, node_id: int
     ) -> Dict[str, sp.Expr]:
         helicity_angles: Dict[str, sp.Expr] = {}
         child_state_ids = sorted(
@@ -328,7 +345,7 @@ def compute_helicity_angles(
 
 
 def compute_invariant_masses(
-    four_momenta: FourMomentumSymbols, topology: Topology
+    four_momenta: "FourMomenta", topology: Topology
 ) -> Dict[str, sp.Expr]:
     """Compute the invariant masses for all final state combinations."""
     if topology.outgoing_edge_ids != set(four_momenta):
@@ -620,7 +637,7 @@ def _implement_latex_subscript(
 @implement_doit_method
 @make_commutative
 class Energy(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Energy":
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> ArraySlice:
@@ -635,7 +652,9 @@ class Energy(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumX(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumX":
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumX":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> ArraySlice:
@@ -646,7 +665,9 @@ class FourMomentumX(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumY(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumY":
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumY":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> ArraySlice:
@@ -657,7 +678,9 @@ class FourMomentumY(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class FourMomentumZ(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "FourMomentumZ":
+    def __new__(
+        cls, momentum: "FourMomentumSymbol", **hints: Any
+    ) -> "FourMomentumZ":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> ArraySlice:
@@ -668,7 +691,7 @@ class FourMomentumZ(HasMomentum, UnevaluatedExpression):
 @make_commutative
 class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
     def __new__(
-        cls, momentum: ArraySymbol, **hints: Any
+        cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "ThreeMomentumNorm":
         return create_expression(cls, momentum, **hints)
 
@@ -690,7 +713,7 @@ class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class InvariantMass(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Energy":
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> ArraySlice:
@@ -705,7 +728,7 @@ class InvariantMass(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class Phi(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Phi":
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Phi":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> sp.Expr:
@@ -720,7 +743,7 @@ class Phi(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class Theta(HasMomentum, UnevaluatedExpression):
-    def __new__(cls, momentum: ArraySymbol, **hints: Any) -> "Theta":
+    def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Theta":
         return create_expression(cls, momentum, **hints)
 
     def evaluate(self) -> sp.Expr:
@@ -752,7 +775,7 @@ def _assert_two_body_decay(topology: Topology, node_id: int) -> None:
         )
 
 
-def create_four_momentum_symbols(topology: Topology) -> FourMomentumSymbols:
+def create_four_momentum_symbols(topology: Topology) -> "FourMomenta":
     n_final_states = len(topology.outgoing_edge_ids)
     return {i: ArraySymbol(f"p{i}") for i in range(n_final_states)}
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -742,6 +742,8 @@ class FourMomentumZ(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
+    """Norm of the three-momentum of a `FourMomentumSymbol`."""
+
     def __new__(
         cls, momentum: "FourMomentumSymbol", **hints: Any
     ) -> "ThreeMomentumNorm":
@@ -765,6 +767,8 @@ class ThreeMomentumNorm(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class InvariantMass(HasMomentum, UnevaluatedExpression):
+    """Invariant mass of a `FourMomentumSymbol`."""
+
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Energy":
         return create_expression(cls, momentum, **hints)
 
@@ -780,6 +784,8 @@ class InvariantMass(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class Phi(HasMomentum, UnevaluatedExpression):
+    r"""Azimuthal angle :math:`\phi` of a `FourMomentumSymbol`."""
+
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Phi":
         return create_expression(cls, momentum, **hints)
 
@@ -795,6 +801,8 @@ class Phi(HasMomentum, UnevaluatedExpression):
 @implement_doit_method
 @make_commutative
 class Theta(HasMomentum, UnevaluatedExpression):
+    r"""Polar (elevation) angle :math:`\theta` of a `FourMomentumSymbol`."""
+
     def __new__(cls, momentum: "FourMomentumSymbol", **hints: Any) -> "Theta":
         return create_expression(cls, momentum, **hints)
 

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -333,10 +333,10 @@ class Theta(UnevaluatedExpression):
         return fR"\theta\left({momentum}\right)"
 
 
-class BoostZ(sp.Expr):
+class BoostZMatrix(sp.Expr):
     """Represents a Lorentz boost matrix in the :math:`z`-direction."""
 
-    def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZ":
+    def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZMatrix":
         return create_expression(cls, beta, **kwargs)
 
     @property
@@ -379,10 +379,10 @@ class BoostZ(sp.Expr):
         ).transpose((2, 0, 1))"""
 
 
-class RotationY(sp.Expr):
+class RotationYMatrix(sp.Expr):
     """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`."""
 
-    def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationY":
+    def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationYMatrix":
         return create_expression(cls, angle, **hints)
 
     @property
@@ -424,10 +424,10 @@ class RotationY(sp.Expr):
         ).transpose((2, 0, 1))"""
 
 
-class RotationZ(sp.Expr):
+class RotationZMatrix(sp.Expr):
     """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`."""
 
-    def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZ":
+    def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZMatrix":
         return create_expression(cls, angle, **hints)
 
     @property
@@ -532,9 +532,9 @@ def compute_helicity_angles(
                     beta = p3_norm / Energy(four_momentum)
                     new_momentum_pool = {
                         k: ArrayMultiplication(
-                            BoostZ(beta),
-                            RotationY(-theta),
-                            RotationZ(-phi),
+                            BoostZMatrix(beta),
+                            RotationYMatrix(-theta),
+                            RotationZMatrix(-phi),
                             p,
                         )
                         for k, p in four_momenta.items()

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -560,11 +560,14 @@ class BoostZ(sp.Expr):
 
 
 class RotationY(sp.Expr):
+    """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`."""
+
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationY":
         return create_expression(cls, angle, **hints)
 
     @property
     def angle(self) -> sp.Expr:
+        """Angle with which to rotate, see e.g. `Phi` and `Theta`."""
         return self.args[0]
 
     def as_explicit(self) -> sp.Expr:
@@ -602,11 +605,14 @@ class RotationY(sp.Expr):
 
 
 class RotationZ(sp.Expr):
+    """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`."""
+
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZ":
         return create_expression(cls, angle, **hints)
 
     @property
     def angle(self) -> sp.Expr:
+        """Angle with which to rotate, see e.g. `Phi` and `Theta`."""
         return self.args[0]
 
     def as_explicit(self) -> sp.Expr:

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -334,7 +334,7 @@ class Theta(UnevaluatedExpression):
 
 
 class BoostZ(sp.Expr):
-    """Represents a Lorentz boost **matrix** in the :math:`z`-direction."""
+    """Represents a Lorentz boost matrix in the :math:`z`-direction."""
 
     def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZ":
         return create_expression(cls, beta, **kwargs)

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -129,17 +129,12 @@ def implement_doit_method(
     return decorated_class
 
 
-def make_commutative() -> Callable[
-    [Type[UnevaluatedExpression]], Type[UnevaluatedExpression]
-]:
-    def decorator(
-        decorated_class: Type[UnevaluatedExpression],
-    ) -> Type[UnevaluatedExpression]:
-        decorated_class.is_commutative = True
-        decorated_class.is_extended_real = True
-        return decorated_class
-
-    return decorator
+def make_commutative(
+    decorated_class: Type[UnevaluatedExpression],
+) -> Type[UnevaluatedExpression]:
+    decorated_class.is_commutative = True
+    decorated_class.is_extended_real = True
+    return decorated_class
 
 
 def create_expression(

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -127,6 +127,28 @@ def implement_doit_method(decorated_class: DecoratedClass) -> DecoratedClass:
     return decorated_class
 
 
+def _implement_latex_subscript(  # pyright: reportUnusedFunction=false
+    subscript: str,
+) -> Callable[[Type[UnevaluatedExpression]], Type[UnevaluatedExpression]]:
+    def decorator(
+        decorated_class: Type[UnevaluatedExpression],
+    ) -> Type[UnevaluatedExpression]:
+        # pylint: disable=protected-access, unused-argument
+        @functools.wraps(decorated_class.doit)
+        def _latex(self: sp.Expr, printer: LatexPrinter, *args: Any) -> str:
+            momentum = printer._print(self._momentum)
+            if printer._needs_mul_brackets(self._momentum):
+                momentum = fR"\left({momentum}\right)"
+            else:
+                momentum = fR"{{{momentum}}}"
+            return f"{momentum}_{subscript}"
+
+        decorated_class._latex = _latex  # type: ignore[assignment]
+        return decorated_class
+
+    return decorator
+
+
 def make_commutative(decorated_class: DecoratedClass) -> DecoratedClass:
     decorated_class.is_commutative = True  # type: ignore[attr-defined]
     decorated_class.is_extended_real = True  # type: ignore[attr-defined]

--- a/src/ampform/sympy/math.py
+++ b/src/ampform/sympy/math.py
@@ -8,7 +8,10 @@ import sympy as sp
 from sympy.plotting.experimental_lambdify import Lambdifier
 from sympy.printing.printer import Printer
 
+from . import make_commutative
 
+
+@make_commutative
 class ComplexSqrt(sp.Expr):
     """Square root that returns positive imaginary values for negative input.
 
@@ -18,8 +21,6 @@ class ComplexSqrt(sp.Expr):
     and :doc:`sympy:modules/printing` for how to implement a custom
     :func:`~sympy.utilities.lambdify.lambdify` printer.
     """
-
-    is_commutative = True
 
     def __new__(cls, x: sp.Expr, *args: Any, **kwargs: Any) -> "ComplexSqrt":
         x = sp.sympify(x)

--- a/tests/sympy/test_array_expressions.py
+++ b/tests/sympy/test_array_expressions.py
@@ -1,0 +1,52 @@
+# pylint: disable=no-self-use
+# cspell:ignore doprint
+from textwrap import dedent
+
+import black
+import sympy as sp
+from sympy.printing.numpy import NumPyPrinter
+
+from ampform.sympy._array_expressions import (
+    ArrayMultiplication,
+    ArraySum,
+    ArraySymbol,
+)
+
+
+class TestArrayMultiplication:
+    def test_numpy_str(self):
+        n_events = 3
+        momentum = sp.MatrixSymbol("p", m=n_events, n=4)
+        beta = sp.Symbol("beta")
+        theta = sp.Symbol("theta")
+        expr = ArrayMultiplication(beta, theta, momentum)
+        numpy_code = _generate_numpy_code(expr)
+        numpy_code = black.format_str(
+            numpy_code, mode=black.Mode(line_length=70)
+        )
+        expected = """\
+        einsum("...ij,...j->...i", beta, einsum("...ij,...j->...i", theta, p))
+        """
+        assert numpy_code == dedent(expected)
+
+
+class TestArraySum:
+    def test_latex(self):
+        x, y = sp.symbols("x y")
+        array_sum = ArraySum(x ** 2, sp.cos(y))
+        assert sp.latex(array_sum) == R"x^{2} + \cos{\left(y \right)}"
+
+    def test_latex_array_symbols(self):
+        p0, p1, p2, p3 = sp.symbols("p:4", cls=ArraySymbol)
+        array_sum = ArraySum(p0, p1, p2, p3)
+        assert sp.latex(array_sum) == "{p}_{0123}"
+
+    def test_numpy(self):
+        expr = ArraySum(*sp.symbols("x y"))
+        numpy_code = _generate_numpy_code(expr)
+        assert numpy_code == "x + y"
+
+
+def _generate_numpy_code(expr: sp.Expr) -> str:
+    printer = NumPyPrinter()
+    return printer.doprint(expr)

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -13,7 +13,7 @@ from sympy.printing.numpy import NumPyPrinter
 
 from ampform.kinematics import (
     Energy,
-    FourMomentumSymbols,
+    FourMomenta,
     FourMomentumX,
     FourMomentumY,
     FourMomentumZ,
@@ -34,7 +34,7 @@ from ampform.sympy._array_expressions import ArraySlice, ArraySymbol
 @pytest.fixture(scope="session")
 def topology_and_momentum_symbols(
     data_sample: Dict[int, np.ndarray]
-) -> Tuple[Topology, FourMomentumSymbols]:
+) -> Tuple[Topology, FourMomenta]:
     n = len(data_sample)
     assert n == 4
     topologies = create_isobar_topologies(n)
@@ -45,7 +45,7 @@ def topology_and_momentum_symbols(
 
 @pytest.fixture(scope="session")
 def helicity_angles(
-    topology_and_momentum_symbols: Tuple[Topology, FourMomentumSymbols]
+    topology_and_momentum_symbols: Tuple[Topology, FourMomenta]
 ) -> Dict[str, sp.Expr]:
     topology, momentum_symbols = topology_and_momentum_symbols
     return compute_helicity_angles(momentum_symbols, topology)
@@ -300,7 +300,7 @@ class TestTheta:
 )
 def test_compute_helicity_angles(
     data_sample: Dict[int, np.ndarray],
-    topology_and_momentum_symbols: Tuple[Topology, FourMomentumSymbols],
+    topology_and_momentum_symbols: Tuple[Topology, FourMomenta],
     angle_name: str,
     expected_values: np.ndarray,
     helicity_angles: Dict[str, sp.Expr],
@@ -314,7 +314,7 @@ def test_compute_helicity_angles(
 
 
 def test_compute_invariant_masses_names(
-    topology_and_momentum_symbols: Tuple[Topology, FourMomentumSymbols]
+    topology_and_momentum_symbols: Tuple[Topology, FourMomenta]
 ):
     topology, momentum_symbols = topology_and_momentum_symbols
     invariant_masses = compute_invariant_masses(momentum_symbols, topology)
@@ -331,7 +331,7 @@ def test_compute_invariant_masses_names(
 
 def test_compute_invariant_masses_single_mass(
     data_sample: Dict[int, np.ndarray],
-    topology_and_momentum_symbols: Tuple[Topology, FourMomentumSymbols],
+    topology_and_momentum_symbols: Tuple[Topology, FourMomenta],
 ):
     topology, momentum_symbols = topology_and_momentum_symbols
     momentum_values = data_sample.values()
@@ -348,7 +348,7 @@ def test_compute_invariant_masses_single_mass(
 def test_compute_invariant_masses(
     mass_name: str,
     data_sample: Dict[int, np.ndarray],
-    topology_and_momentum_symbols: Tuple[Topology, FourMomentumSymbols],
+    topology_and_momentum_symbols: Tuple[Topology, FourMomenta],
 ):
     topology, momentum_symbols = topology_and_momentum_symbols
     momentum_values = data_sample.values()

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -1,9 +1,7 @@
 # pylint: disable=no-member, no-self-use, redefined-outer-name
-# cspell:ignore atol doprint matexpr
-from textwrap import dedent
+# cspell:ignore atol doprint
 from typing import Dict, Tuple
 
-import black
 import numpy as np
 import pytest
 import sympy as sp
@@ -21,8 +19,6 @@ from ampform.kinematics import (
     Phi,
     Theta,
     ThreeMomentumNorm,
-    _ArrayMultiplication,
-    _ArraySum,
     compute_helicity_angles,
     compute_invariant_masses,
     create_four_momentum_symbols,
@@ -49,40 +45,6 @@ def helicity_angles(
 ) -> Dict[str, sp.Expr]:
     topology, momentum_symbols = topology_and_momentum_symbols
     return compute_helicity_angles(momentum_symbols, topology)
-
-
-class TestArrayMultiplication:
-    def test_numpy_str(self):
-        n_events = 3
-        momentum = sp.MatrixSymbol("p", m=n_events, n=4)
-        beta = sp.Symbol("beta")
-        theta = sp.Symbol("theta")
-        expr = _ArrayMultiplication(beta, theta, momentum)
-        numpy_code = _generate_numpy_code(expr)
-        numpy_code = black.format_str(
-            numpy_code, mode=black.Mode(line_length=70)
-        )
-        expected = """\
-        einsum("...ij,...j->...i", beta, einsum("...ij,...j->...i", theta, p))
-        """
-        assert numpy_code == dedent(expected)
-
-
-class TestArraySum:
-    def test_latex(self):
-        x, y = sp.symbols("x y")
-        array_sum = _ArraySum(x ** 2, sp.cos(y))
-        assert sp.latex(array_sum) == R"x^{2} + \cos{\left(y \right)}"
-
-    def test_latex_array_symbols(self):
-        p0, p1, p2, p3 = sp.symbols("p:4", cls=ArraySymbol)
-        array_sum = _ArraySum(p0, p1, p2, p3)
-        assert sp.latex(array_sum) == "{p}_{0123}"
-
-    def test_numpy(self):
-        expr = _ArraySum(*sp.symbols("x y"))
-        numpy_code = _generate_numpy_code(expr)
-        assert numpy_code == "x + y"
 
 
 class TestFourMomentumXYZ:

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -12,8 +12,6 @@ from qrules.topology import Topology, create_isobar_topologies
 from sympy.printing.numpy import NumPyPrinter
 
 from ampform.kinematics import (
-    ArrayMultiplication,
-    ArraySum,
     Energy,
     FourMomentumSymbols,
     FourMomentumX,
@@ -23,6 +21,8 @@ from ampform.kinematics import (
     Phi,
     Theta,
     ThreeMomentumNorm,
+    _ArrayMultiplication,
+    _ArraySum,
     compute_helicity_angles,
     compute_invariant_masses,
     create_four_momentum_symbols,
@@ -57,7 +57,7 @@ class TestArrayMultiplication:
         momentum = sp.MatrixSymbol("p", m=n_events, n=4)
         beta = sp.Symbol("beta")
         theta = sp.Symbol("theta")
-        expr = ArrayMultiplication(beta, theta, momentum)
+        expr = _ArrayMultiplication(beta, theta, momentum)
         numpy_code = _generate_numpy_code(expr)
         numpy_code = black.format_str(
             numpy_code, mode=black.Mode(line_length=70)
@@ -71,16 +71,16 @@ class TestArrayMultiplication:
 class TestArraySum:
     def test_latex(self):
         x, y = sp.symbols("x y")
-        array_sum = ArraySum(x ** 2, sp.cos(y))
+        array_sum = _ArraySum(x ** 2, sp.cos(y))
         assert sp.latex(array_sum) == R"x^{2} + \cos{\left(y \right)}"
 
     def test_latex_array_symbols(self):
         p0, p1, p2, p3 = sp.symbols("p:4", cls=ArraySymbol)
-        array_sum = ArraySum(p0, p1, p2, p3)
+        array_sum = _ArraySum(p0, p1, p2, p3)
         assert sp.latex(array_sum) == "{p}_{0123}"
 
     def test_numpy(self):
-        expr = ArraySum(*sp.symbols("x y"))
+        expr = _ArraySum(*sp.symbols("x y"))
         numpy_code = _generate_numpy_code(expr)
         assert numpy_code == "x + y"
 


### PR DESCRIPTION
Preview [here](https://ampform--211.org.readthedocs.build/en/211/api/ampform.kinematics.html). Compare to [v0.12.2](https://ampform.readthedocs.org/en/0.12.2/api/ampform.kinematics.html).

- Definitions in the API are follow the sorting of the source code.
- Hidden the classes for SymPy ArraySymbols by moving them to `ampform.sympy._array_expresssions`.
- Added docstrings to all remaining classes, like `BoostZ`.
- Improved the `docs/_extend_docstrings.py` script.
- Hidden several methods and attributes that come from `sympy.Basic`.
- See [commit history]() for other changes.