### PR TITLE
refactor: extract NumPyPrintable class

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -90,6 +90,7 @@
         "isospin",
         "itertools",
         "jupyter",
+        "lambdification",
         "lambdified",
         "lambdify",
         "lineshape",

--- a/.flake8
+++ b/.flake8
@@ -51,6 +51,7 @@ rst-roles =
     ref
     term
 rst-directives =
+    autolink-preface
     automethod
     deprecated
     envvar

--- a/.flake8
+++ b/.flake8
@@ -51,6 +51,7 @@ rst-roles =
     ref
     term
 rst-directives =
+    automethod
     deprecated
     envvar
     exception

--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -18,6 +18,7 @@ from sphinx.environment import BuildEnvironment
 __TARGET_SUBSTITUTIONS = {
     "sp.Expr": "sympy.core.expr.Expr",
     "sp.Symbol": "sympy.core.symbol.Symbol",
+    "sympy.printing.numpy.NumPyPrinter": "sympy.printing.printer.Printer",
     "typing_extensions.Protocol": "typing.Protocol",
 }
 __REF_TYPE_SUBSTITUTIONS = {

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -15,6 +15,7 @@ from sympy.printing.latex import LatexPrinter
 from sympy.printing.numpy import NumPyPrinter
 
 from ampform.sympy import (
+    NumPyPrintable,
     UnevaluatedExpression,
     _implement_latex_subscript,
     create_expression,
@@ -243,7 +244,7 @@ class FourMomentumZ(UnevaluatedExpression):
 
 @implement_doit_method
 @make_commutative
-class ThreeMomentumNorm(UnevaluatedExpression):
+class ThreeMomentumNorm(NumPyPrintable, UnevaluatedExpression):
     """Norm of the three-momentum of a `FourMomentumSymbol`."""
 
     def __new__(
@@ -333,7 +334,7 @@ class Theta(UnevaluatedExpression):
         return Rf"\theta\left({momentum}\right)"
 
 
-class BoostZMatrix(sp.Expr):
+class BoostZMatrix(NumPyPrintable):
     """Represents a Lorentz boost matrix in the :math:`z`-direction."""
 
     def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZMatrix":
@@ -379,7 +380,7 @@ class BoostZMatrix(sp.Expr):
         ).transpose((2, 0, 1))"""
 
 
-class RotationYMatrix(sp.Expr):
+class RotationYMatrix(NumPyPrintable):
     """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`."""
 
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationYMatrix":
@@ -424,7 +425,7 @@ class RotationYMatrix(sp.Expr):
         ).transpose((2, 0, 1))"""
 
 
-class RotationZMatrix(sp.Expr):
+class RotationZMatrix(NumPyPrintable):
     """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`."""
 
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZMatrix":

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -11,12 +11,14 @@ from sympy.printing.latex import LatexPrinter
 
 
 class UnevaluatedExpression(sp.Expr):
-    """Base class for classes that expressions with an ``evaluate()`` method.
+    """Base class for classes that expressions with an :meth:`evaluate` method.
 
     Derive from this class when decorating a class with :func:`implement_expr`
     or :func:`implement_doit_method`. It is important to derive from
-    `UnevaluatedExpression`, because an :code:`evaluate()` method has to be
+    `UnevaluatedExpression`, because an :meth:`evaluate` method has to be
     implemented.
+
+    .. automethod:: evaluate
     """
 
     # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L74-L77
@@ -44,7 +46,7 @@ class UnevaluatedExpression(sp.Expr):
 
     @abstractmethod
     def evaluate(self) -> sp.Expr:
-        pass
+        """Unfold this `~sympy.core.expr.Expr`."""
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
         """Provide a mathematical Latex representation for notebooks."""

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -12,14 +12,31 @@ from sympy.printing.numpy import NumPyPrinter
 
 
 class UnevaluatedExpression(sp.Expr):
-    """Base class for classes that expressions with an :meth:`evaluate` method.
+    """Base class for expression classes with an :meth:`evaluate` method.
 
-    Derive from this class when decorating a class with :func:`implement_expr`
-    or :func:`implement_doit_method`. It is important to derive from
-    `UnevaluatedExpression`, because an :meth:`evaluate` method has to be
-    implemented.
+    Deriving from `~sympy.core.expr.Expr` allows us to keep expression trees
+    condense before unfolding them with their `~sympy.core.basic.Basic.doit`
+    method. This allows us to:
 
+    1. condense the LaTeX representation of an expression tree by providing a
+       custom :meth:`_latex` method.
+    2. overwrite its printer methods (see `NumPyPrintable` and e.g.
+       :doc:`compwa-org:report/001`).
+
+    The `UnevaluatedExpression` base class makes implementations of its derived
+    classes more secure by enforcing the developer to provide implementations
+    for these methods, so that SymPy mechanisms work correctly. Decorators like
+    :func:`implement_expr` and :func:`implement_doit_method` provide convenient
+    means to implement the missing methods.
+
+    .. autolink-preface::
+
+        import sympy as sp
+        from ampform.sympy import UnevaluatedExpression, create_expression
+
+    .. automethod:: __new__
     .. automethod:: evaluate
+    .. automethod:: _latex
     """
 
     # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L74-L77
@@ -30,6 +47,30 @@ class UnevaluatedExpression(sp.Expr):
     def __new__(  # pylint: disable=unused-argument
         cls, *args: Any, name: Optional[str] = None, **hints: Any
     ) -> "UnevaluatedExpression":
+        """Constructor for a class derived from `UnevaluatedExpression`.
+
+        This :meth:`~object.__new__` method correctly sets the
+        `~sympy.core.basic.Basic.args`, assumptions etc. Overwrite it in order
+        to further specify its signature. The function
+        :func:`create_expression` can be used in its implementation, like so:
+
+        >>> class MyExpression(UnevaluatedExpression):
+        ...    def __new__(
+        ...        cls, x: sp.Symbol, y: sp.Symbol, n: int, **hints
+        ...    ) -> "MyExpression":
+        ...        return create_expression(cls, x, y, n, **hints)
+        ...
+        ...    def evaluate(self) -> sp.Expr:
+        ...        x, y, n = self.args
+        ...        return (x + y)**n
+        ...
+        >>> x, y = sp.symbols("x y")
+        >>> expr = MyExpression(x, y, n=3)
+        >>> expr
+        MyExpression(x, y, 3)
+        >>> expr.evaluate()
+        (x + y)**3
+        """
         # https://github.com/sympy/sympy/blob/1.8/sympy/core/basic.py#L113-L119
         obj = object.__new__(cls)
         obj._args = args
@@ -47,10 +88,38 @@ class UnevaluatedExpression(sp.Expr):
 
     @abstractmethod
     def evaluate(self) -> sp.Expr:
-        """Unfold this `~sympy.core.expr.Expr`."""
+        """Evaluate and 'unfold' this `UnevaluatedExpression` by one level.
+
+        >>> from ampform.dynamics import BreakupMomentumSquared
+        >>> issubclass(BreakupMomentumSquared, UnevaluatedExpression)
+        True
+        >>> s, m1, m2 = sp.symbols("s m1 m2")
+        >>> expr = BreakupMomentumSquared(s, m1, m2)
+        >>> expr
+        BreakupMomentumSquared(s, m1, m2)
+        >>> expr.evaluate()
+        (s - (m1 - m2)**2)*(s - (m1 + m2)**2)/(4*s)
+        >>> expr.doit(deep=False)
+        (s - (m1 - m2)**2)*(s - (m1 + m2)**2)/(4*s)
+
+        .. note:: When decorating this class with :func:`implement_doit_method`,
+            its :meth:`evaluate` method is equivalent to
+            :meth:`~sympy.core.basic.Basic.doit` with :code:`deep=False`.
+        """
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        """Provide a mathematical Latex representation for notebooks."""
+        r"""Provide a mathematical Latex representation for pretty printing.
+
+        >>> from ampform.dynamics import BreakupMomentumSquared
+        >>> issubclass(BreakupMomentumSquared, UnevaluatedExpression)
+        True
+        >>> s, m1 = sp.symbols("s m1")
+        >>> expr = BreakupMomentumSquared(s, m1, m1)
+        >>> print(sp.latex(expr))
+        q^2\left(s\right)
+        >>> print(sp.latex(expr.doit()))
+        - m_{1}^{2} + \frac{s}{4}
+        """
         args = tuple(map(printer._print, self.args))
         name = self.__class__.__name__
         if self._name is not None:
@@ -213,10 +282,7 @@ def create_expression(
     name: Optional[str] = None,
     **kwargs: Any,
 ) -> sp.Expr:
-    """Helper function for implementing :code:`Expr.__new__`.
-
-    See e.g. source code of `.BlattWeisskopfSquared`.
-    """
+    """Helper function for implementing `UnevaluatedExpression.__new__`."""
     args = sp.sympify(args)
     expr = UnevaluatedExpression.__new__(cls, *args, name=name, **kwargs)
     if evaluate:

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -171,7 +171,7 @@ class NumPyPrintable(sp.Expr):
 
 
 DecoratedClass = TypeVar("DecoratedClass", bound=UnevaluatedExpression)
-"""`~typing.TypeVar` for decorators like `make_commutative`."""
+"""`~typing.TypeVar` for decorators like :func:`make_commutative`."""
 
 
 def implement_expr(
@@ -179,9 +179,9 @@ def implement_expr(
 ) -> Callable[[Type[DecoratedClass]], Type[DecoratedClass]]:
     """Decorator for classes that derive from `UnevaluatedExpression`.
 
-    Implement a `~object.__new__` and `~sympy.core.basic.Basic.doit` method for
-    a class that derives from `~sympy.core.expr.Expr` (via
-    `UnevaluatedExpression`).
+    Implement a :meth:`~object.__new__` and
+    :meth:`~sympy.core.basic.Basic.doit` method for a class that derives from
+    `~sympy.core.expr.Expr` (via `UnevaluatedExpression`).
     """
 
     def decorator(
@@ -197,9 +197,9 @@ def implement_expr(
 def implement_new_method(
     n_args: int,
 ) -> Callable[[Type[DecoratedClass]], Type[DecoratedClass]]:
-    """Implement ``__new__()`` method for an `UnevaluatedExpression` class.
+    """Implement :meth:`UnevaluatedExpression.__new__` on a derived class.
 
-    Implement a `~object.__new__` method for a class that derives from
+    Implement a :meth:`~object.__new__` method for a class that derives from
     `~sympy.core.expr.Expr` (via `UnevaluatedExpression`).
     """
 
@@ -233,8 +233,11 @@ def implement_doit_method(
 ) -> Type[DecoratedClass]:
     """Implement ``doit()`` method for an `UnevaluatedExpression` class.
 
-    Implement a `~sympy.core.basic.Basic.doit` method for a class that derives
-    from `~sympy.core.expr.Expr` (via `UnevaluatedExpression`).
+    Implement a :meth:`~sympy.core.basic.Basic.doit` method for a class that
+    derives from `~sympy.core.expr.Expr` (via `UnevaluatedExpression`). A
+    :meth:`~sympy.core.basic.Basic.doit` method is an extension of an
+    :meth:`~.UnevaluatedExpression.evaluate` method in the sense that it can
+    work recursively on deeper expression trees.
     """
 
     @functools.wraps(decorated_class.doit)  # type: ignore[attr-defined]
@@ -273,6 +276,10 @@ def _implement_latex_subscript(  # pyright: reportUnusedFunction=false
 def make_commutative(
     decorated_class: Type[DecoratedClass],
 ) -> Type[DecoratedClass]:
+    """Set commutative and 'extended real' assumptions on expression class.
+
+    .. seealso:: :doc:`sympy:guides/assumptions`
+    """
     decorated_class.is_commutative = True  # type: ignore[attr-defined]
     decorated_class.is_extended_real = True  # type: ignore[attr-defined]
     return decorated_class

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -45,8 +45,11 @@ class UnevaluatedExpression(sp.Expr):
     """Optional instance attribute that can be used in LaTeX representations."""
 
     def __new__(  # pylint: disable=unused-argument
-        cls, *args: Any, name: Optional[str] = None, **hints: Any
-    ) -> "UnevaluatedExpression":
+        cls: Type["DecoratedClass"],
+        *args: Any,
+        name: Optional[str] = None,
+        **hints: Any,
+    ) -> "DecoratedClass":
         """Constructor for a class derived from `UnevaluatedExpression`.
 
         This :meth:`~object.__new__` method correctly sets the

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -55,13 +55,13 @@ class UnevaluatedExpression(sp.Expr):
         return f"{name}{args}"
 
 
-DecoratedClass = TypeVar("DecoratedClass")
+DecoratedClass = TypeVar("DecoratedClass", bound=UnevaluatedExpression)
 """`~typing.TypeVar` for decorators like `make_commutative`."""
 
 
 def implement_expr(
     n_args: int,
-) -> Callable[[DecoratedClass], DecoratedClass]:
+) -> Callable[[Type[DecoratedClass]], Type[DecoratedClass]]:
     """Decorator for classes that derive from `UnevaluatedExpression`.
 
     Implement a `~object.__new__` and `~sympy.core.basic.Basic.doit` method for
@@ -69,7 +69,9 @@ def implement_expr(
     `UnevaluatedExpression`).
     """
 
-    def decorator(decorated_class: DecoratedClass) -> DecoratedClass:
+    def decorator(
+        decorated_class: Type[DecoratedClass],
+    ) -> Type[DecoratedClass]:
         decorated_class = implement_new_method(n_args)(decorated_class)
         decorated_class = implement_doit_method(decorated_class)
         return decorated_class
@@ -79,14 +81,16 @@ def implement_expr(
 
 def implement_new_method(
     n_args: int,
-) -> Callable[[DecoratedClass], DecoratedClass]:
+) -> Callable[[Type[DecoratedClass]], Type[DecoratedClass]]:
     """Implement ``__new__()`` method for an `UnevaluatedExpression` class.
 
     Implement a `~object.__new__` method for a class that derives from
     `~sympy.core.expr.Expr` (via `UnevaluatedExpression`).
     """
 
-    def decorator(decorated_class: DecoratedClass) -> DecoratedClass:
+    def decorator(
+        decorated_class: Type[DecoratedClass],
+    ) -> Type[DecoratedClass]:
         def new_method(  # pylint: disable=unused-argument
             cls: Type,
             *args: sp.Symbol,
@@ -109,7 +113,9 @@ def implement_new_method(
     return decorator
 
 
-def implement_doit_method(decorated_class: DecoratedClass) -> DecoratedClass:
+def implement_doit_method(
+    decorated_class: Type[DecoratedClass],
+) -> Type[DecoratedClass]:
     """Implement ``doit()`` method for an `UnevaluatedExpression` class.
 
     Implement a `~sympy.core.basic.Basic.doit` method for a class that derives
@@ -149,7 +155,9 @@ def _implement_latex_subscript(  # pyright: reportUnusedFunction=false
     return decorator
 
 
-def make_commutative(decorated_class: DecoratedClass) -> DecoratedClass:
+def make_commutative(
+    decorated_class: Type[DecoratedClass],
+) -> Type[DecoratedClass]:
     decorated_class.is_commutative = True  # type: ignore[attr-defined]
     decorated_class.is_extended_real = True  # type: ignore[attr-defined]
     return decorated_class


### PR DESCRIPTION
API of the [`ampform.sympy`](https://ampform--213.org.readthedocs.build/en/213/api/ampform.sympy.html) module has become more self-explanatory through the addition of a [`NumPyPrintable`](https://ampform--213.org.readthedocs.build/en/213/api/ampform.sympy.html#ampform.sympy.NumPyPrintable) interface and several explanations and doctests in related classes and decorator functions. Preview [here](https://ampform--213.org.readthedocs.build/en/213/api/ampform.sympy.html).