### PR TITLE
refactor: rename PhaseSpaceFactorAnalytic

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -177,6 +177,22 @@ def extend_ComplexSqrt() -> None:
     )
 
 
+def extend_EqualMassPhaseSpaceFactor() -> None:
+    from ampform.dynamics import EqualMassPhaseSpaceFactor, PhaseSpaceFactorAbs
+
+    s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
+    expr = EqualMassPhaseSpaceFactor(s, m_a, m_b)
+    _append_latex_doit_definition(expr)
+    rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
+    _append_to_docstring(
+        EqualMassPhaseSpaceFactor,
+        f"""
+    with :math:`{sp.latex(rho_hat)}` defined by `.PhaseSpaceFactorAbs`
+    :eq:`PhaseSpaceFactorAbs`.
+    """,
+    )
+
+
 def extend_EnergyDependentWidth() -> None:
     from ampform.dynamics import EnergyDependentWidth
 
@@ -288,22 +304,6 @@ def extend_PhaseSpaceFactorAbs() -> None:
         PhaseSpaceFactorAbs,
         """
     with :math:`q^2(s)` defined as :eq:`BreakupMomentumSquared`.
-    """,
-    )
-
-
-def extend_PhaseSpaceFactorAnalytic() -> None:
-    from ampform.dynamics import PhaseSpaceFactorAbs, PhaseSpaceFactorAnalytic
-
-    s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
-    expr = PhaseSpaceFactorAnalytic(s, m_a, m_b)
-    _append_latex_doit_definition(expr)
-    rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
-    _append_to_docstring(
-        PhaseSpaceFactorAnalytic,
-        f"""
-    with :math:`{sp.latex(rho_hat)}` defined by `.PhaseSpaceFactorAbs`
-    :eq:`PhaseSpaceFactorAbs`.
     """,
     )
 

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -375,7 +375,7 @@
    "outputs": [],
    "source": [
     "from ampform.dynamics import (\n",
-    "    PhaseSpaceFactorAnalytic,\n",
+    "    EqualMassPhaseSpaceFactor,\n",
     "    relativistic_breit_wigner_with_ff,\n",
     ")\n",
     "\n",
@@ -387,7 +387,7 @@
     "    m_b=m_b,\n",
     "    angular_momentum=L,\n",
     "    meson_radius=1,\n",
-    "    phsp_factor=PhaseSpaceFactorAnalytic,\n",
+    "    phsp_factor=EqualMassPhaseSpaceFactor,\n",
     ")\n",
     "rel_bw_with_ff"
    ]
@@ -418,7 +418,7 @@
     "    m_b=m_b,\n",
     "    angular_momentum=L,\n",
     "    meson_radius=1,\n",
-    "    phsp_factor=PhaseSpaceFactorAnalytic,\n",
+    "    phsp_factor=EqualMassPhaseSpaceFactor,\n",
     ")\n",
     "Math(sp.multiline_latex(width, width.evaluate(), environment=\"eqnarray\"))"
    ]
@@ -481,7 +481,7 @@
     "    m_b=m_b,\n",
     "    angular_momentum=L,\n",
     "    meson_radius=d,\n",
-    "    phsp_factor=PhaseSpaceFactorAnalytic,\n",
+    "    phsp_factor=EqualMassPhaseSpaceFactor,\n",
     ")\n",
     "\n",
     "# Lambdify\n",

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -409,7 +409,7 @@
     "    alpha=0.7,\n",
     ")\n",
     "\n",
-    "ax_rho_ac.set_title(\"analytic\")\n",
+    "ax_rho_ac.set_title(R\"equal mass $\\rho^\\mathrm{eq}(m^2)$\")\n",
     "iplt.plot(\n",
     "    plot_domain,\n",
     "    func_real(np_rho_ac),\n",

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following 'case-by-case' **analytic continuation**, {class}`.PhaseSpaceFactorAnalytic`:"
+    "The following 'case-by-case' **analytic continuation** for decay products with an _equal_ mass, {class}`.EqualMassPhaseSpaceFactor`:"
    ]
   },
   {
@@ -218,9 +218,9 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import PhaseSpaceFactorAnalytic\n",
+    "from ampform.dynamics import EqualMassPhaseSpaceFactor\n",
     "\n",
-    "rho_ac = PhaseSpaceFactorAnalytic(s, m_a, m_b)\n",
+    "rho_ac = EqualMassPhaseSpaceFactor(s, m_a, m_b)\n",
     "Math(sp.multiline_latex(rho_ac, rho_ac.evaluate(), environment=\"eqnarray\"))"
    ]
   },
