### PR TITLE
chore: simplify numpy code of matrix expressions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -190,6 +190,7 @@
         "kmatrix",
         "kutschke",
         "kwargs",
+        "lambdifygenerated",
         "linestyle",
         "linewidth",
         "linkcheck",

--- a/.cspell.json
+++ b/.cspell.json
@@ -191,6 +191,7 @@
         "kutschke",
         "kwargs",
         "lambdifygenerated",
+        "lambdifying",
         "linestyle",
         "linewidth",
         "linkcheck",

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -21,6 +21,7 @@ from sympy.printing.numpy import NumPyPrinter
 
 from ampform.kinematics import FourMomentumSymbol, _ArraySize
 from ampform.sympy import NumPyPrintable
+from ampform.sympy._array_expressions import ArrayMultiplication
 
 logging.getLogger().setLevel(logging.ERROR)
 
@@ -86,6 +87,41 @@ def extend_BoostZMatrix() -> None:
         BoostZMatrix(b, n_events=_ArraySize(b)).doit(),
         use_cse=True,
         docstring_class=BoostZMatrix,
+    )
+
+    from ampform.kinematics import RotationYMatrix, RotationZMatrix
+
+    _append_to_docstring(
+        BoostZMatrix,
+        """
+    Note that this code was generated with :func:`sympy.lambdify
+    <sympy.utilities.lambdify.lambdify>` with :code:`cse=True` (using
+    :func:`.cse_all_symbols`, to be more precise). The repetition of
+    :func:`numpy.ones` is still bothersome, but these sub-nodes is also
+    extracted by :func:`sympy.cse <sympy.simplify.cse_main.cse>` if the
+    expression is nested further down in an :doc:`expression tree
+    <sympy:tutorial/manipulation>`, for instance when boosting a
+    `.FourMomentumSymbol` :math:`p` in the :math:`z`-direction:
+    """,
+    )
+    p, beta, phi, theta = sp.symbols("p beta phi theta")
+    expr = ArrayMultiplication(
+        BoostZMatrix(beta, n_events=_ArraySize(p)),
+        RotationYMatrix(theta, n_events=_ArraySize(p)),
+        RotationZMatrix(phi, n_events=_ArraySize(p)),
+        p,
+    )
+    _append_to_docstring(
+        BoostZMatrix,
+        f"""\n
+    .. math:: {sp.latex(expr)}
+        :label: boost-in-z-direction
+
+    which in :mod:`numpy` code becomes:
+    """,
+    )
+    _append_code_rendering(
+        expr.doit(), use_cse=True, docstring_class=BoostZMatrix
     )
 
 

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -19,7 +19,7 @@ import qrules
 import sympy as sp
 from sympy.printing.numpy import NumPyPrinter
 
-from ampform.kinematics import FourMomentumSymbol
+from ampform.kinematics import FourMomentumSymbol, _ArraySize
 from ampform.sympy import NumPyPrintable
 
 logging.getLogger().setLevel(logging.ERROR)
@@ -83,7 +83,7 @@ def extend_BoostZMatrix() -> None:
     )
     b = sp.Symbol("b")
     _append_code_rendering(
-        BoostZMatrix(b, n_events).doit(),
+        BoostZMatrix(b, n_events=_ArraySize(b)).doit(),
         use_cse=True,
         docstring_class=BoostZMatrix,
     )
