### PR TITLE
feat: wrap parameter_defaults in ParameterValues class

### DIFF
--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -16,6 +16,7 @@ from sphinx.addnodes import pending_xref
 from sphinx.environment import BuildEnvironment
 
 __TARGET_SUBSTITUTIONS = {
+    "ampform.helicity._T": "typing.TypeVar",
     "sp.Expr": "sympy.core.expr.Expr",
     "sp.Symbol": "sympy.core.symbol.Symbol",
     "sympy.printing.numpy.NumPyPrinter": "sympy.printing.printer.Printer",

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -115,7 +115,7 @@ class ParameterValues(abc.Mapping):
                 f"Parameter mapping has {len(self)} keys, but trying to"
                 f" get item {__k}"
             )
-        raise TypeError(
+        raise KeyError(  # no TypeError because of sympy.core.expr.Expr.xreplace
             f"Cannot get parameter value for key type {type(__k).__name__}"
         )
 
@@ -144,7 +144,7 @@ class ParameterValues(abc.Mapping):
                 f"Parameter mapping has {len(self)} keys, but trying to"
                 f" set item {__k}"
             )
-        raise TypeError(
+        raise KeyError(  # no TypeError because of sympy.core.expr.Expr.xreplace
             f"Cannot set parameter value for key type {type(__k).__name__}"
         )
 

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -1,21 +1,28 @@
-# pylint: disable=import-outside-toplevel
-"""Generate an amplitude model with the helicity formalism."""
+# pylint: disable=import-outside-toplevel, too-many-arguments, too-many-lines
+"""Generate an amplitude model with the helicity formalism.
+
+.. autolink-preface::
+
+    import sympy as sp
+"""
 
 import collections
 import logging
 import operator
-from collections import OrderedDict
+from collections import OrderedDict, abc
 from difflib import get_close_matches
 from functools import reduce
 from typing import (
     DefaultDict,
     Dict,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
     Set,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -54,9 +61,12 @@ def _order_component_mapping(
     )
 
 
+_T = TypeVar("_T")
+
+
 def _order_symbol_mapping(
-    mapping: Mapping[sp.Symbol, sp.Expr]
-) -> "OrderedDict[sp.Symbol, sp.Expr]":
+    mapping: Mapping[sp.Symbol, _T]  # type: ignore[valid-type]
+) -> "OrderedDict[sp.Symbol, _T]":
     return collections.OrderedDict(
         [
             (symbol, mapping[symbol])
@@ -67,14 +77,90 @@ def _order_symbol_mapping(
     )
 
 
+class ParameterValues(abc.Mapping):
+    """Ordered mapping to `ParameterValue` with convenient getter and setter.
+
+    >>> a, b, c = sp.symbols("a b c")
+    >>> parameters = ParameterValues({a: 0.0, b: 1+1j, c: -2})
+    >>> parameters[a]
+    0.0
+    >>> parameters["b"]
+    (1+1j)
+    >>> parameters["b"] = 3
+    >>> parameters[1]
+    3
+    >>> parameters[2]
+    -2
+    >>> parameters[2] = 3.14
+    >>> parameters[c]
+    3.14
+    """
+
+    def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
+        self.__mapping = _order_symbol_mapping(mapping)
+
+    def __getitem__(self, __k: Union[sp.Symbol, int, str]) -> ParameterValue:
+        if isinstance(__k, sp.Symbol):
+            return self.__mapping[__k]
+        if isinstance(__k, str):
+            for symbol, value in self.__mapping.items():
+                if symbol.name == __k:
+                    return value
+            raise KeyError(f'No parameter available with name "{__k}"')
+        if isinstance(__k, int):
+            for i, value in enumerate(self.__mapping.values()):
+                if i == __k:
+                    return value
+            raise KeyError(
+                f"Parameter mapping has {len(self)} keys, but trying to"
+                f" get item {__k}"
+            )
+        raise TypeError(
+            f"Cannot get parameter value for key type {type(__k).__name__}"
+        )
+
+    def __setitem__(  # noqa: R701
+        self, __k: Union[sp.Symbol, int, str], __v: ParameterValue
+    ) -> None:
+        try:
+            self[__k]
+        except KeyError as e:
+            raise KeyError("Not allowed to define new items") from e
+        if isinstance(__k, sp.Symbol):
+            self.__mapping[__k] = __v
+            return
+        if isinstance(__k, str):
+            for symbol in self.__mapping:
+                if symbol.name == __k:
+                    self.__mapping[symbol] = __v
+                    return
+            raise KeyError(f'No parameter available with name "{__k}"')
+        if isinstance(__k, int):
+            for i, symbol in enumerate(self.__mapping):
+                if i == __k:
+                    self.__mapping[symbol] = __v
+                    return
+            raise KeyError(
+                f"Parameter mapping has {len(self)} keys, but trying to"
+                f" set item {__k}"
+            )
+        raise TypeError(
+            f"Cannot set parameter value for key type {type(__k).__name__}"
+        )
+
+    def __len__(self) -> int:
+        return len(self.__mapping)
+
+    def __iter__(self) -> Iterator[sp.Symbol]:
+        return iter(self.__mapping)
+
+
 @attr.frozen
 class HelicityModel:  # noqa: R701
     expression: sp.Expr = attr.ib(
         validator=attr.validators.instance_of(sp.Expr)
     )
-    parameter_defaults: "OrderedDict[sp.Symbol, ParameterValue]" = attr.ib(
-        converter=_order_symbol_mapping
-    )
+    parameter_defaults: ParameterValues = attr.ib(converter=ParameterValues)
     """A mapping of suggested parameter values.
 
     Keys are `~sympy.core.symbol.Symbol` instances from the main

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -254,7 +254,7 @@ def _merge_args_kwargs(
     """
     output_dict = {}
     for arg in args:
-        if not isinstance(arg, dict):
+        if not isinstance(arg, abc.Mapping):
             raise TypeError("Positional arguments have to be of type dict")
         output_dict.update(arg)
     output_dict.update(kwargs)

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-member, no-self-use
+
 from typing import Tuple
 
 import pytest
@@ -9,6 +10,7 @@ from ampform import get_builder
 from ampform.helicity import (
     HelicityAmplitudeBuilder,
     HelicityModel,
+    ParameterValues,
     _generate_kinematic_variables,
     formulate_wigner_d,
     group_transitions,
@@ -140,6 +142,19 @@ class TestHelicityModel:
                 )
                 selected_intensity = next(selected_intensities)
                 assert from_amplitudes == model.components[selected_intensity]
+
+
+class TestParameterValues:
+    @pytest.mark.parametrize("subs_method", ["subs"])
+    def test_subs_xreplace(self, subs_method: str):
+        a, b, x, y = sp.symbols("a b x y")
+        expr: sp.Expr = a * x + b * y
+        parameters = ParameterValues({a: 2, b: -3})
+        if subs_method == "subs":
+            expr = expr.subs(parameters)
+        elif subs_method == "xreplace":
+            expr = expr.xreplace(parameters)
+        assert expr == 2 * x - 3 * y
 
 
 @pytest.mark.parametrize(

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -145,7 +145,7 @@ class TestHelicityModel:
 
 
 class TestParameterValues:
-    @pytest.mark.parametrize("subs_method", ["subs"])
+    @pytest.mark.parametrize("subs_method", ["subs", "xreplace"])
     def test_subs_xreplace(self, subs_method: str):
         a, b, x, y = sp.symbols("a b x y")
         expr: sp.Expr = a * x + b * y
@@ -154,6 +154,8 @@ class TestParameterValues:
             expr = expr.subs(parameters)
         elif subs_method == "xreplace":
             expr = expr.xreplace(parameters)
+        else:
+            raise NotImplementedError
         assert expr == 2 * x - 3 * y
 
 


### PR DESCRIPTION
#228 has made some parameter names even longer and harder to get with `dict.__getitem__()`. This PR wraps the `parameter_defaults` in a `ParameterValues` class that allows doing stuff like:

```python
>>> import sympy as sp
>>> a, b, c = sp.symbols("a b c")
>>> from ampform.helicity import ParameterValues
>>> parameters = ParameterValues({a: 0.0, b: 1+1j, c: -2})
>>> parameters[a]  # get by sympy.Symbol
0.0
>>> parameters["b"]  # get by str name
(1+1j)
>>> parameters["b"] = 3  # get by position in OrderedDict
>>> parameters[1]
3
>>> parameters[2]
-2
>>> parameters[2] = 3.14  # set by position in OrderedDict
>>> parameters[c]
3.14
```

Note that, as opposed to the previously used `OrderedDict`, this class prevents users from adding more parameters to the `parameter_defaults`.