### PR TITLE
chore: simplify einsum rendering ArrayMultiplication

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -19,7 +19,7 @@ import qrules
 import sympy as sp
 from sympy.printing.numpy import NumPyPrinter
 
-from ampform.sympy._array_expressions import ArraySymbol
+from ampform.kinematics import FourMomentumSymbol
 
 logging.getLogger().setLevel(logging.ERROR)
 
@@ -148,7 +148,7 @@ def extend_Energy_and_FourMomentumXYZ() -> None:
 
     def _extend(component_class: Type[sp.Expr]) -> None:
         _append_to_docstring(component_class, "\n\n")
-        p = ArraySymbol("p")
+        p = FourMomentumSymbol("p")
         expr = component_class(p)
         _append_latex_doit_definition(expr, inline=True)
 
@@ -161,7 +161,7 @@ def extend_Energy_and_FourMomentumXYZ() -> None:
 def extend_InvariantMass() -> None:
     from ampform.kinematics import InvariantMass
 
-    p = ArraySymbol("p")
+    p = FourMomentumSymbol("p")
     expr = InvariantMass(p)
     _append_latex_doit_definition(expr)
 
@@ -227,7 +227,7 @@ def extend_PhaseSpaceFactorComplex() -> None:
 def extend_Phi() -> None:
     from ampform.kinematics import Phi
 
-    p = ArraySymbol("p")
+    p = FourMomentumSymbol("p")
     expr = Phi(p)
     _append_latex_doit_definition(expr)
 
@@ -282,7 +282,7 @@ def extend_RotationZMatrix() -> None:
 def extend_Theta() -> None:
     from ampform.kinematics import Theta
 
-    p = ArraySymbol("p")
+    p = FourMomentumSymbol("p")
     expr = Theta(p)
     _append_latex_doit_definition(expr)
 
@@ -290,7 +290,7 @@ def extend_Theta() -> None:
 def extend_ThreeMomentumNorm() -> None:
     from ampform.kinematics import ThreeMomentumNorm
 
-    p = ArraySymbol("p")
+    p = FourMomentumSymbol("p")
     expr = ThreeMomentumNorm(p)
     _append_to_docstring(type(expr), "\n\n" + 4 * " ")
     _append_latex_doit_definition(expr, deep=False, inline=True)

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -25,7 +25,7 @@ from ampform.sympy.math import ComplexSqrt
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # pragma: no cover
 
 
 @implement_doit_method
@@ -160,7 +160,7 @@ class PhaseSpaceFactorProtocol(Protocol):
         self, s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol
     ) -> sp.Expr:
         """Expected `~inspect.signature`."""
