### PR TITLE
feat: add switch for energy-dependent width

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -482,6 +482,7 @@
     "from ampform.dynamics.builder import RelativisticBreitWignerBuilder\n",
     "\n",
     "bw_builder = RelativisticBreitWignerBuilder(\n",
+    "    energy_dependent_width=True,\n",
     "    form_factor=True,\n",
     "    phsp_factor=PhaseSpaceFactor,  # optional\n",
     ")\n",

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -117,10 +117,9 @@ class RelativisticBreitWignerBuilder:
     :meth:`.set_dynamics`.
 
     Args:
-        form_factor: Formulate a relativistic Breit-Wigner function with form
-            factor, using :func:`.relativistic_breit_wigner_with_ff`. If set to
-            `False`, :meth:`__call__` builds a
-            :func:`.relativistic_breit_wigner` (_without_ form factor).
+        form_factor: Formulate a relativistic Breit-Wigner function multiplied
+            by a Blatt-Weisskopf form factor (Equation
+            :eq:`BlattWeisskopfSquared`).
         phsp_factor: A class that complies with the
             `.PhaseSpaceFactorProtocol`. Defaults to `.PhaseSpaceFactor`.
     """

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -131,14 +131,14 @@ class RelativisticBreitWignerBuilder:
     ) -> None:
         if phsp_factor is None:
             phsp_factor = PhaseSpaceFactor
-        self.__phsp_factor = phsp_factor
-        self.__with_form_factor = form_factor
+        self.phsp_factor = phsp_factor
+        self.form_factor = form_factor
 
     def __call__(
         self, resonance: Particle, variable_pool: TwoBodyKinematicVariableSet
     ) -> "BuilderReturnType":
         """Formulate a relativistic Breit-Wigner for this resonance."""
-        if self.__with_form_factor:
+        if self.form_factor:
             return self.__formulate_with_form_factor(resonance, variable_pool)
         return self.__formulate(resonance, variable_pool)
 
@@ -187,7 +187,7 @@ class RelativisticBreitWignerBuilder:
             m_b=product2_inv_mass,
             angular_momentum=angular_momentum,
             meson_radius=meson_radius,
-            phsp_factor=self.__phsp_factor,
+            phsp_factor=self.phsp_factor,
         )
         parameter_defaults = {
             res_mass: resonance.mass,

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -266,6 +266,7 @@ form factor.
 """
 
 create_relativistic_breit_wigner_with_ff = RelativisticBreitWignerBuilder(
+    energy_dependent_width=True,
     form_factor=True,
     phsp_factor=PhaseSpaceFactor,
 ).__call__
