### PR TITLE
build: upgrade to QRules v0.9.6

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -152,7 +152,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.5
+qrules==0.9.6
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -194,7 +194,7 @@ types-docutils==0.17.4
 types-pkg-resources==0.1.3
 types-requests==2.27.7
 types-setuptools==57.4.8
-types-urllib3==1.26.7
+types-urllib3==1.26.8
 typing-extensions==4.0.1
 urllib3==1.26.8
 virtualenv==20.13.0

--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -148,7 +148,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.5
+qrules==0.9.6
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -190,7 +190,7 @@ types-docutils==0.17.4
 types-pkg-resources==0.1.3
 types-requests==2.27.7
 types-setuptools==57.4.8
-types-urllib3==1.26.7
+types-urllib3==1.26.8
 typing-extensions==4.0.1 ; python_version < "3.8.0"
 urllib3==1.26.8
 virtualenv==20.13.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -149,7 +149,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.5
+qrules==0.9.6
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -191,7 +191,7 @@ types-docutils==0.17.4
 types-pkg-resources==0.1.3
 types-requests==2.27.7
 types-setuptools==57.4.8
-types-urllib3==1.26.7
+types-urllib3==1.26.8
 typing-extensions==4.0.1 ; python_version < "3.8.0"
 urllib3==1.26.8
 virtualenv==20.13.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -153,7 +153,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.5
+qrules==0.9.6
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -195,7 +195,7 @@ types-docutils==0.17.4
 types-pkg-resources==0.1.3
 types-requests==2.27.7
 types-setuptools==57.4.8
-types-urllib3==1.26.7
+types-urllib3==1.26.8
 typing-extensions==4.0.1
 urllib3==1.26.8
 virtualenv==20.13.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -152,7 +152,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.5
+qrules==0.9.6
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -194,7 +194,7 @@ types-docutils==0.17.4
 types-pkg-resources==0.1.3
 types-requests==2.27.7
 types-setuptools==57.4.8
-types-urllib3==1.26.7
+types-urllib3==1.26.8
 typing-extensions==4.0.1
 urllib3==1.26.8
 virtualenv==20.13.0

--- a/tests/test_angular_distributions.py
+++ b/tests/test_angular_distributions.py
@@ -85,28 +85,28 @@ class TestEpemToDmD0Pip:
         ("angular_variables", "expected_distribution_function"),
         [
             (  # cos(theta) distribution from epem decay
-                "theta_1+2",
-                1 + sp.cos(sp.Symbol("theta_1+2", real=True)) ** 2,
+                "theta_0+2",
+                1 + sp.cos(sp.Symbol("theta_0+2", real=True)) ** 2,
             ),
             (  # phi distribution of the epem decay
-                "phi_1+2",
+                "phi_0+2",
                 1,
             ),
             (  # cos(theta') distribution from D2*
-                "theta_1,1+2",
+                "theta_0,0+2",
                 1
-                - (2 * sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2 - 1)
+                - (2 * sp.cos(sp.Symbol("theta_0,0+2", real=True)) ** 2 - 1)
                 ** 2,
             ),
             (  # phi' distribution of the D2* decay
-                "phi_1,1+2",
-                3 - 2 * sp.sin(sp.Symbol("phi_1,1+2", real=True)) ** 2,
+                "phi_0,0+2",
+                3 - 2 * sp.sin(sp.Symbol("phi_0,0+2", real=True)) ** 2,
             ),
             (  # 2d distribution of the D2* decay
-                ["theta_1,1+2", "phi_1,1+2"],
-                (1 - sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2)
-                * (sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2)
-                * (2 + sp.cos(2 * sp.Symbol("phi_1,1+2", real=True))),
+                ["theta_0,0+2", "phi_0,0+2"],
+                (1 - sp.cos(sp.Symbol("theta_0,0+2", real=True)) ** 2)
+                * (sp.cos(sp.Symbol("theta_0,0+2", real=True)) ** 2)
+                * (2 + sp.cos(2 * sp.Symbol("phi_0,0+2", real=True))),
             ),
         ],
     )
@@ -117,9 +117,9 @@ class TestEpemToDmD0Pip:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,1+2",
-            "theta_1+2",
-            "theta_1,1+2",
+            "phi_0,0+2",
+            "theta_0+2",
+            "theta_0,0+2",
         }
 
         if isinstance(angular_variables, str):
@@ -182,22 +182,22 @@ class TestD1ToD0PiPi:
         ("angular_variables", "expected_distribution_function"),
         [
             (  # theta distribution from D1 decay
-                "theta_1+2",
+                "theta_0+2",
                 sp.Rational(5, 4)
                 + sp.Rational(3, 4)
-                * sp.cos(sp.Symbol("theta_1+2", real=True)) ** 2,
+                * sp.cos(sp.Symbol("theta_0+2", real=True)) ** 2,
             ),
             (  # theta distribution from D*
-                "theta_1,1+2",
+                "theta_0,0+2",
                 1
                 - sp.Rational(3, 4)
-                * sp.cos(sp.Symbol("theta_1,1+2", real=True)) ** 2,
+                * sp.cos(sp.Symbol("theta_0,0+2", real=True)) ** 2,
             ),
             (  # phi distribution of the D* decay
-                "phi_1,1+2",
+                "phi_0,0+2",
                 1
                 - sp.Rational(4, 9)
-                * sp.cos(2 * sp.Symbol("phi_1,1+2", real=True)),
+                * sp.cos(2 * sp.Symbol("phi_0,0+2", real=True)),
             ),
         ],
     )
@@ -208,9 +208,9 @@ class TestD1ToD0PiPi:
         sympy_model: sp.Expr,
     ) -> None:
         assert {s.name for s in sympy_model.free_symbols} == {
-            "phi_1,1+2",
-            "theta_1+2",
-            "theta_1,1+2",
+            "phi_0,0+2",
+            "theta_0+2",
+            "theta_0,0+2",
         }
 
         if isinstance(angular_variables, str):


### PR DESCRIPTION
See release notes [QRules v0.9.6](https://github.com/ComPWA/qrules/releases/tag/0.9.6). Required for a consistent determination of opposite helicity states, see #212.

_Note that this can change helicity angle labels! See a324c9e_