### PR TITLE
feat: implement HelicityModel.rename_symbols()

### DIFF
--- a/docs/usage/modify.ipynb
+++ b/docs/usage/modify.ipynb
@@ -136,6 +136,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Couple parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can couple parameters renaming them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "renames = {\n",
+    "    R\"C_{J/\\psi(1S) \\to {f_{0}(980)}_{0} \\gamma_{+1}; f_{0}(980) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
+    "        \"C\"\n",
+    "    ),\n",
+    "    R\"C_{J/\\psi(1S) \\to {f_{0}(1500)}_{0} \\gamma_{+1}; f_{0}(1500) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
+    "        \"C\"\n",
+    "    ),\n",
+    "}\n",
+    "new_model = original_model.rename_symbols(renames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "new_model.parameter_defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "new_model.components[\n",
+    "    R\"I_{J/\\psi(1S)_{+1} \\to \\gamma_{+1} \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Parameter substitution"
    ]
   },
@@ -284,7 +345,7 @@
    "source": [
     "new_model.components[\n",
     "    R\"A_{J/\\psi(1S)_{-1} \\to {f_{0}(980)}_{0} \\gamma_{-1}; {f_{0}(980)}_{0}\"\n",
-    "    r\" \\to \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
+    "    R\" \\to \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
     "]"
    ]
   },
@@ -322,67 +383,6 @@
     "    original_model.expression.subs(original_model.parameter_defaults).doit()\n",
     "    == evaluated_expr\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Couple parameters"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similarly to {ref}`usage/modify:Parameter substitution`, we can couple parameters renaming them:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "full-width"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "renames = {\n",
-    "    R\"C_{J/\\psi(1S) \\to {f_{0}(980)}_{0} \\gamma_{+1}; f_{0}(980) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
-    "        \"C\"\n",
-    "    ),\n",
-    "    R\"C_{J/\\psi(1S) \\to {f_{0}(1500)}_{0} \\gamma_{+1}; f_{0}(1500) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
-    "        \"C\"\n",
-    "    ),\n",
-    "}\n",
-    "new_model = original_model.rename_symbols(renames)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "new_model.parameter_defaults"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "full-width"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "new_model.components[\n",
-    "    R\"I_{J/\\psi(1S)_{+1} \\to \\gamma_{+1} \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
-    "]"
    ]
   }
  ],

--- a/docs/usage/modify.ipynb
+++ b/docs/usage/modify.ipynb
@@ -67,17 +67,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    ":::{tip}\n",
-    "\n",
-    "[Submit a feature request](https://github.com/ComPWA/ampform/issues/new/choose) if you would like to see these procedures provided by AmpForm as a function!\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -154,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's say we want to express all coefficients as a product of magnitude $C$  with their phase $\\phi$."
+    "Let's say we want to express all coefficients as a product $Ce^{i\\phi}$ of magnitude $C$  with phase $\\phi$."
    ]
   },
   {
@@ -294,9 +283,8 @@
    "outputs": [],
    "source": [
     "new_model.components[\n",
-    "    R\"A_{J/\\psi(1S)_{-1} \\to {f_{0}(980)}_{0} \\gamma_{-1};\"\n",
-    "    r\" {f_{0}(980)}_{0} \\to\"\n",
-    "    R\" \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
+    "    R\"A_{J/\\psi(1S)_{-1} \\to {f_{0}(980)}_{0} \\gamma_{-1}; {f_{0}(980)}_{0}\"\n",
+    "    r\" \\to \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
     "]"
    ]
   },
