### PR TITLE
fix: improve signatures in helicity module

### DIFF
--- a/docs/_relink_references.py
+++ b/docs/_relink_references.py
@@ -29,6 +29,7 @@ __REF_TYPE_SUBSTITUTIONS = {
     "None": "obj",
     "ParameterValue": "obj",
     "ampform.dynamics.builder.BuilderReturnType": "obj",
+    "ampform.helicity.ParameterValue": "obj",
     "ampform.kinematics.FourMomenta": "obj",
     "ampform.kinematics.FourMomentumSymbol": "obj",
     "ampform.sympy.DecoratedClass": "obj",

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -26,7 +26,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    TypeVar,
     Union,
     ValuesView,
 )
@@ -65,30 +64,6 @@ ParameterValue = Union[float, complex, int]
 """Allowed value types for parameters."""
 
 
-def _order_component_mapping(
-    mapping: Mapping[str, ParameterValue]
-) -> "OrderedDict[str, ParameterValue]":
-    return collections.OrderedDict(
-        [(key, mapping[key]) for key in sorted(mapping, key=natural_sorting)]
-    )
-
-
-_T = TypeVar("_T")
-
-
-def _order_symbol_mapping(
-    mapping: Mapping[sp.Symbol, _T]  # type: ignore[valid-type]
-) -> "OrderedDict[sp.Symbol, _T]":
-    return collections.OrderedDict(
-        [
-            (symbol, mapping[symbol])
-            for symbol in sorted(
-                mapping, key=lambda s: natural_sorting(s.name)
-            )
-        ]
-    )
-
-
 class ParameterValues(abc.Mapping):
     """Ordered mapping to `ParameterValue` with convenient getter and setter.
 
@@ -112,7 +87,7 @@ class ParameterValues(abc.Mapping):
     """
 
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
-        self.__parameters = _order_symbol_mapping(mapping)
+        self.__parameters = dict(mapping)
 
     def __getitem__(self, key: Union[sp.Symbol, int, str]) -> ParameterValue:
         par = self._get_parameter(key)
@@ -168,6 +143,27 @@ class ParameterValues(abc.Mapping):
 
     def values(self) -> ValuesView[ParameterValue]:
         return self.__parameters.values()
+
+
+def _order_component_mapping(
+    mapping: Mapping[str, sp.Expr]
+) -> "OrderedDict[str, sp.Expr]":
+    return collections.OrderedDict(
+        [(key, mapping[key]) for key in sorted(mapping, key=natural_sorting)]
+    )
+
+
+def _order_symbol_mapping(
+    mapping: Mapping[sp.Symbol, sp.Expr]
+) -> "OrderedDict[sp.Symbol, sp.Expr]":
+    return collections.OrderedDict(
+        [
+            (symbol, mapping[symbol])
+            for symbol in sorted(
+                mapping, key=lambda s: natural_sorting(s.name)
+            )
+        ]
+    )
 
 
 @frozen

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -89,12 +89,12 @@ class ParameterValues(abc.Mapping):
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
         self.__parameters = dict(mapping)
 
-    def __getitem__(self, key: Union[sp.Symbol, int, str]) -> ParameterValue:
+    def __getitem__(self, key: Union[sp.Symbol, int, str]) -> "ParameterValue":
         par = self._get_parameter(key)
         return self.__parameters[par]
 
     def __setitem__(
-        self, key: Union[sp.Symbol, int, str], value: ParameterValue
+        self, key: Union[sp.Symbol, int, str], value: "ParameterValue"
     ) -> None:
         par = self._get_parameter(key)
         self.__parameters[par] = value

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -114,53 +114,53 @@ class ParameterValues(abc.Mapping):
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
         self.__mapping = _order_symbol_mapping(mapping)
 
-    def __getitem__(self, __k: Union[sp.Symbol, int, str]) -> ParameterValue:
-        if isinstance(__k, sp.Symbol):
-            return self.__mapping[__k]
-        if isinstance(__k, str):
+    def __getitem__(self, key: Union[sp.Symbol, int, str]) -> ParameterValue:
+        if isinstance(key, sp.Symbol):
+            return self.__mapping[key]
+        if isinstance(key, str):
             for symbol, value in self.__mapping.items():
-                if symbol.name == __k:
+                if symbol.name == key:
                     return value
-            raise KeyError(f'No parameter available with name "{__k}"')
-        if isinstance(__k, int):
+            raise KeyError(f'No parameter available with name "{key}"')
+        if isinstance(key, int):
             for i, value in enumerate(self.__mapping.values()):
-                if i == __k:
+                if i == key:
                     return value
             raise KeyError(
                 f"Parameter mapping has {len(self)} keys, but trying to"
-                f" get item {__k}"
+                f" get item {key}"
             )
         raise KeyError(  # no TypeError because of sympy.core.expr.Expr.xreplace
-            f"Cannot get parameter value for key type {type(__k).__name__}"
+            f"Cannot get parameter value for key type {type(key).__name__}"
         )
 
     def __setitem__(  # noqa: R701
-        self, __k: Union[sp.Symbol, int, str], __v: ParameterValue
+        self, key: Union[sp.Symbol, int, str], value: ParameterValue
     ) -> None:
         try:
