### PR TITLE
refactor: simplify HelicityAdapter class

### DIFF
--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -386,8 +386,6 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
         self.__adapter = HelicityAdapter(reaction)
         self.stable_final_state_ids = stable_final_state_ids  # type: ignore[assignment]
         self.scalar_initial_state_mass = scalar_initial_state_mass  # type: ignore[assignment]
-        for grouping in reaction.transition_groups:
-            self.__adapter.register_topology(grouping.topology)
 
     @property
     def adapter(self) -> HelicityAdapter:


### PR DESCRIPTION
Implementation of the [`HelicityAdapter`](https://ampform.readthedocs.io/en/0.12.3/api/ampform.kinematics.html#ampform.kinematics.HelicityAdapter) class was a bit too complicated. This PR makes the class into a simple manager of Topology instances that can create expressions from these topologies. Interface hasn't changed though.