-        ...
+        ...  # pragma: no cover
 
 
 @implement_doit_method

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -20,7 +20,7 @@ from . import (
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
-else:
+else:  # pragma: no cover
     from typing_extensions import Protocol
 
 

--- a/src/ampform/helicity/naming.py
+++ b/src/ampform/helicity/naming.py
@@ -177,6 +177,19 @@ class CanonicalAmplitudeNameGenerator(HelicityAmplitudeNameGenerator):
 
 
 def generate_transition_label(transition: StateTransition) -> str:
+    r"""Generate a label for a coherent intensity, including spin projection.
+
+    >>> import qrules
+    >>> reaction = qrules.generate_transitions(
+    ...     initial_state="J/psi(1S)",
+    ...     final_state=["gamma", "pi0", "pi0"],
+    ...     allowed_intermediate_particles=["f(0)(980)"],
+    ... )
+    >>> print(generate_transition_label(reaction.transitions[0]))
+    J/\psi(1S)_{-1} \to \gamma_{-1} \pi^{0}_{0} \pi^{0}_{0}
+    >>> print(generate_transition_label(reaction.transitions[-1]))
+    J/\psi(1S)_{+1} \to \gamma_{+1} \pi^{0}_{0} \pi^{0}_{0}
+    """
     initial_state_ids = transition.topology.incoming_edge_ids
     final_state_ids = transition.topology.outgoing_edge_ids
     initial_states = get_sorted_states(transition, initial_state_ids)

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -141,7 +141,7 @@ def create_four_momentum_symbols(topology: Topology) -> "FourMomenta":
     {0: p0, 1: p1, 2: p2}
     """
     n_final_states = len(topology.outgoing_edge_ids)
-    return {i: ArraySymbol(f"p{i}") for i in range(n_final_states)}
+    return {i: FourMomentumSymbol(f"p{i}") for i in range(n_final_states)}
 
 
 FourMomenta = Dict[int, "FourMomentumSymbol"]

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -30,7 +30,7 @@ from ampform.sympy._array_expressions import (
 )
 from ampform.sympy.math import ComplexSqrt
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     if sys.version_info < (3, 10):
         from typing_extensions import TypeAlias
     else:

--- a/src/ampform/sympy/_array_expressions.py
+++ b/src/ampform/sympy/_array_expressions.py
@@ -355,6 +355,16 @@ class ArrayAxisSum(sp.Expr):
 
 
 class ArrayMultiplication(sp.Expr):
+    r"""Contract rank-:math:`n` arrays and a rank-:math`n-1` array.
+
+    This class is particularly useful to create a tensor product of rank-3
+    matrix array classes, such as `.BoostZ`, `.RotationY`, and `.RotationZ`,
+    with a rank-2 `.FourMomentumSymbol`. In that case, if :math:`n` is the
+    number of events, you would get a contraction of arrays of shape
+    :math:`n\times\times4\times4` (:math:`n` Lorentz matrices) to
+    :math:`n\times\times4` (:math:`n` four-momentum tuples).
+    """
+
     def __new__(cls, *tensors: sp.Expr, **hints: Any) -> "ArrayMultiplication":
         return create_expression(cls, *tensors, **hints)
 

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     PrettyPrinter = Any
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     if sys.version_info >= (3, 10):
         from typing import TypeGuard  # pylint: disable=no-name-in-module
     else:

--- a/tests/sympy/test_array_expressions.py
+++ b/tests/sympy/test_array_expressions.py
@@ -1,8 +1,5 @@
 # pylint: disable=no-self-use
 # cspell:ignore doprint
-from textwrap import dedent
-
-import black
 import sympy as sp
 from sympy.printing.numpy import NumPyPrinter
 
@@ -21,13 +18,7 @@ class TestArrayMultiplication:
         theta = sp.Symbol("theta")
         expr = ArrayMultiplication(beta, theta, momentum)
         numpy_code = _generate_numpy_code(expr)
-        numpy_code = black.format_str(
-            numpy_code, mode=black.Mode(line_length=70)
-        )
-        expected = """\
-        einsum("...ij,...j->...i", beta, einsum("...ij,...j->...i", theta, p))
-        """
-        assert numpy_code == dedent(expected)
+        assert numpy_code == 'einsum("...ij,...jk,...k->...i", beta, theta, p)'
 
 
 class TestArraySum:

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -70,9 +70,9 @@ class TestFourMomentumXYZ:
     def symbols(
         self,
     ) -> Tuple[
-        ArraySymbol, Energy, FourMomentumX, FourMomentumY, FourMomentumZ
+        FourMomentumSymbol, Energy, FourMomentumX, FourMomentumY, FourMomentumZ
     ]:
-        p = ArraySymbol("p")
+        p = FourMomentumSymbol("p")
         e = Energy(p)
         p_x = FourMomentumX(p)
         p_y = FourMomentumY(p)
@@ -113,7 +113,7 @@ class TestInvariantMass:
         state_id: int,
         expected_mass: float,
     ):
-        p = ArraySymbol(f"p{state_id}")
+        p = FourMomentumSymbol(f"p{state_id}")
         mass = InvariantMass(p)
         np_mass = sp.lambdify(p, mass.doit(), "numpy")
         four_momenta = data_sample[state_id]
@@ -125,7 +125,7 @@ class TestInvariantMass:
 class TestThreeMomentumNorm:
     @property
     def p_norm(self) -> ThreeMomentumNorm:
-        p = ArraySymbol("p")
+        p = FourMomentumSymbol("p")
         return ThreeMomentumNorm(p)
 
     def test_latex(self):
@@ -140,7 +140,7 @@ class TestThreeMomentumNorm:
 class TestPhi:
     @property
     def phi(self) -> Theta:
-        p = ArraySymbol("p")
+        p = FourMomentumSymbol("p")
         return Phi(p)
 
     def test_latex(self):
@@ -156,7 +156,7 @@ class TestPhi:
 class TestTheta:
     @property
     def theta(self) -> Theta:
-        p = ArraySymbol("p")
+        p = FourMomentumSymbol("p")
         return Theta(p)
 
     def test_latex(self):

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -10,8 +10,10 @@ from qrules.topology import Topology, create_isobar_topologies
 from sympy.printing.numpy import NumPyPrinter
 
 from ampform.kinematics import (
+    BoostZMatrix,
     Energy,
     FourMomenta,
+    FourMomentumSymbol,
     FourMomentumX,
     FourMomentumY,
     FourMomentumZ,
@@ -45,6 +47,23 @@ def helicity_angles(
 ) -> Dict[str, sp.Expr]:
     topology, momentum_symbols = topology_and_momentum_symbols
     return compute_helicity_angles(momentum_symbols, topology)
+
+
+class TestBoostZMatrix:
+    def test_boost_into_own_rest_frame_gives_mass(self):
+        p = FourMomentumSymbol("p")
+        expr = BoostZMatrix(ThreeMomentumNorm(p) / Energy(p))
+        func = sp.lambdify(p, expr.doit())
+        p_array = np.array([[5, 0, 0, 1]])
+        boost_z = func(p_array)[0]
+        boosted_array = np.einsum("...ij,...j->...i", boost_z, p_array)
+        mass = 4.89897949
+        assert pytest.approx(boosted_array[0]) == [mass, 0, 0, 0]
+
+        expr = InvariantMass(p)
+        func = sp.lambdify(p, expr.doit())
+        mass_array = func(p_array)
+        assert pytest.approx(mass_array[0]) == mass
 
 
 class TestFourMomentumXYZ:


### PR DESCRIPTION
`ArrayMultiplication` lambdified to a recursive call to [`einsum()`](https://numpy.org/doc/stable/reference/generated/numpy.einsum.html), which results in larger lambdified code. This PR lambdifies the code to an einsum path, e.g. `...ij,...jk->...i`.