### PR TITLE
fix: check for angular momentum in form factor

### DIFF
--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -728,13 +728,17 @@ def _generate_kinematic_variable_set(
         get_invariant_mass_label(transition.topology, decay.children[1].id),
         real=True,
     )
+    angular_momentum: Optional[int] = decay.interaction.l_magnitude
+    if angular_momentum is None:
+        if decay.parent.particle.spin.is_integer():
+            angular_momentum = int(decay.parent.particle.spin)
     return TwoBodyKinematicVariableSet(
         incoming_state_mass=inv_mass,
         outgoing_state_mass1=child1_mass,
         outgoing_state_mass2=child2_mass,
         helicity_theta=theta,
         helicity_phi=phi,
-        angular_momentum=decay.extract_angular_momentum(),
+        angular_momentum=angular_momentum,
     )
 
 

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -79,18 +79,6 @@ class TwoBodyDecay:
             interaction=transition.interactions[node_id],
         )
 
-    def extract_angular_momentum(self) -> int:
-        angular_momentum = self.interaction.l_magnitude
-        if angular_momentum is not None:
-            return angular_momentum
-        spin_magnitude = self.parent.particle.spin
-        if spin_magnitude.is_integer():
-            return int(spin_magnitude)
-        raise ValueError(
-            f"Spin magnitude ({spin_magnitude}) of single particle state"
-            " cannot be used as the angular momentum as it is not integral!"
-        )
-
 
 def get_helicity_info(
     transition: StateTransition, node_id: int

--- a/tests/helicity/test_decay.py
+++ b/tests/helicity/test_decay.py
@@ -1,60 +1,7 @@
 # pylint: disable=no-member, no-self-use
-from typing import Optional
-
-import pytest
-from qrules.particle import Particle
-from qrules.quantum_numbers import InteractionProperties
 from qrules.topology import create_isobar_topologies
 
-from ampform.helicity.decay import (
-    StateWithID,
-    TwoBodyDecay,
-    determine_attached_final_state,
-)
-
-
-def _create_dummy_decay(
-    l_magnitude: Optional[int], spin_magnitude: float
-) -> TwoBodyDecay:
-    dummy = Particle(name="dummy", pid=123, spin=spin_magnitude, mass=1.0)
-    return TwoBodyDecay(
-        parent=StateWithID(
-            id=0, particle=dummy, spin_projection=spin_magnitude
-        ),
-        children=(
-            StateWithID(id=1, particle=dummy, spin_projection=0.0),
-            StateWithID(id=2, particle=dummy, spin_projection=0.0),
-        ),
-        interaction=InteractionProperties(l_magnitude=l_magnitude),
-    )
-
-
-class TestTwoBodyDecay:
-    @pytest.mark.parametrize(
-        ("decay", "expected_l"),
-        [
-            (_create_dummy_decay(1, 0.5), 1),
-            (_create_dummy_decay(0, 1.0), 0),
-            (_create_dummy_decay(2, 1.0), 2),
-            (_create_dummy_decay(None, 0.0), 0),
-            (_create_dummy_decay(None, 1.0), 1),
-        ],
-    )
-    def test_extract_angular_momentum(
-        self, decay: TwoBodyDecay, expected_l: int
-    ):
-        assert expected_l == decay.extract_angular_momentum()
-
-    @pytest.mark.parametrize(
-        "decay",
-        [
-            _create_dummy_decay(None, 0.5),
-            _create_dummy_decay(None, 1.5),
-        ],
-    )
-    def test_invalid_angular_momentum(self, decay: TwoBodyDecay):
-        with pytest.raises(ValueError, match="not integral"):
-            decay.extract_angular_momentum()
+from ampform.helicity.decay import determine_attached_final_state
 
 
 def test_determine_attached_final_state():

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ description =
 allowlist_externals =
     pytest
 commands =
-    pytest {posargs:tests} \
+    pytest {posargs:src tests} \
         --cov-fail-under=75 \
         --cov-report=html \
         --cov-report=xml \


### PR DESCRIPTION
Removed the check for integral angular momentum. Instead, AmpForm now checks for angular momentum when formulating a form factor. This allows formulating Breit-Wigner dynamics _without_ form factor on an amplitude model formulated with `formalism="helicity"` if it has with half-spin resonances.