### PR TITLE
ci: run RTD on Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ formats:
   - htmlzip
 
 python:
-  version: 3.7
+  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
[`sphinx-apidoc`](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html) does not render the docstring for the `FourMomentumSymbol` type alias (#211) when running on Python 3.7. See for instance the [API preview of the latest PR](https://ampform--214.org.readthedocs.build/en/214/api/ampform.kinematics.html#ampform.kinematics.FourMomentumSymbol). The docstring is correctly rendered when building with Python 3.8, see preview [here]().

Note: RTD for QRules also switched to Python 3.8 in https://github.com/ComPWA/qrules/pull/136.