@@ -282,7 +282,7 @@ def extend_RotationZMatrix() -> None:
     )
     a = sp.Symbol("a")
     _append_code_rendering(
-        RotationZMatrix(a, n_events).doit(),
+        RotationZMatrix(a, n_events=_ArraySize(a)).doit(),
         use_cse=True,
         docstring_class=RotationZMatrix,
     )

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -448,7 +448,7 @@ def _append_code_rendering(
     _append_to_docstring(
         docstring_class,
         f"""\n
-    .. code::
+    .. code-block:: python
 
         {import_statements}
         {numpy_code}

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -82,7 +82,11 @@ def extend_BoostZMatrix() -> None:
     """,
     )
     b = sp.Symbol("b")
-    _append_code_rendering(BoostZMatrix(b))
+    _append_code_rendering(
+        BoostZMatrix(b).doit(),
+        use_cse=True,
+        docstring_class=BoostZMatrix,
+    )
 
 
 def extend_BreakupMomentumSquared() -> None:

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -445,15 +445,25 @@ def _append_code_rendering(
         docstring_class = type(expr)
     numpy_code = textwrap.dedent(numpy_code)
     numpy_code = textwrap.indent(numpy_code, prefix=8 * " ").strip()
-    _append_to_docstring(
-        docstring_class,
-        f"""\n
+    options = ""
+    if (
+        max(__get_text_width(import_statements), __get_text_width(numpy_code))
+        > 90
+    ):
+        options += ":class: full-width\n"
+    appended_text = f"""\n
     .. code-block:: python
-
+        {options}
         {import_statements}
         {numpy_code}
-    """,
-    )
+    """
+    _append_to_docstring(docstring_class, appended_text)
+
+
+def __get_text_width(text: str) -> int:
+    lines = text.split("\n")
+    widths = map(len, lines)
+    return max(widths)
 
 
 def _append_latex_doit_definition(

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -437,10 +437,12 @@ def _append_code_rendering(
     use_cse: bool = False,
     docstring_class: Optional[type] = None,
 ) -> None:
+    from ampform.sympy import cse_all_symbols
+
     printer = NumPyPrinter()
     if use_cse:
         args = sorted(expr.free_symbols, key=str)
-        func = sp.lambdify(args, expr, cse=True, printer=printer)
+        func = sp.lambdify(args, expr, cse=cse_all_symbols, printer=printer)
         numpy_code = inspect.getsource(func)
     else:
         numpy_code = expr._numpycode(printer)

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -95,9 +95,8 @@ def extend_BoostZMatrix() -> None:
         BoostZMatrix,
         """
     Note that this code was generated with :func:`sympy.lambdify
-    <sympy.utilities.lambdify.lambdify>` with :code:`cse=True` (using
-    :func:`.cse_all_symbols`, to be more precise). The repetition of
-    :func:`numpy.ones` is still bothersome, but these sub-nodes is also
+    <sympy.utilities.lambdify.lambdify>` with :code:`cse=True`. The repetition
+    of :func:`numpy.ones` is still bothersome, but these sub-nodes is also
     extracted by :func:`sympy.cse <sympy.simplify.cse_main.cse>` if the
     expression is nested further down in an :doc:`expression tree
     <sympy:tutorial/manipulation>`, for instance when boosting a
@@ -473,12 +472,10 @@ def _append_code_rendering(
     use_cse: bool = False,
     docstring_class: Optional[type] = None,
 ) -> None:
-    from ampform.sympy import cse_all_symbols
-
     printer = NumPyPrinter()
     if use_cse:
         args = sorted(expr.free_symbols, key=str)
-        func = sp.lambdify(args, expr, cse=cse_all_symbols, printer=printer)
+        func = sp.lambdify(args, expr, cse=True, printer=printer)
         numpy_code = inspect.getsource(func)
     else:
         numpy_code = expr._numpycode(printer)

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -84,7 +84,7 @@ def extend_BoostZMatrix() -> None:
     )
     b = sp.Symbol("b")
     _append_code_rendering(
-        BoostZMatrix(b, n_events=_ArraySize(b)).doit(),
+        BoostZMatrix(b).doit(),
         use_cse=True,
         docstring_class=BoostZMatrix,
     )
@@ -317,7 +317,7 @@ def extend_RotationZMatrix() -> None:
     )
     a = sp.Symbol("a")
     _append_code_rendering(
-        RotationZMatrix(a, n_events=_ArraySize(a)).doit(),
+        RotationZMatrix(a).doit(),
         use_cse=True,
         docstring_class=RotationZMatrix,
     )

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -61,8 +61,8 @@ def extend_BlattWeisskopfSquared() -> None:
 def extend_BoostZMatrix() -> None:
     from ampform.kinematics import BoostZMatrix
 
-    beta = sp.Symbol("beta")
-    expr = BoostZMatrix(beta)
+    beta, n_events = sp.symbols("beta n")
+    expr = BoostZMatrix(beta, n_events)
     _append_to_docstring(
         BoostZMatrix,
         f"""\n
@@ -83,7 +83,7 @@ def extend_BoostZMatrix() -> None:
     )
     b = sp.Symbol("b")
     _append_code_rendering(
-        BoostZMatrix(b).doit(),
+        BoostZMatrix(b, n_events).doit(),
         use_cse=True,
         docstring_class=BoostZMatrix,
     )
@@ -240,8 +240,8 @@ def extend_Phi() -> None:
 def extend_RotationYMatrix() -> None:
     from ampform.kinematics import RotationYMatrix
 
-    angle = sp.Symbol("alpha")
-    expr = RotationYMatrix(angle)
+    angle, n_events = sp.symbols("alpha n")
+    expr = RotationYMatrix(angle, n_events)
     _append_to_docstring(
         RotationYMatrix,
         f"""\n
@@ -259,8 +259,8 @@ def extend_RotationYMatrix() -> None:
 def extend_RotationZMatrix() -> None:
     from ampform.kinematics import RotationZMatrix
 
-    angle = sp.Symbol("alpha")
-    expr = RotationZMatrix(angle)
+    angle, n_events = sp.symbols("alpha n")
+    expr = RotationZMatrix(angle, n_events)
     _append_to_docstring(
         RotationZMatrix,
         f"""\n
@@ -282,7 +282,7 @@ def extend_RotationZMatrix() -> None:
     )
     a = sp.Symbol("a")
     _append_code_rendering(
-        RotationZMatrix(a).doit(),
+        RotationZMatrix(a, n_events).doit(),
         use_cse=True,
         docstring_class=RotationZMatrix,
     )

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -321,6 +321,12 @@ def extend_RotationZMatrix() -> None:
         use_cse=True,
         docstring_class=RotationZMatrix,
     )
+    _append_to_docstring(
+        RotationZMatrix,
+        """
+    See also the note that comes with Equation :eq:`boost-in-z-direction`.
+    """,
+    )
 
 
 def extend_Theta() -> None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,9 @@ autodoc_type_aliases = {
 autodoc_typehints_format = "short"
 codeautolink_concat_default = True
 codeautolink_global_preface = """
+import numpy
+import numpy as np
+import sympy as sp
 from IPython.display import display
 """
 AUTODOC_INSERT_SIGNATURE_LINEBREAKS = False

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -340,18 +340,17 @@ class Theta(UnevaluatedExpression):
 
 
 class BoostZMatrix(NumPyPrintable):
-    """Represents a Lorentz boost matrix in the :math:`z`-direction."""
+    r"""Represents a Lorentz boost matrix in the :math:`z`-direction.
+
+    Args:
+        beta: Velocity in the :math:`z`-direction, :math:`\beta=p_z/E`.
+    """
 
     def __new__(cls, beta: sp.Expr, **kwargs: Any) -> "BoostZMatrix":
         return create_expression(cls, beta, **kwargs)
 
-    @property
-    def beta(self) -> sp.Expr:
-        r"""Velocity in the :math:`z`-direction, :math:`\beta=p_z/E`."""
-        return self.args[0]
-
     def as_explicit(self) -> sp.Expr:
-        beta = self.beta
+        beta = self.args[0]
         gamma = 1 / sp.sqrt(1 - beta**2)
         return sp.Matrix(
             [
@@ -363,14 +362,14 @@ class BoostZMatrix(NumPyPrintable):
         )
 
     def _latex(self, printer: LatexPrinter, *args: Any) -> str:
-        beta = printer._print(self.beta)
+        beta = printer._print(self.args[0])
         return Rf"\boldsymbol{{B_z}}\left({beta}\right)"
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
         printer.module_imports[printer._module].update(
             {"array", "ones", "zeros", "sqrt"}
         )
-        beta = printer._print(self.beta)
+        beta = printer._print(self.args[0])
         gamma = f"1 / sqrt(1 - ({beta}) ** 2)"
         n_events = f"len({beta})"
         zeros = f"zeros({n_events})"

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -387,18 +387,17 @@ class BoostZMatrix(NumPyPrintable):
 
 @implement_doit_method
 class RotationYMatrix(UnevaluatedExpression):
-    """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`."""
+    """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`.
+
+    Args:
+        angle: Angle with which to rotate, see e.g. `Phi` and `Theta`.
+    """
 
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationYMatrix":
         return create_expression(cls, angle, **hints)
 
-    @property
-    def angle(self) -> sp.Expr:
-        """Angle with which to rotate, see e.g. `Phi` and `Theta`."""
-        return self.args[0]
-
     def as_explicit(self) -> sp.Expr:
-        angle = self.angle
+        angle = self.args[0]
         return sp.Matrix(
             [
                 [1, 0, 0, 0],
@@ -409,7 +408,7 @@ class RotationYMatrix(UnevaluatedExpression):
         )
 
     def evaluate(self) -> "_RotationYMatrixImplementation":
-        angle = self.angle
+        angle = self.args[0]
         size = _ArraySize(angle)
         return _RotationYMatrixImplementation(
             angle=angle,
@@ -451,15 +450,14 @@ class _RotationYMatrixImplementation(NumPyPrintable):
 
 @implement_doit_method
 class RotationZMatrix(UnevaluatedExpression):
-    """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`."""
+    """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`.
+
+    Args:
+        angle: Angle with which to rotate, see e.g. `Phi` and `Theta`.
+    """
 
     def __new__(cls, angle: sp.Expr, **hints: Any) -> "RotationZMatrix":
         return create_expression(cls, angle, **hints)
-
-    @property
-    def angle(self) -> sp.Expr:
-        """Angle with which to rotate, see e.g. `Phi` and `Theta`."""
-        return self.args[0]
 
     def as_explicit(self) -> sp.Expr:
         angle = self.args[0]
@@ -473,7 +471,7 @@ class RotationZMatrix(UnevaluatedExpression):
         )
 
     def evaluate(self) -> "_RotationZMatrixImplementation":
-        angle = self.angle
+        angle = self.args[0]
         size = _ArraySize(angle)
         return _RotationZMatrixImplementation(
             angle=angle,

--- a/src/ampform/kinematics.py
+++ b/src/ampform/kinematics.py
@@ -4,7 +4,7 @@
 
 import itertools
 import sys
-from typing import TYPE_CHECKING, Any, Dict, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Set, Union
 
 import attr
 import sympy as sp
@@ -345,11 +345,15 @@ class BoostZMatrix(UnevaluatedExpression):
 
     Args:
         beta: Velocity in the :math:`z`-direction, :math:`\beta=p_z/E`.
+        n_events: Number of events :math:`n` for this matrix array of shape
+            :math:`n\times4\times4`. Defaults to the `len` of :code:`beta`.
     """
 
     def __new__(
-        cls, beta: sp.Expr, n_events: sp.Symbol, **kwargs: Any
+        cls, beta: sp.Expr, n_events: Optional[sp.Symbol] = None, **kwargs: Any
     ) -> "BoostZMatrix":
+        if n_events is None:
+            n_events = _ArraySize(beta)
         return create_expression(cls, beta, n_events, **kwargs)
 
     def as_explicit(self) -> sp.Expr:
@@ -413,15 +417,19 @@ class _BoostZMatrixImplementation(NumPyPrintable):
 
 @implement_doit_method
 class RotationYMatrix(UnevaluatedExpression):
-    """Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`.
+    r"""Rotation matrix around the :math:`y`-axis for a `FourMomentumSymbol`.
 
     Args:
         angle: Angle with which to rotate, see e.g. `Phi` and `Theta`.
+        n_events: Number of events :math:`n` for this matrix array of shape
+            :math:`n\times4\times4`. Defaults to the `len` of :code:`angle`.
     """
 
     def __new__(
-        cls, angle: sp.Expr, n_events: sp.Symbol, **hints: Any
+        cls, angle: sp.Expr, n_events: Optional[sp.Symbol] = None, **hints: Any
     ) -> "RotationYMatrix":
+        if n_events is None:
+            n_events = _ArraySize(angle)
         return create_expression(cls, angle, n_events, **hints)
 
     def as_explicit(self) -> sp.Expr:
@@ -484,15 +492,19 @@ class _RotationYMatrixImplementation(NumPyPrintable):
 
 @implement_doit_method
 class RotationZMatrix(UnevaluatedExpression):
-    """Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`.
+    r"""Rotation matrix around the :math:`z`-axis for a `FourMomentumSymbol`.
 
     Args:
         angle: Angle with which to rotate, see e.g. `Phi` and `Theta`.
+        n_events: Number of events :math:`n` for this matrix array of shape
+            :math:`n\times4\times4`. Defaults to the `len` of :code:`angle`.
     """
 
     def __new__(
-        cls, angle: sp.Expr, n_events: sp.Symbol, **hints: Any
+        cls, angle: sp.Expr, n_events: Optional[sp.Symbol] = None, **hints: Any
     ) -> "RotationZMatrix":
+        if n_events is None:
+            n_events = _ArraySize(angle)
         return create_expression(cls, angle, n_events, **hints)
 
     def as_explicit(self) -> sp.Expr:

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -335,7 +335,7 @@ def create_symbol_matrix(name: str, m: int, n: int) -> sp.Matrix:
 
 def cse_all_symbols(
     expr: sp.Expr,
-) -> Tuple[List[Tuple[sp.Symbol, sp.Expr]], List[sp.Expr]]:
+) -> Tuple[List[Tuple[sp.Symbol, sp.Expr]], sp.Expr]:
     """Identify all symbols as common sub-expressions.
 
     :func:`sympy.cse <sympy.simplify.cse_main.cse>`, which is used by default
@@ -356,7 +356,7 @@ def cse_all_symbols(
     >>> a, b, y = sp.symbols("a b y")
     >>> expr = a+b + y ** (a+b)
     >>> cse_all_symbols(expr)
-    ([(x0, a + b), (x1, y)], [x0 + x1**x0])
+    ([(x0, a + b), (x1, y)], x0 + x1**x0)
     """
     replacements, reduced_exprs = sp.cse(expr)
     replacements_dict = dict(replacements)
@@ -372,7 +372,7 @@ def cse_all_symbols(
         dummy = next(symbol_generator)
         replacements.append((dummy, non_dummy))
         reduced_exprs = [e.xreplace({non_dummy: dummy}) for e in reduced_exprs]
-    return replacements, reduced_exprs
+    return replacements, reduced_exprs[0]
 
 
 def _continue_numbering(

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -4,11 +4,23 @@
 
 import functools
 from abc import abstractmethod
-from typing import Any, Callable, Optional, Tuple, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 import sympy as sp
 from sympy.printing.latex import LatexPrinter
 from sympy.printing.numpy import NumPyPrinter
+from sympy.utilities.iterables import numbered_symbols
 
 
 class UnevaluatedExpression(sp.Expr):
@@ -319,3 +331,59 @@ def create_symbol_matrix(name: str, m: int, n: int) -> sp.Matrix:
     """
     symbol = sp.IndexedBase(name, shape=(m, n))
     return sp.Matrix([[symbol[i, j] for j in range(n)] for i in range(m)])
+
+
+def cse_all_symbols(
+    expr: sp.Expr,
+) -> Tuple[List[Tuple[sp.Symbol, sp.Expr]], List[sp.Expr]]:
+    """Identify all symbols as common sub-expressions.
+
+    :func:`sympy.cse <sympy.simplify.cse_main.cse>`, which is used by default
+    when setting :code:`cse=True` in
+    :func:`~sympy.utilities.lambdify.lambdify`, does not extract all symbols as
+    common sub-expressions:
+
+    >>> a, b, y = sp.symbols("a b y")
+    >>> expr = a+b + y ** (a+b)
+    >>> sp.cse(expr)
+    ([(x0, a + b)], [x0 + y**x0])
+
+    In most cases, this is fine, but when lambdifying matrix classes like
+    `.BoostZMatrix` and `.RotationZMatrix`, we want to identify the
+    :func:`numpy.ones` expressions as common sub-expressions as well. This can
+    be done by using :func:`cse_all_symbols`:
+
+    >>> a, b, y = sp.symbols("a b y")
+    >>> expr = a+b + y ** (a+b)
+    >>> cse_all_symbols(expr)
+    ([(x0, a + b), (x1, y)], [x0 + x1**x0])
+    """
+    replacements, reduced_exprs = sp.cse(expr)
+    replacements_dict = dict(replacements)
+    free_symbols: Set[sp.Symbol] = set()
+    for reduced_expr in reduced_exprs:
+        free_symbols |= reduced_expr.free_symbols
+    non_dummy_symbols = sorted(free_symbols - set(replacements_dict), key=str)
+    if not non_dummy_symbols:
+        return replacements, reduced_exprs
+
+    symbol_generator = _continue_numbering(replacements_dict)
+    for non_dummy in non_dummy_symbols:
+        dummy = next(symbol_generator)
+        replacements.append((dummy, non_dummy))
+        reduced_exprs = [e.xreplace({non_dummy: dummy}) for e in reduced_exprs]
+    return replacements, reduced_exprs
+
+
+def _continue_numbering(
+    symbols: Iterable[sp.Symbol],
+) -> Generator[sp.Symbol, None, None]:
+    ordered_symbols = sorted(symbols, key=str)
+    if len(ordered_symbols) > 0:
+        last_symbol = ordered_symbols[-1]
+        return numbered_symbols(
+            prefix=last_symbol.name[0],
+            start=int(last_symbol.name[1:]) + 1,
+            **last_symbol.assumptions0,
+        )
+    return numbered_symbols()

--- a/src/ampform/sympy/_array_expressions.py
+++ b/src/ampform/sympy/_array_expressions.py
@@ -377,7 +377,7 @@ class ArrayMultiplication(sp.Expr):
         return " ".join(tensors)
 
     def _numpycode(self, printer: NumPyPrinter, *args: Any) -> str:
-        printer.module_imports[printer._module].update({"einsum", "transpose"})
+        printer.module_imports[printer._module].add("einsum")
         tensors = list(map(printer._print, self.args))
         if len(tensors) == 0:
             return ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,17 @@ import qrules
 from _pytest.config import Config
 from _pytest.fixtures import SubRequest
 from qrules import ParticleCollection, ReactionInfo, load_default_particles
+from qrules.settings import NumberOfThreads
 
 from ampform import get_builder
 from ampform.dynamics.builder import create_relativistic_breit_wigner_with_ff
 from ampform.helicity import HelicityModel
 
 logging.getLogger().setLevel(level=logging.ERROR)
+
+# Ensure consistent test coverage when running pytest multithreaded
+# https://github.com/ComPWA/qrules/issues/11
+NumberOfThreads.set(1)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -32,7 +32,6 @@ from ampform.kinematics import (
     compute_invariant_masses,
     create_four_momentum_symbols,
 )
-from ampform.sympy import cse_all_symbols
 from ampform.sympy._array_expressions import (
     ArrayMultiplication,
     ArraySlice,
@@ -238,21 +237,19 @@ class TestRotationYMatrix:
         angle = sp.Symbol("a")
         rotation_expr = rotation_expr.doit()
         rotation_expr = rotation_expr.subs(sp.Symbol("n"), _ArraySize(angle))
-        return sp.lambdify(angle, rotation_expr, cse=cse_all_symbols)
+        return sp.lambdify(angle, rotation_expr, cse=True)
 
     def test_numpycode_cse(self, rotation_expr: RotationYMatrix):
-        func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
+        func = sp.lambdify([], rotation_expr.doit(), cse=True)
         src = inspect.getsource(func)
         expected_src = """
         def _lambdifygenerated():
-            x0 = a
-            x1 = n
             return (array(
                     [
-                        [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
-                        [zeros(x1), cos(x0), zeros(x1), sin(x0)],
-                        [zeros(x1), zeros(x1), ones(x1), zeros(x1)],
-                        [zeros(x1), -sin(x0), zeros(x1), cos(x0)],
+                        [ones(n), zeros(n), zeros(n), zeros(n)],
+                        [zeros(n), cos(a), zeros(n), sin(a)],
+                        [zeros(n), zeros(n), ones(n), zeros(n)],
+                        [zeros(n), -sin(a), zeros(n), cos(a)],
                     ]
                 ).transpose((2, 0, 1)))
         """
@@ -279,21 +276,19 @@ class TestRotationZMatrix:
         angle = sp.Symbol("a")
         rotation_expr = rotation_expr.doit()
         rotation_expr = rotation_expr.subs(sp.Symbol("n"), _ArraySize(angle))
-        return sp.lambdify(angle, rotation_expr, cse=cse_all_symbols)
+        return sp.lambdify(angle, rotation_expr, cse=True)
 
     def test_numpycode_cse(self, rotation_expr: RotationZMatrix):
-        func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
+        func = sp.lambdify([], rotation_expr.doit(), cse=True)
         src = inspect.getsource(func)
         expected_src = """
         def _lambdifygenerated():
-            x0 = a
-            x1 = n
             return (array(
                     [
-                        [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
-                        [zeros(x1), cos(x0), -sin(x0), zeros(x1)],
-                        [zeros(x1), sin(x0), cos(x0), zeros(x1)],
-                        [zeros(x1), zeros(x1), zeros(x1), ones(x1)],
+                        [ones(n), zeros(n), zeros(n), zeros(n)],
+                        [zeros(n), cos(a), -sin(a), zeros(n)],
+                        [zeros(n), sin(a), cos(a), zeros(n)],
+                        [zeros(n), zeros(n), zeros(n), ones(n)],
                     ]
                 ).transpose((2, 0, 1)))
         """
@@ -321,7 +316,7 @@ def test_rotation_over_multiple_two_pi_is_identity(rotation):
     angle = sp.Symbol("a")
     n_events = _ArraySize(angle)
     expr = rotation(angle, n_events)
-    func = sp.lambdify(angle, expr.doit(), cse=cse_all_symbols)
+    func = sp.lambdify(angle, expr.doit(), cse=True)
     angle_array = np.arange(-2, 4, 1) * 2 * np.pi
     rotation_matrices = func(angle_array)
     identity = np.array(

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -192,7 +192,7 @@ class TestRotationYMatrix:
         angle = sp.Symbol("a")
         rotation_expr = rotation_expr.doit()
         rotation_expr = rotation_expr.subs(sp.Symbol("n"), _ArraySize(angle))
-        return sp.lambdify(angle, rotation_expr, cse=True)
+        return sp.lambdify(angle, rotation_expr, cse=cse_all_symbols)
 
     def test_numpycode_cse(self, rotation_expr: RotationYMatrix):
         func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
@@ -201,14 +201,14 @@ class TestRotationYMatrix:
         def _lambdifygenerated():
             x0 = a
             x1 = n
-            return ([array(
+            return (array(
                     [
                         [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
                         [zeros(x1), cos(x0), zeros(x1), sin(x0)],
                         [zeros(x1), zeros(x1), ones(x1), zeros(x1)],
                         [zeros(x1), -sin(x0), zeros(x1), cos(x0)],
                     ]
-                ).transpose((2, 0, 1))])
+                ).transpose((2, 0, 1)))
         """
         expected_src = textwrap.dedent(expected_src)
         assert src.strip() == expected_src.strip()
@@ -233,7 +233,7 @@ class TestRotationZMatrix:
         angle = sp.Symbol("a")
         rotation_expr = rotation_expr.doit()
         rotation_expr = rotation_expr.subs(sp.Symbol("n"), _ArraySize(angle))
-        return sp.lambdify(angle, rotation_expr, cse=True)
+        return sp.lambdify(angle, rotation_expr, cse=cse_all_symbols)
 
     def test_numpycode_cse(self, rotation_expr: RotationZMatrix):
         func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
@@ -242,14 +242,14 @@ class TestRotationZMatrix:
         def _lambdifygenerated():
             x0 = a
             x1 = n
-            return ([array(
+            return (array(
                     [
                         [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
                         [zeros(x1), cos(x0), -sin(x0), zeros(x1)],
                         [zeros(x1), sin(x0), cos(x0), zeros(x1)],
                         [zeros(x1), zeros(x1), zeros(x1), ones(x1)],
                     ]
-                ).transpose((2, 0, 1))])
+                ).transpose((2, 0, 1)))
         """
         expected_src = textwrap.dedent(expected_src)
         assert src.strip() == expected_src.strip()
@@ -275,7 +275,7 @@ def test_rotation_over_multiple_two_pi_is_identity(rotation):
     angle = sp.Symbol("a")
     n_events = _ArraySize(angle)
     expr = rotation(angle, n_events)
-    func = sp.lambdify(angle, expr.doit(), cse=True)
+    func = sp.lambdify(angle, expr.doit(), cse=cse_all_symbols)
     angle_array = np.arange(-2, 4, 1) * 2 * np.pi
     rotation_matrices = func(angle_array)
     identity = np.array(

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -1,5 +1,7 @@
 # pylint: disable=no-member, no-self-use, redefined-outer-name
 # cspell:ignore atol doprint
+import inspect
+import textwrap
 from typing import Dict, Tuple
 
 import numpy as np
@@ -19,6 +21,7 @@ from ampform.kinematics import (
     FourMomentumZ,
     InvariantMass,
     Phi,
+    RotationZMatrix,
     Theta,
     ThreeMomentumNorm,
     compute_helicity_angles,
@@ -169,6 +172,27 @@ class TestTheta:
             numpy_code
             == "numpy.arccos(p[:, 3]/numpy.sqrt(sum(p[:, 1:]**2, axis=1)))"
         )
+
+
+class TestRotationZMatrix:
+    def test_numpycode(self):
+        angle = sp.Symbol("a")
+        expr = RotationZMatrix(angle)
+        func = sp.lambdify(angle, expr)
+        src = inspect.getsource(func)
+        expected_src = """
+def _lambdifygenerated(a):
+    return (array(
+            [
+                [ones(len(a)), zeros(len(a)), zeros(len(a)), zeros(len(a))],
+                [zeros(len(a)), cos(a), -sin(a), zeros(len(a))],
+                [zeros(len(a)), sin(a), cos(a), zeros(len(a))],
+                [zeros(len(a)), zeros(len(a)), zeros(len(a)), ones(len(a))],
+            ]
+        ).transpose((2, 0, 1)))
+        """
+        expected_src = textwrap.dedent(expected_src)
+        assert src.strip() == expected_src.strip()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -32,6 +32,7 @@ from ampform.kinematics import (
     compute_invariant_masses,
     create_four_momentum_symbols,
 )
+from ampform.sympy import cse_all_symbols
 from ampform.sympy._array_expressions import ArraySlice, ArraySymbol
 
 
@@ -194,18 +195,20 @@ class TestRotationYMatrix:
         return sp.lambdify(angle, rotation_expr, cse=True)
 
     def test_numpycode_cse(self, rotation_expr: RotationYMatrix):
-        func = sp.lambdify([], rotation_expr.doit(), cse=True)
+        func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
         src = inspect.getsource(func)
         expected_src = """
         def _lambdifygenerated():
-            return (array(
+            x0 = a
+            x1 = n
+            return ([array(
                     [
-                        [ones(n), zeros(n), zeros(n), zeros(n)],
-                        [zeros(n), cos(a), zeros(n), sin(a)],
-                        [zeros(n), zeros(n), ones(n), zeros(n)],
-                        [zeros(n), -sin(a), zeros(n), cos(a)],
+                        [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
+                        [zeros(x1), cos(x0), zeros(x1), sin(x0)],
+                        [zeros(x1), zeros(x1), ones(x1), zeros(x1)],
+                        [zeros(x1), -sin(x0), zeros(x1), cos(x0)],
                     ]
-                ).transpose((2, 0, 1)))
+                ).transpose((2, 0, 1))])
         """
         expected_src = textwrap.dedent(expected_src)
         assert src.strip() == expected_src.strip()
@@ -233,18 +236,20 @@ class TestRotationZMatrix:
         return sp.lambdify(angle, rotation_expr, cse=True)
 
     def test_numpycode_cse(self, rotation_expr: RotationZMatrix):
-        func = sp.lambdify([], rotation_expr.doit(), cse=True)
+        func = sp.lambdify([], rotation_expr.doit(), cse=cse_all_symbols)
         src = inspect.getsource(func)
         expected_src = """
         def _lambdifygenerated():
-            return (array(
+            x0 = a
+            x1 = n
+            return ([array(
                     [
-                        [ones(n), zeros(n), zeros(n), zeros(n)],
-                        [zeros(n), cos(a), -sin(a), zeros(n)],
-                        [zeros(n), sin(a), cos(a), zeros(n)],
-                        [zeros(n), zeros(n), zeros(n), ones(n)],
+                        [ones(x1), zeros(x1), zeros(x1), zeros(x1)],
+                        [zeros(x1), cos(x0), -sin(x0), zeros(x1)],
+                        [zeros(x1), sin(x0), cos(x0), zeros(x1)],
+                        [zeros(x1), zeros(x1), zeros(x1), ones(x1)],
                     ]
-                ).transpose((2, 0, 1)))
+                ).transpose((2, 0, 1))])
         """
         expected_src = textwrap.dedent(expected_src)
         assert src.strip() == expected_src.strip()

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -314,8 +314,7 @@ def test_rotation_latex_repr_is_identical_with_doit(rotation):
 @pytest.mark.parametrize("rotation", [RotationYMatrix, RotationZMatrix])
 def test_rotation_over_multiple_two_pi_is_identity(rotation):
     angle = sp.Symbol("a")
-    n_events = _ArraySize(angle)
-    expr = rotation(angle, n_events)
+    expr = rotation(angle)
     func = sp.lambdify(angle, expr.doit(), cse=True)
     angle_array = np.arange(-2, 4, 1) * 2 * np.pi
     rotation_matrices = func(angle_array)


### PR DESCRIPTION
Closes #231 

Extracted [`NumPyPrintable`](https://ampform--232.org.readthedocs.build/en/232/api/ampform.sympy.html#ampform.sympy.NumPyPrintable) implementation classes from [`BoostZMatrix`](https://ampform--232.org.readthedocs.build/en/232/api/ampform.kinematics.html#ampform.kinematics.BoostZMatrix), [`RotationYMatrix`](https://ampform--232.org.readthedocs.build/en/232/api/ampform.kinematics.html#ampform.kinematics.RotationYMatrix) and [`RotationZMatrix`](https://ampform--232.org.readthedocs.build/en/232/api/ampform.kinematics.html#ampform.kinematics.RotationZMatrix), so that the code generated with [`sympy.lambdify()`](https://docs.sympy.org/latest/modules/utilities/lambdify.html#sympy.utilities.lambdify.lambdify) decreases and has a smaller memory footprint (if using `cse=True`). This can best be seen by comparing the [new docstring for `BoostZMatrix`](https://ampform--232.org.readthedocs.build/en/232/api/ampform.kinematics.html#ampform.kinematics.BoostZMatrix) with [the old one](https://ampform--230.org.readthedocs.build/en/230/api/ampform.kinematics.html#ampform.kinematics.BoostZMatrix).