@@ -277,6 +278,7 @@ form factor and a 'normal' `.PhaseSpaceFactor`.
 """
 
 create_analytic_breit_wigner = RelativisticBreitWignerBuilder(
+    energy_dependent_width=True,
     form_factor=True,
     phsp_factor=PhaseSpaceFactorAnalytic,
 ).__call__

--- a/tests/dynamics/test_builder.py
+++ b/tests/dynamics/test_builder.py
@@ -1,0 +1,99 @@
+# pylint: disable=invalid-name, no-self-use, too-many-locals
+import pytest
+import sympy as sp
+from qrules.particle import Particle
+
+from ampform.dynamics import (
+    BlattWeisskopfSquared,
+    BreakupMomentumSquared,
+    EnergyDependentWidth,
+)
+from ampform.dynamics.builder import (
+    RelativisticBreitWignerBuilder,
+    TwoBodyKinematicVariableSet,
+)
+
+
+class TestRelativisticBreitWignerBuilder:
+    @pytest.fixture(scope="session")
+    def particle(self) -> Particle:
+        return Particle(
+            name="N",
+            mass=1.3,
+            width=0.2,
+            pid=1111111,
+            spin=3 / 2,
+        )
+
+    @pytest.fixture(scope="session")
+    def variable_set(self) -> TwoBodyKinematicVariableSet:
+        return TwoBodyKinematicVariableSet(
+            incoming_state_mass=sp.Symbol("m"),
+            outgoing_state_mass1=sp.Symbol("m1"),
+            outgoing_state_mass2=sp.Symbol("m2"),
+            helicity_phi=sp.Symbol("phi"),
+            helicity_theta=sp.Symbol("theta"),
+            angular_momentum=sp.Symbol("L", integer=True, negative=False),
+        )
+
+    def test_simple_breit_wigner(
+        self, particle: Particle, variable_set: TwoBodyKinematicVariableSet
+    ):
+        builder = RelativisticBreitWignerBuilder(energy_dependent_width=False)
+
+        builder.form_factor = False
+        bw, parameters = builder(particle, variable_set)
+        s = variable_set.incoming_state_mass**2
+        m0 = sp.Symbol("m_{N}")
+        w0 = sp.Symbol(R"\Gamma_{N}")
+        assert bw == w0 * m0 / (-sp.I * w0 * m0 - s + m0**2)
+        assert set(parameters) == {m0, w0}
+        assert parameters[m0] == particle.mass
+        assert parameters[w0] == particle.width
+
+        builder.form_factor = True
+        bw_with_ff, parameters = builder(particle, variable_set)
+        m1 = variable_set.outgoing_state_mass1
+        m2 = variable_set.outgoing_state_mass2
+        q_squared = BreakupMomentumSquared(s, m1, m2)
+        L = variable_set.angular_momentum  # noqa: N806
+        d = sp.Symbol(R"d_{N}")
+        ff = sp.sqrt(BlattWeisskopfSquared(L, d**2 * q_squared))
+        assert bw_with_ff / bw == ff
+        assert set(parameters) == {m0, w0, d}
+        assert parameters[m0] == particle.mass
+        assert parameters[w0] == particle.width
+        assert parameters[d] == 1
+
+    def test_breit_wigner_with_energy_dependent_width(
+        self, particle: Particle, variable_set: TwoBodyKinematicVariableSet
+    ):
+        builder = RelativisticBreitWignerBuilder(energy_dependent_width=True)
+
+        builder.form_factor = False
+        bw, parameters = builder(particle, variable_set)
+        s = variable_set.incoming_state_mass**2
+        m0 = sp.Symbol("m_{N}")
+        w0 = sp.Symbol(R"\Gamma_{N}")
+        m1 = variable_set.outgoing_state_mass1
+        m2 = variable_set.outgoing_state_mass2
+        L = variable_set.angular_momentum  # noqa: N806
+        d = sp.Symbol(R"d_{N}")
+        w = EnergyDependentWidth(
+            s, m0, w0, m_a=m1, m_b=m2, angular_momentum=L, meson_radius=d
+        )
+        assert bw == w0 * m0 / (-sp.I * w * m0 - s + m0**2)
+        assert set(parameters) == {m0, w0, d}
+        assert parameters[m0] == particle.mass
+        assert parameters[w0] == particle.width
+        assert parameters[d] == 1
+
+        builder.form_factor = True
+        bw_with_ff, parameters = builder(particle, variable_set)
+        q_squared = BreakupMomentumSquared(s, m1, m2)
+        ff = sp.sqrt(BlattWeisskopfSquared(L, d**2 * q_squared))
+        assert bw_with_ff / bw == ff
+        assert set(parameters) == {m0, w0, d}
+        assert parameters[m0] == particle.mass
+        assert parameters[w0] == particle.width
+        assert parameters[d] == 1


### PR DESCRIPTION
It's now possible to independently activate energy-dependent width and a form factor in the [`RelativisticBreitWignerBuilder`](https://ampform--236.org.readthedocs.build/en/236/api/ampform.dynamics.builder.html#ampform.dynamics.builder.RelativisticBreitWignerBuilder).
Usage example [here](https://ampform--236.org.readthedocs.build/en/236/usage/amplitude.html#set-dynamics). See also #235.