@@ -299,7 +299,7 @@
     "\n",
     "m = sp.Symbol(\"m\", real=True)\n",
     "rho_c = PhaseSpaceFactorComplex(m**2, m_a, m_b)\n",
-    "rho_ac = PhaseSpaceFactorAnalytic(m**2, m_a, m_b)\n",
+    "rho_ac = EqualMassPhaseSpaceFactor(m**2, m_a, m_b)\n",
     "np_rho_c, sliders = symplot.prepare_sliders(\n",
     "    plot_symbol=m, expression=rho_c.doit()\n",
     ")\n",

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -154,7 +154,7 @@ class PhaseSpaceFactorProtocol(Protocol):
 
     Use this `~typing.Protocol` when defining other implementations of a phase
     space factor. Compare for instance `.PhaseSpaceFactor` and
-    `.PhaseSpaceFactorAnalytic`.
+    `.EqualMassPhaseSpaceFactor`.
     """
 
     def __call__(self, s, m_a, m_b) -> sp.Expr:
@@ -198,7 +198,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
 
     This version of the phase space factor is often denoted as
     :math:`\hat{\rho}` and is used in analytic continuation
-    (`.PhaseSpaceFactorAnalytic`).
+    (`.EqualMassPhaseSpaceFactor`).
     """
 
     is_commutative = True
@@ -221,7 +221,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
 
 
 @implement_doit_method
