### PR TITLE
feat: extract DynamicsSelector class

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -55,7 +55,7 @@ gprof2dot==2021.2.21
 graphviz==0.19.1
 greenlet==1.1.2
 hepunits==2.2.0
-identify==2.4.10
+identify==2.4.11
 idna==3.3
 imagesize==1.3.0
 importlib-metadata==4.11.1
@@ -74,7 +74,7 @@ jupyter-cache==0.4.3
 jupyter-client==7.1.2
 jupyter-core==4.9.2
 jupyter-server==1.13.5
-jupyter-server-mathjax==0.2.4
+jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.9
 jupyterlab-code-formatter==1.4.10
@@ -152,7 +152,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.6
+qrules==0.9.7
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -193,7 +193,7 @@ tqdm==4.62.3
 traitlets==5.1.1
 types-docutils==0.17.6
 types-pkg-resources==0.1.3
-types-requests==2.27.10
+types-requests==2.27.11
 types-setuptools==57.4.9
 types-urllib3==1.26.9
 typing-extensions==4.1.1

--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -148,12 +148,13 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.6
+qrules==0.9.7
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
 rich==11.2.0
 send2trash==1.8.0
+singledispatchmethod==1.0 ; python_version < "3.8.0"
 six==1.16.0
 smmap==5.0.0
 sniffio==1.2.0
@@ -189,7 +190,7 @@ traitlets==4.3.3
 typed-ast==1.5.2
 types-docutils==0.17.6
 types-pkg-resources==0.1.3
-types-requests==2.27.10
+types-requests==2.27.11
 types-setuptools==57.4.9
 types-urllib3==1.26.9
 typing-extensions==4.1.1 ; python_version < "3.8.0"

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -52,7 +52,7 @@ gprof2dot==2021.2.21
 graphviz==0.19.1
 greenlet==1.1.2
 hepunits==2.2.0
-identify==2.4.10
+identify==2.4.11
 idna==3.3
 imagesize==1.3.0
 importlib-metadata==4.2.0
@@ -72,7 +72,7 @@ jupyter-cache==0.4.3
 jupyter-client==7.1.2
 jupyter-core==4.9.2
 jupyter-server==1.13.5
-jupyter-server-mathjax==0.2.4
+jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.9
 jupyterlab-code-formatter==1.4.10
@@ -149,12 +149,13 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.6
+qrules==0.9.7
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
 rich==11.2.0
 send2trash==1.8.0
+singledispatchmethod==1.0 ; python_version < "3.8.0"
 six==1.16.0
 smmap==5.0.0
 sniffio==1.2.0
@@ -190,7 +191,7 @@ traitlets==5.1.1
 typed-ast==1.5.2
 types-docutils==0.17.6
 types-pkg-resources==0.1.3
-types-requests==2.27.10
+types-requests==2.27.11
 types-setuptools==57.4.9
 types-urllib3==1.26.9
 typing-extensions==4.1.1 ; python_version < "3.8.0"

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -55,7 +55,7 @@ gprof2dot==2021.2.21
 graphviz==0.19.1
 greenlet==1.1.2
 hepunits==2.2.0
-identify==2.4.10
+identify==2.4.11
 idna==3.3
 imagesize==1.3.0
 importlib-metadata==4.11.1
@@ -75,7 +75,7 @@ jupyter-cache==0.4.3
 jupyter-client==7.1.2
 jupyter-core==4.9.2
 jupyter-server==1.13.5
-jupyter-server-mathjax==0.2.4
+jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.9
 jupyterlab-code-formatter==1.4.10
@@ -153,7 +153,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.6
+qrules==0.9.7
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -194,7 +194,7 @@ tqdm==4.62.3
 traitlets==5.1.1
 types-docutils==0.17.6
 types-pkg-resources==0.1.3
-types-requests==2.27.10
+types-requests==2.27.11
 types-setuptools==57.4.9
 types-urllib3==1.26.9
 typing-extensions==4.1.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -55,7 +55,7 @@ gprof2dot==2021.2.21
 graphviz==0.19.1
 greenlet==1.1.2
 hepunits==2.2.0
-identify==2.4.10
+identify==2.4.11
 idna==3.3
 imagesize==1.3.0
 importlib-metadata==4.11.1
@@ -74,7 +74,7 @@ jupyter-cache==0.4.3
 jupyter-client==7.1.2
 jupyter-core==4.9.2
 jupyter-server==1.13.5
-jupyter-server-mathjax==0.2.4
+jupyter-server-mathjax==0.2.5
 jupyter-sphinx==0.3.2
 jupyterlab==3.2.9
 jupyterlab-code-formatter==1.4.10
@@ -152,7 +152,7 @@ python-dateutil==2.8.2
 pytz==2021.3
 pyyaml==6.0
 pyzmq==22.3.0
-qrules==0.9.6
+qrules==0.9.7
 radon==5.1.0
 requests==2.27.1
 restructuredtext-lint==1.3.2
@@ -193,7 +193,7 @@ tqdm==4.62.3
 traitlets==5.1.1
 types-docutils==0.17.6
 types-pkg-resources==0.1.3
-types-requests==2.27.10
+types-requests==2.27.11
 types-setuptools==57.4.9
 types-urllib3==1.26.9
 typing-extensions==4.1.1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -48,6 +48,7 @@ jobs:
     name: Unit tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,7 +146,7 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.222
