### PR TITLE
refactor: extract formulate_form_factor()

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -240,6 +240,22 @@ def extend_EuclideanNorm() -> None:
     _append_code_rendering(expr)
 
 
+def extend_formulate_form_factor() -> None:
+    from ampform.dynamics import formulate_form_factor
+
+    s, m_a, m_b, L, d = sp.symbols("s m_a m_b L d")
+    form_factor = formulate_form_factor(
+        s, m_a, m_b, angular_momentum=L, meson_radius=d
+    )
+    _append_to_docstring(
+        formulate_form_factor,
+        f"""
+    .. math:: {sp.latex(form_factor)}
+        :label: formulate_form_factor
+    """,
+    )
+
+
 def extend_InvariantMass() -> None:
     from ampform.kinematics import InvariantMass
 

--- a/docs/usage/dynamics/k-matrix.ipynb
+++ b/docs/usage/dynamics/k-matrix.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While {mod}`ampform` does not yet provide a generic way to formulate an amplitude model with $\\boldsymbol{K}$-matrix dynamics, the (experimental) {mod}`.kmatrix` module makes it fairly simple to produce a symbolic expression for a parameterized $\\boldsymbol{K}$-matrix with an arbitrary number of poles and channels and play around with it interactively. For more info on the $\\boldsymbol{K}$-matrix, see the classic paper by Chung {cite}`chungPartialWaveAnalysis1995`, {pdg-review}`Resonances`, or this instructive presentation {cite}`meyerMatrixTutorial2008`.\n",
+    "While {mod}`ampform` does not yet provide a generic way to formulate an amplitude model with $\\boldsymbol{K}$-matrix dynamics, the (experimental) {mod}`.kmatrix` module makes it fairly simple to produce a symbolic expression for a parameterized $\\boldsymbol{K}$-matrix with an arbitrary number of poles and channels and play around with it interactively. For more info on the $\\boldsymbol{K}$-matrix, see the classic paper by Chung {cite}`chungPartialWaveAnalysis1995`, {pdg-review}`2021; Resonances`, or this instructive presentation {cite}`meyerMatrixTutorial2008`.\n",
     "\n",
     "Section {ref}`usage/dynamics/k-matrix:Physics` summarizes {cite}`chungPartialWaveAnalysis1995`, so that the {mod}`.kmatrix` module can reference to the equations. It also points out some subtleties and deviations.\n",
     "\n",
@@ -501,7 +501,7 @@
     "\n",
     "with $\\gamma_{R,i}$ some _real_ constants and $\\Gamma^0_{R,i}$ the **partial width** of each pole. In the Lorentz-invariant form, the fixed width $\\Gamma^0$ is replaced by an \"energy dependent\" {class}`.EnergyDependentWidth` $\\Gamma(s)$.[^phase-space-factor-normalization] The **width** for each pole can be computed as $\\Gamma^0_R = \\sum_i\\Gamma^0_{R,i}$.\n",
     "\n",
-    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.EnergyDependentWidth` as in {pdg-review}`2020; Resonances; p.6`, Eq. (49.21). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor at the pole position $m_R$. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_i(m_R)}$."
+    "[^phase-space-factor-normalization]: Unlike Eq. (77) in {cite}`chungPartialWaveAnalysis1995`, AmpForm defines {class}`.EnergyDependentWidth` as in {pdg-review}`2021; Resonances; p.6`, Eq. (50.28). The difference is that the phase space factor denoted by $\\rho_i$ in Eq. (77) in {cite}`chungPartialWaveAnalysis1995` is divided by the phase space factor at the pole position $m_R$. So in AmpForm, the choice is $\\rho_i \\to \\frac{\\rho_i(s)}{\\rho_i(m_R)}$."
    ]
   },
   {
@@ -527,7 +527,7 @@
     "\n",
     "with $B_{R,i}(q(s))$ the **centrifugal damping factor** (see {class}`.BlattWeisskopfSquared`) for channel $i$ and $\\beta_R^0$ some (generally complex) constants that describe the production information of the decaying state $R$. Usually, these constants are rescaled just like the residue functions in {eq}`residue function`:\n",
     "\n",
-    "[^damping-factor-P-parametrization]: Just as with [^phase-space-factor-normalization], we have smuggled a bit in the last equation in order to be able to reproduce Eq. (49.19) in {pdg-review}`2020; Resonances; p.6` in the case $n=1,n_R=1$, on which {func}`.relativistic_breit_wigner_with_ff` is based.\n",
+    "[^damping-factor-P-parametrization]: Just as with [^phase-space-factor-normalization], we have smuggled a bit in the last equation in order to be able to reproduce Equation (50.23) in {pdg-review}`2021; Resonances; p.9` in the case $n=1,n_R=1$, on which {func}`.relativistic_breit_wigner_with_ff` is based.\n",
     "\n",
     "```{margin}\n",
     "{cite}`chungPartialWaveAnalysis1995` Eq. (121)\n",