-class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
+class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
     """Analytic continuation for the :func:`PhaseSpaceFactor`.
 
     See :pdg-review:`2018; Resonances; p.9` and
@@ -233,7 +233,7 @@ class PhaseSpaceFactorAnalytic(UnevaluatedExpression):
 
     is_commutative = True
 
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorAnalytic:
+    def __new__(cls, s, m_a, m_b, **hints) -> EqualMassPhaseSpaceFactor:
         return create_expression(cls, s, m_a, m_b, **hints)
 
     def evaluate(self) -> sp.Expr:

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -180,8 +180,7 @@ class PhaseSpaceFactor(UnevaluatedExpression):
         return sp.sqrt(q_squared) / denominator
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
         subscript = _indices_to_subscript(_determine_indices(s))
         name = R"\rho" + subscript if self._name is None else self._name
         return Rf"{name}\left({s}\right)"
@@ -213,8 +212,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
         return sp.sqrt(sp.Abs(q_squared)) / denominator
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
         subscript = _indices_to_subscript(_determine_indices(s))
         name = R"\hat{\rho}" + subscript if self._name is None else self._name
         return Rf"{name}\left({s}\right)"
@@ -243,8 +241,7 @@ class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
         return _analytic_continuation(rho_hat, s, s_threshold)
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
         subscript = _indices_to_subscript(_determine_indices(s))
         name = (
             R"\rho^\mathrm{eq}" + subscript
@@ -274,8 +271,7 @@ class PhaseSpaceFactorComplex(UnevaluatedExpression):
         return ComplexSqrt(q_squared) / denominator
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
         subscript = _indices_to_subscript(_determine_indices(s))
         name = (
             R"\rho^\mathrm{c}" + subscript
@@ -379,8 +375,8 @@ class EnergyDependentWidth(UnevaluatedExpression):
         return gamma0 * (form_factor_sq / form_factor0_sq) * (rho / rho0)
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, _, width, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
+        width = printer._print(self.args[2])
         subscript = _indices_to_subscript(_determine_indices(width))
         name = Rf"\Gamma{subscript}" if self._name is None else self._name
         return Rf"{name}\left({s}\right)"
@@ -417,8 +413,7 @@ class BreakupMomentumSquared(UnevaluatedExpression):
         return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)  # type: ignore[operator]
 
     def _latex(self, printer: LatexPrinter, *args) -> str:
-        s, *_ = self.args
-        s = printer._print(s)
+        s = printer._print(self.args[0])
         subscript = _indices_to_subscript(_determine_indices(s))
         name = "q^2" + subscript if self._name is None else self._name
         return Rf"{name}\left({s}\right)"

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -247,7 +247,7 @@ class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
         s = printer._print(s)
         subscript = _indices_to_subscript(_determine_indices(s))
         name = (
-            R"\rho^\mathrm{ac}" + subscript
+            R"\rho^\mathrm{eq}" + subscript
             if self._name is None
             else self._name
         )

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -11,8 +11,8 @@ from qrules.particle import Particle
 
 from . import (
     EnergyDependentWidth,
+    EqualMassPhaseSpaceFactor,
     PhaseSpaceFactor,
-    PhaseSpaceFactorAnalytic,
     PhaseSpaceFactorProtocol,
     formulate_form_factor,
     relativistic_breit_wigner,
@@ -268,14 +268,14 @@ form factor and a 'normal' `.PhaseSpaceFactor`.
 create_analytic_breit_wigner = RelativisticBreitWignerBuilder(
     energy_dependent_width=True,
     form_factor=True,
-    phsp_factor=PhaseSpaceFactorAnalytic,
+    phsp_factor=EqualMassPhaseSpaceFactor,
 ).__call__
 """
 Create a `.relativistic_breit_wigner_with_ff` with analytic continuation.
 
 This is a convenience function for a `RelativisticBreitWignerBuilder` _with_
 form factor and a 'analytic' phase space factor (see
-`.PhaseSpaceFactorAnalytic`).
+`.EqualMassPhaseSpaceFactor`).
 
 .. seealso:: :doc:`/usage/dynamics/analytic-continuation`.
 """

--- a/tests/dynamics/test_sympy.py
+++ b/tests/dynamics/test_sympy.py
@@ -7,7 +7,7 @@ import sympy as sp
 from ampform.dynamics import (
     BlattWeisskopfSquared,
     EnergyDependentWidth,
-    PhaseSpaceFactorAnalytic,
+    EqualMassPhaseSpaceFactor,
 )
 from ampform.sympy import UnevaluatedExpression
 
@@ -43,7 +43,7 @@ class TestUnevaluatedExpression:
             m_b=m_a,
             angular_momentum=0,
             meson_radius=1,
-            phsp_factor=PhaseSpaceFactorAnalytic,
+            phsp_factor=EqualMassPhaseSpaceFactor,
             name="Gamma_1",
         )
         pickled_obj = pickle.dumps(expr)

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -7,8 +7,8 @@ from qrules import ParticleCollection
 from ampform.dynamics import (
     BlattWeisskopfSquared,
     EnergyDependentWidth,
+    EqualMassPhaseSpaceFactor,
     PhaseSpaceFactor,
-    PhaseSpaceFactorAnalytic,
 )
 from ampform.helicity import HelicityModel
 
@@ -58,10 +58,10 @@ class TestEnergyDependentWidth:
             m_b=m_b,
             angular_momentum=angular_momentum,
             meson_radius=d,
-            phsp_factor=PhaseSpaceFactorAnalytic,
+            phsp_factor=EqualMassPhaseSpaceFactor,
             name="Gamma_1",
         )
-        assert width.phsp_factor is PhaseSpaceFactorAnalytic
+        assert width.phsp_factor is EqualMassPhaseSpaceFactor
         assert width._name == "Gamma_1"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,8 @@ commands =
 [testenv:nb]
 description =
     Run all notebooks with pytest
+passenv =
+    EXECUTE_NB
 allowlist_externals =
     pytest
 commands =


### PR DESCRIPTION
[`PhaseSpaceFactorAnalytic`](https://ampform.readthedocs.io/en/0.13.3/api/ampform.dynamics.html#ampform.dynamics.PhaseSpaceFactorAnalytic) has been renamed to [`EqualMassPhaseSpaceFactor`](https://ampform--264.org.readthedocs.build/en/264/api/ampform.dynamics.html#ampform.dynamics.EqualMassPhaseSpaceFactor).

`PhaseSpaceFactorAnalytic` was a bit of a misleading name: it only works if the masses of the decay products are _equal_. This should instead be addressed by implementing [[TR-003]](https://compwa-org.rtfd.io/report/003.html), which will result in (yet) another phase space factor expression class.