@@ -347,7 +335,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly to {ref}`usage/modify:Parameter substitution`, we can couple parameters by substituting pairs of parameters with a new {class}`~sympy.core.symbol.Symbol`:"
+    "Similarly to {ref}`usage/modify:Parameter substitution`, we can couple parameters renaming them:"
    ]
   },
   {
@@ -360,70 +348,23 @@
    },
    "outputs": [],
    "source": [
-    "parameter_couplings = [\n",
-    "    (\n",
-    "        sp.Symbol(\n",
-    "            R\"C_{J/\\psi(1S) \\to {f_{0}(980)}_{0} \\gamma_{+1}; f_{0}(980) \\to\"\n",
-    "            R\" \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
-    "        ),\n",
-    "        sp.Symbol(\n",
-    "            R\"C_{J/\\psi(1S) \\to {f_{0}(1500)}_{0} \\gamma_{+1}; f_{0}(1500) \\to\"\n",
-    "            R\" \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
-    "        ),\n",
-    "    )\n",
-    "]"
+    "renames = {\n",
+    "    R\"C_{J/\\psi(1S) \\to {f_{0}(980)}_{0} \\gamma_{+1}; f_{0}(980) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
+    "        \"C\"\n",
+    "    ),\n",
+    "    R\"C_{J/\\psi(1S) \\to {f_{0}(1500)}_{0} \\gamma_{+1}; f_{0}(1500) \\to \\pi^{0}_{0} \\pi^{0}_{0}}\": (\n",
+    "        \"C\"\n",
+    "    ),\n",
+    "}\n",
+    "new_model = original_model.rename_symbols(renames)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_expression = original_model.expression\n",
-    "new_parameter_defaults = dict(original_model.parameter_defaults)  # copy!\n",
-    "new_components = dict(original_model.components)  # copy!\n",
-    "\n",
-    "for i, (par1, par2) in enumerate(parameter_couplings):\n",
-    "    # construct new symbol for the coupled parameter pair\n",
-    "    original_assumptions = {\n",
-    "        **par1.assumptions0,\n",
-    "        **par2.assumptions0,\n",
-    "    }\n",
-    "    new_par = sp.Symbol(f\"C{i}\", **original_assumptions)\n",
-    "    # replace parameter defaults\n",
-    "    value = new_parameter_defaults[par1]\n",
-    "    new_parameter_defaults[new_par] = value\n",
-    "    del new_parameter_defaults[par1]\n",
-    "    del new_parameter_defaults[par2]\n",
-    "    # replace parameters in expression\n",
-    "    new_expression = new_expression.subs(par1, new_par, simultaneous=True)\n",
-    "    new_expression = new_expression.subs(par2, new_par, simultaneous=True)\n",
-    "    # replace parameters in each component\n",
-    "    new_components = {\n",
-    "        key: old_expression.subs(\n",
-    "            {\n",
-    "                par1: new_par,\n",
-    "                par2: new_par,\n",
-    "            },\n",
-    "            simultaneous=True,\n",
-    "        )\n",
-    "        for key, old_expression in new_components.items()\n",
-    "    }\n",
-    "\n",
-    "# create new model from the old\n",
-    "new_model = attrs.evolve(\n",
-    "    original_model,\n",
-    "    expression=new_expression,\n",
-    "    parameter_defaults=new_parameter_defaults,\n",
-    "    components=new_components,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "new_model.parameter_defaults"
@@ -440,9 +381,7 @@
    "outputs": [],
    "source": [
     "new_model.components[\n",
-    "    R\"A_{J/\\psi(1S)_{-1} \\to {f_{0}(980)}_{0} \\gamma_{-1};\"\n",
-    "    r\" {f_{0}(980)}_{0} \\to\"\n",
-    "    R\" \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
+    "    R\"I_{J/\\psi(1S)_{+1} \\to \\gamma_{+1} \\pi^{0}_{0} \\pi^{0}_{0}}\"\n",
     "]"
    ]
   }

--- a/docs/usage/modify.ipynb
+++ b/docs/usage/modify.ipynb
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since a {attr}`.HelicityModel.expression` is simply a {class}`sympy.Expr <sympy.core.expr.Expr>`, it's relatively easy to modify it. In this notebook, we show some examples using the following example decay:"
+    "Since a {attr}`.HelicityModel.expression` is simply a {class}`sympy.Expr <sympy.core.expr.Expr>`, it's relatively easy to modify it. The {class}`.HelicityModel` however also contains other attributes that need to be modified accordingly. In this notebook, we show how to do that for specific use cases using the following example decay:"
    ]
   },
   {

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -14,6 +14,7 @@ from collections import OrderedDict, abc
 from difflib import get_close_matches
 from functools import reduce
 from typing import (
+    TYPE_CHECKING,
     Any,
     DefaultDict,
     Dict,
@@ -60,6 +61,9 @@ if sys.version_info >= (3, 8):
 else:
     from singledispatchmethod import singledispatchmethod
 
+if TYPE_CHECKING:
+    from IPython.lib.pretty import PrettyPrinter
+
 ParameterValue = Union[float, complex, int]
 """Allowed value types for parameters."""
 
@@ -88,6 +92,24 @@ class ParameterValues(abc.Mapping):
 
     def __init__(self, mapping: Mapping[sp.Symbol, ParameterValue]) -> None:
         self.__parameters = dict(mapping)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.__parameters})"