@@ -1445,7 +1445,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[^pole-vs-resonance]: See {pdg-review}`2020; Resonances; p.5` and Section 49.1 for a discussion about what poles and resonances are. See also the intro to Section 5 in {cite}`chungPartialWaveAnalysis1995`."
+    "[^pole-vs-resonance]: See {pdg-review}`2021; Resonances`, Section 50.1, for a discussion about what poles and resonances are. See also the intro to Section 5 in {cite}`chungPartialWaveAnalysis1995`."
    ]
   },
   {

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ filterwarnings =
     error
     ignore:.*invalid value encountered in sqrt.*:RuntimeWarning
     ignore:Passing a schema to Validator.iter_errors is deprecated.*:DeprecationWarning
+    ignore:The .* argument to NotebookFile is deprecated.*:pytest.PytestRemovedIn8Warning
     ignore:The distutils package is deprecated.*:DeprecationWarning
     ignore:The distutils.* module is deprecated.*:DeprecationWarning
     ignore:unclosed .*:ResourceWarning

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -45,8 +45,8 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
 
     Note that equal powers of :math:`z` appear in the nominator and the
     denominator, while some sources have nominator :math:`1`, instead of
-    :math:`z^L`. Compare for instance :pdg-review:`2020; Resonances; p.6`, just
-    before Equation (49.20).
+    :math:`z^L`. Compare for instance Equation (50.27) in :pdg-review:`2021;
+    Resonances; p.9`.
 
     Each of these cases for :math:`L` has been taken from
     :cite:`pychyGekoppeltePartialwellenanalyseAnnihilationen2016`, p.59,
@@ -165,7 +165,7 @@ class PhaseSpaceFactorProtocol(Protocol):
 class PhaseSpaceFactor(UnevaluatedExpression):
     """Standard phase-space factor, using :func:`BreakupMomentumSquared`.
 
-    See :pdg-review:`2020; Resonances; p.4`, Equation (49.8).
+    See :pdg-review:`2021; Resonances; p.6`, Equation (50.9).
     """
 
     is_commutative = True
@@ -310,7 +310,7 @@ def _phase_space_factor_denominator(s) -> sp.Mul:
 class EnergyDependentWidth(UnevaluatedExpression):
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
-    See :pdg-review:`2020; Resonances; p.6` and
+    See Equation (50.28) in :pdg-review:`2021; Resonances; p.9` and
     :cite:`asnerDalitzPlotAnalysis2006`, equation (6). Default value for
     :code:`phsp_factor` is :meth:`PhaseSpaceFactor`.
 
@@ -446,7 +446,7 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     """Relativistic Breit-Wigner with `.BlattWeisskopfSquared` factor.
 
     See :ref:`usage/dynamics:_With_ form factor` and
-    :pdg-review:`2020; Resonances; p.6`.
+    :pdg-review:`2021; Resonances; p.9`.
     """
     q_squared = BreakupMomentumSquared(s, m_a, m_b)
     ff_squared = BlattWeisskopfSquared(

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -448,17 +448,32 @@ def relativistic_breit_wigner_with_ff(  # pylint: disable=too-many-arguments
     See :ref:`usage/dynamics:_With_ form factor` and
     :pdg-review:`2021; Resonances; p.9`.
     """
+    form_factor = formulate_form_factor(
+        s, m_a, m_b, angular_momentum, meson_radius
+    )
+    energy_dependent_width = EnergyDependentWidth(
+        s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius, phsp_factor
+    )
+    return (mass0 * gamma0 * form_factor) / (
+        mass0**2 - s - energy_dependent_width * mass0 * sp.I
+    )
+
+
+def formulate_form_factor(
+    s, m_a, m_b, angular_momentum, meson_radius
+) -> sp.Expr:
+    """Formulate a Blatt-Weisskopf form factor.
+
+    Returns the production process factor :math:`n_a` from Equation (50.26) in
+    :pdg-review:`2021; Resonances; p.9`, which features the
+    `~sympy.functions.elementary.miscellaneous.sqrt` of a
+    `.BlattWeisskopfSquared`.
+    """
     q_squared = BreakupMomentumSquared(s, m_a, m_b)
     ff_squared = BlattWeisskopfSquared(
         angular_momentum, z=q_squared * meson_radius**2
     )
-    form_factor = sp.sqrt(ff_squared)
-    mass_dependent_width = EnergyDependentWidth(
-        s, mass0, gamma0, m_a, m_b, angular_momentum, meson_radius, phsp_factor
-    )
-    return (mass0 * gamma0 * form_factor) / (
-        mass0**2 - s - mass_dependent_width * mass0 * sp.I
-    )
+    return sp.sqrt(ff_squared)
 
 
 def _indices_to_subscript(indices: Sequence[int]) -> str:

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -121,8 +121,7 @@ class RelativisticBreitWignerBuilder:
             by a Blatt-Weisskopf form factor, see Equation
             :eq:`BlattWeisskopfSquared`.
         energy_dependent_width: Use an `.EnergyDependentWidth` in the
-            denominator of the Breit-Wigner. See
-            :pdg-review:`2020; Resonances; p.6`, Equation (49.21).
+            denominator of the Breit-Wigner.
         phsp_factor: A class that complies with the
             `.PhaseSpaceFactorProtocol` that is used in the energy-dependent
             width. Defaults to `.PhaseSpaceFactor`.

--- a/src/ampform/dynamics/kmatrix.py
+++ b/src/ampform/dynamics/kmatrix.py
@@ -16,11 +16,10 @@ from abc import ABC, abstractmethod
 import sympy as sp
 
 from ampform.dynamics import (
-    BlattWeisskopfSquared,
-    BreakupMomentumSquared,
     EnergyDependentWidth,
     PhaseSpaceFactor,
     PhaseSpaceFactorProtocol,
+    formulate_form_factor,
 )
 from ampform.sympy import create_symbol_matrix
 
@@ -406,11 +405,9 @@ class RelativisticPVector(TMatrix):
         gamma = residue_constant[pole_id, i]
         mass0 = pole_position[pole_id]
         width = pole_width[pole_id, i]
-        q_squared = BreakupMomentumSquared(s, m_a[i], m_b[i])
-        form_factor_squared = BlattWeisskopfSquared(
-            angular_momentum, z=q_squared * meson_radius**2
+        form_factor = formulate_form_factor(
+            s, m_a[i], m_b[i], angular_momentum, meson_radius
         )
-        form_factor = sp.sqrt(form_factor_squared)
         return sp.Sum(
             beta * gamma * mass0 * width * form_factor / (mass0**2 - s),
             (pole_id, 1, n_poles),


### PR DESCRIPTION
Extracted the formulation of the production form factor in [PDG2021 Equation (50.26)](https://pdg.lbl.gov/2021/reviews/rpp2021-rev-resonances.pdf#page=9) as a separate function. See [this preview]() for the formula.

It formulates a special version of (the square root of) `BlattWeisskopfSquared`, with break-up momentum and a meson radius (impact parameter) and is used in `relativistic_breit_wigner_with_ff()`, `RelativisticPVector`, `create_non_dynamic_with_ff()`, etc.

This PR might solve #261: if something needs to be changed there, one simply needs to modify this new `formulate_form_factor()` function.


--- 

Also updated all PDG references to PDG2021.