+    rev: v1.1.223
     hooks:
       - id: pyright
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,7 +154,6 @@ autodoc_default_options = {
     "special-members": ", ".join(
         [
             "__call__",
-            "__getitem__",
         ]
     ),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,10 @@ autodoc_default_options = {
             "evaluate",
             "is_commutative",
             "is_extended_real",
+            "items",
+            "keys",
             "precedence",
+            "values",
         ]
     ),
     "members": True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ setup_requires =
 install_requires =
     attrs >=20.1.0  # on_setattr and https://www.attrs.org/en/stable/api.html#next-gen
     qrules ==0.9.*
+    singledispatchmethod; python_version <"3.8.0"
     sympy >=1.8  # module sympy.printing.numpy
     typing-extensions; python_version <"3.8.0"
 packages = find:

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -9,9 +9,10 @@
 import collections
 import logging
 import operator
+import sys
 from collections import OrderedDict, abc
 from difflib import get_close_matches
-from functools import reduce, singledispatchmethod
+from functools import reduce
 from typing import (
     Any,
     DefaultDict,
@@ -54,6 +55,11 @@ from .naming import (
     get_helicity_angle_label,
     natural_sorting,
 )
+
+if sys.version_info >= (3, 8):
+    from functools import singledispatchmethod
+else:
+    from singledispatchmethod import singledispatchmethod
 
 ParameterValue = Union[float, complex, int]
 """Allowed value types for parameters."""

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -97,6 +97,8 @@ class ParameterValues(abc.Mapping):
     >>> parameters[2] = 3.14
     >>> parameters[c]
     3.14
+
+    .. automethod:: __getitem__
     """
 
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -294,22 +294,21 @@ class DynamicsSelector(abc.Mapping):
 
     @assign.register(TwoBodyDecay)
     def _(
-        self, selection: TwoBodyDecay, builder: ResonanceDynamicsBuilder
+        self, decay: TwoBodyDecay, builder: ResonanceDynamicsBuilder
     ) -> None:
-        self.__choices[selection] = builder
+        self.__choices[decay] = builder
 
     @assign.register(tuple)
     def _(
         self,
-        selection: Tuple[StateTransition, int],
+        transition_node: Tuple[StateTransition, int],
         builder: ResonanceDynamicsBuilder,
     ) -> None:
-        decay = TwoBodyDecay.create(selection)
+        decay = TwoBodyDecay.create(transition_node)
         return self.assign(decay, builder)
 
     @assign.register(str)
-    def _(self, selection: str, builder: ResonanceDynamicsBuilder) -> None:
-        particle_name = selection
+    def _(self, particle_name: str, builder: ResonanceDynamicsBuilder) -> None:
         found_particle = False
         for decay in self.__choices:
             decaying_particle = decay.parent.particle
@@ -322,10 +321,8 @@ class DynamicsSelector(abc.Mapping):
             )
 
     @assign.register(Particle)
-    def _(
-        self, selection: Particle, builder: ResonanceDynamicsBuilder
-    ) -> None:
-        return self.assign(selection.name, builder)
+    def _(self, particle: Particle, builder: ResonanceDynamicsBuilder) -> None:
+        return self.assign(particle.name, builder)
 
     def __getitem__(
         self, __k: Union[TwoBodyDecay, Tuple[StateTransition, int]]

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -36,6 +36,7 @@ from attrs.validators import instance_of
 from qrules.combinatorics import (
     perform_external_edge_identical_particle_combinatorics,
 )
+from qrules.particle import Particle
 from qrules.transition import ReactionInfo, StateTransition
 
 from ampform.dynamics.builder import (
@@ -313,6 +314,12 @@ class DynamicsSelector(abc.Mapping):
             logging.warning(
                 f'Model contains no resonance with name "{particle_name}"'
             )
+
+    @assign.register(Particle)
+    def _(
+        self, selection: Particle, builder: ResonanceDynamicsBuilder
+    ) -> None:
+        return self.assign(selection.name, builder)
 
     def __getitem__(
         self, __k: Union[TwoBodyDecay, Tuple[StateTransition, int]]

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -63,6 +63,8 @@ class SliderKwargs(abc.Mapping):
     Sliders can be defined in :func:`~mpl_interactions.pyplot.interactive_plot`
     through :term:`kwargs <python:keyword argument>`. This wrapper class can be
     used for that.
+
+    .. automethod:: __getitem__
     """
 
     def __init__(


### PR DESCRIPTION
`HelicityAmplitudeBuilder.__dynamics_choices` has been extracted to a new `DynamicsSelector` class. This reduces the responsibilities of the `HelicityAmplitudeBuilder` and makes it easier to implement new implementations for selection of dynamics.

Something similar has been done for 'collector' attributes like `HelicityAmplitudeBuilder.__parameter_defaults` and `__components`. This will be useful when implementing [TR-014](https://compwa-org.readthedocs.io/report/014.html), which will require keeping track of amplitude definitions.

Note: once QRules v0.10 is out, https://github.com/ComPWA/qrules/pull/156 and https://github.com/ComPWA/qrules/pull/157 make it possible to define the dynamics choices as a mapping over topologies and visualize them as graphviz.