+
+    def _repr_pretty_(self, p: "PrettyPrinter", cycle: bool) -> None:
+        class_name = type(self).__name__
+        if cycle:
+            p.text(f"{class_name}(...)")
+        else:
+            with p.group(indent=2, open=f"{class_name}({{"):
+                p.breakable()
+                for par, value in self.items():
+                    p.pretty(par)
+                    p.text(": ")
+                    p.pretty(value)
+                    p.text(",")
+                    p.breakable()
+            p.text("})")
 
     def __getitem__(self, key: Union[sp.Symbol, int, str]) -> "ParameterValue":
         par = self._get_parameter(key)

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -124,7 +124,7 @@ class UnevaluatedExpression(sp.Expr):
         - m_{1}^{2} + \frac{s}{4}
         """
         args = tuple(map(printer._print, self.args))
-        name = self.__class__.__name__
+        name = type(self).__name__
         if self._name is not None:
             name = self._name
         return f"{name}{args}"

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -142,13 +142,13 @@ class SliderKwargs(abc.Mapping):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}("
+            f"{type(self).__name__}("
             f"sliders={self._sliders}, "
             f"arg_to_symbol={self._arg_to_symbol})"
         )
 
     def _repr_pretty_(self, p: PrettyPrinter, cycle: bool) -> None:
-        class_name = self.__class__.__name__
+        class_name = type(self).__name__
         if cycle:
             p.text(f"{class_name}(...)")
         else:

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -1,9 +1,11 @@
 # pylint: disable=no-member, no-self-use
 
+import logging
 from typing import Tuple
 
 import pytest
 import sympy as sp
+from _pytest.logging import LogCaptureFixture
 from qrules import ReactionInfo
 
 from ampform import get_builder
@@ -115,6 +117,90 @@ class TestHelicityAmplitudeBuilder:
 
 
 class TestHelicityModel:
+    def test_rename_symbols_no_renames(
+        self, amplitude_model: Tuple[str, HelicityModel]
+    ):
+        _, model = amplitude_model
+        new_model = model.rename_symbols({})
+        assert new_model == model
+
+    def test_rename_parameters(
+        self, amplitude_model: Tuple[str, HelicityModel]
+    ):
+        _, model = amplitude_model
+        d1, d2 = sp.symbols("d_{f_{0}(980)} d_{f_{0}(1500)}")
+        assert {d1, d2} <= set(model.parameter_defaults)
+        assert {d1, d2} <= model.expression.free_symbols
+
+        new_d = sp.Symbol("d")
+        new_model = model.rename_symbols(
+            {
+                d1.name: new_d.name,
+                d2.name: new_d.name,
+            }
+        )
+        assert not {d1, d2} & new_model.expression.free_symbols
+        assert not {d1, d2} & set(new_model.parameter_defaults)
+        assert new_d in new_model.parameter_defaults
+        assert new_d in new_model.expression.free_symbols
+        assert (
+            len(new_model.expression.free_symbols)
+            == len(model.expression.free_symbols) - 1
+        )
+        assert (
+            len(new_model.parameter_defaults)
+            == len(model.parameter_defaults) - 1
+        )
+        assert (
+            model.expression.xreplace({d1: new_d, d2: new_d})
+            == new_model.expression
+        )
+
+    def test_rename_variables(
+        self, amplitude_model: Tuple[str, HelicityModel]
+    ):
+        _, model = amplitude_model
+        old_symbol = sp.Symbol("m_12", real=True)
+        assert old_symbol in model.kinematic_variables
+        assert old_symbol in model.expression.free_symbols
+
+        new_symbol = sp.Symbol("m_{f_0}", real=True)
+        new_model = model.rename_symbols({old_symbol.name: new_symbol.name})
+        assert old_symbol not in new_model.kinematic_variables
+        assert old_symbol not in new_model.expression.free_symbols
+        assert new_symbol in new_model.kinematic_variables
+        assert new_symbol in new_model.expression.free_symbols
+        assert (
+            model.expression.xreplace({old_symbol: new_symbol})
+            == new_model.expression
+        )
+
+    def test_assumptions_after_rename(
+        self, amplitude_model: Tuple[str, HelicityModel]
+    ):
+        # pylint: disable=protected-access
+        _, model = amplitude_model
+        old = "m_{f_{0}(980)}"
+        new = "m"
+        new_model = model.rename_symbols({old: new})
+        assert (
+            new_model.parameter_defaults._get_parameter(new).assumptions0
+            == model.parameter_defaults._get_parameter(old).assumptions0
+        )
+
+    def test_rename_symbols_warnings(
+        self,
+        amplitude_model: Tuple[str, HelicityModel],
+        caplog: LogCaptureFixture,
+    ):
+        _, model = amplitude_model
+        old_name = "non-existent"
+        with caplog.at_level(logging.WARNING):
+            new_model = model.rename_symbols({old_name: "new name"})
+        assert caplog.records
+        assert old_name in caplog.records[-1].msg
+        assert new_model == model
+
     def test_sum_components(self, amplitude_model: Tuple[str, HelicityModel]):
         # pylint: disable=cell-var-from-loop, line-too-long
         _, model = amplitude_model


### PR DESCRIPTION
See use case example [here]() (couple parameters). The method is makes it easier to address [this error](https://github.com/ComPWA/ampform/runs/5320069236?check_suite_focus=true) in #243.