-            self[__k]
+            self[key]
         except KeyError as e:
             raise KeyError("Not allowed to define new items") from e
-        if isinstance(__k, sp.Symbol):
-            self.__mapping[__k] = __v
+        if isinstance(key, sp.Symbol):
+            self.__mapping[key] = value
             return
-        if isinstance(__k, str):
+        if isinstance(key, str):
             for symbol in self.__mapping:
-                if symbol.name == __k:
-                    self.__mapping[symbol] = __v
+                if symbol.name == key:
+                    self.__mapping[symbol] = value
                     return
-            raise KeyError(f'No parameter available with name "{__k}"')
-        if isinstance(__k, int):
+            raise KeyError(f'No parameter available with name "{key}"')
+        if isinstance(key, int):
             for i, symbol in enumerate(self.__mapping):
-                if i == __k:
-                    self.__mapping[symbol] = __v
+                if i == key:
+                    self.__mapping[symbol] = value
                     return
             raise KeyError(
                 f"Parameter mapping has {len(self)} keys, but trying to"
-                f" set item {__k}"
+                f" set item {key}"
             )
         raise KeyError(  # no TypeError because of sympy.core.expr.Expr.xreplace
-            f"Cannot set parameter value for key type {type(__k).__name__}"
+            f"Cannot set parameter value for key type {type(key).__name__}"
         )
 
     def __len__(self) -> int:

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -112,18 +112,18 @@ class ParameterValues(abc.Mapping):
     """
 
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
-        self.__mapping = _order_symbol_mapping(mapping)
+        self.__parameters = _order_symbol_mapping(mapping)
 
     def __getitem__(self, key: Union[sp.Symbol, int, str]) -> ParameterValue:
         if isinstance(key, sp.Symbol):
-            return self.__mapping[key]
+            return self.__parameters[key]
         if isinstance(key, str):
-            for symbol, value in self.__mapping.items():
+            for symbol, value in self.__parameters.items():
                 if symbol.name == key:
                     return value
             raise KeyError(f'No parameter available with name "{key}"')
         if isinstance(key, int):
-            for i, value in enumerate(self.__mapping.values()):
+            for i, value in enumerate(self.__parameters.values()):
                 if i == key:
                     return value
             raise KeyError(
@@ -142,18 +142,18 @@ class ParameterValues(abc.Mapping):
         except KeyError as e:
             raise KeyError("Not allowed to define new items") from e
         if isinstance(key, sp.Symbol):
-            self.__mapping[key] = value
+            self.__parameters[key] = value
             return
         if isinstance(key, str):
-            for symbol in self.__mapping:
+            for symbol in self.__parameters:
                 if symbol.name == key:
-                    self.__mapping[symbol] = value
+                    self.__parameters[symbol] = value
                     return
             raise KeyError(f'No parameter available with name "{key}"')
         if isinstance(key, int):
-            for i, symbol in enumerate(self.__mapping):
+            for i, symbol in enumerate(self.__parameters):
                 if i == key:
-                    self.__mapping[symbol] = value
+                    self.__parameters[symbol] = value
                     return
             raise KeyError(
                 f"Parameter mapping has {len(self)} keys, but trying to"
@@ -164,19 +164,19 @@ class ParameterValues(abc.Mapping):
         )
 
     def __len__(self) -> int:
-        return len(self.__mapping)
+        return len(self.__parameters)
 
     def __iter__(self) -> Iterator[sp.Symbol]:
-        return iter(self.__mapping)
+        return iter(self.__parameters)
 
     def items(self) -> ItemsView[sp.Symbol, ParameterValue]:
-        return self.__mapping.items()
+        return self.__parameters.items()
 
     def keys(self) -> KeysView[sp.Symbol]:
-        return self.__mapping.keys()
+        return self.__parameters.keys()
 
     def values(self) -> ValuesView[ParameterValue]:
-        return self.__mapping.values()
+        return self.__parameters.values()
 
 
 @frozen

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -108,6 +108,7 @@ class ParameterValues(abc.Mapping):
     3.14
 
     .. automethod:: __getitem__
+    .. automethod:: __setitem__
     """
 
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ commands =
         --re-ignore .*/.ipynb_checkpoints/.* \
         --re-ignore .*/__pycache__/.* \
         --re-ignore .*\.gitignore \
+        --re-ignore .*\.tmp \
         --re-ignore docs/.*\.csv \
         --re-ignore docs/.*\.gif \
         --re-ignore docs/.*\.gv \
@@ -63,7 +64,6 @@ commands =
         --re-ignore docs/.*\.pickle \
         --re-ignore docs/.*\.png \
         --re-ignore docs/.*\.svg \
-        --re-ignore docs/.*\.tmp \
         --re-ignore docs/.*\.yaml \
         --re-ignore docs/.*\.yml \
         --re-ignore docs/_build/.* \


### PR DESCRIPTION
Note: it's not yet possible to abbreviate type aliases in nested type hints. Sphinx will fix this (https://github.com/sphinx-doc/sphinx/pull/10183) in [v4.5.0](https://www.sphinx-doc.org/en/master/changes.html#release-4-5-0-in-development). This will also make it possible to improve the order of definitions in the `helicity` module (makes more sense to define `HelicityModel` first). See also https://github.com/ComPWA/compwa-org/issues/116.