### PR TITLE
refactor: move phsp factors to separate module

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -100,6 +100,7 @@
         "mypy",
         "nishijima",
         "numpy",
+        "parametrizations",
         "permutate",
         "pydocstyle",
         "pylint",

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -156,7 +156,7 @@ def extend_BoostZMatrix() -> None:
 
 
 def extend_BreakupMomentumSquared() -> None:
-    from ampform.dynamics import BreakupMomentumSquared
+    from ampform.dynamics.phasespace import BreakupMomentumSquared
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = BreakupMomentumSquared(s, m_a, m_b)
@@ -178,7 +178,10 @@ def extend_ComplexSqrt() -> None:
 
 
 def extend_EqualMassPhaseSpaceFactor() -> None:
-    from ampform.dynamics import EqualMassPhaseSpaceFactor, PhaseSpaceFactorAbs
+    from ampform.dynamics.phasespace import (
+        EqualMassPhaseSpaceFactor,
+        PhaseSpaceFactorAbs,
+    )
 
     s, m_a, m_b = sp.symbols(R"s, m_a, m_b")
     expr = EqualMassPhaseSpaceFactor(s, m_a, m_b)
@@ -281,7 +284,7 @@ def extend_InvariantMass() -> None:
 
 
 def extend_PhaseSpaceFactor() -> None:
-    from ampform.dynamics import PhaseSpaceFactor
+    from ampform.dynamics.phasespace import PhaseSpaceFactor
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactor(s, m_a, m_b)
@@ -295,7 +298,7 @@ def extend_PhaseSpaceFactor() -> None:
 
 
 def extend_PhaseSpaceFactorAbs() -> None:
-    from ampform.dynamics import PhaseSpaceFactorAbs
+    from ampform.dynamics.phasespace import PhaseSpaceFactorAbs
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorAbs(s, m_a, m_b)
@@ -309,7 +312,7 @@ def extend_PhaseSpaceFactorAbs() -> None:
 
 
 def extend_PhaseSpaceFactorComplex() -> None:
-    from ampform.dynamics import PhaseSpaceFactorComplex
+    from ampform.dynamics.phasespace import PhaseSpaceFactorComplex
 
     s, m_a, m_b = sp.symbols("s, m_a, m_b")
     expr = PhaseSpaceFactorComplex(s, m_a, m_b)
@@ -323,7 +326,7 @@ def extend_PhaseSpaceFactorComplex() -> None:
 
 
 def extend_PhaseSpaceFactorSWave() -> None:
-    from ampform.dynamics import PhaseSpaceFactorSWave
+    from ampform.dynamics.phasespace import PhaseSpaceFactorSWave
 
     s, m_a, m_b = sp.symbols("s m_a m_b")
     expr = PhaseSpaceFactorSWave(s, m_a, m_b)
@@ -414,7 +417,7 @@ def extend_ThreeMomentum() -> None:
 
 
 def extend_chew_mandelstam_s_wave() -> None:
-    from ampform.dynamics import chew_mandelstam_s_wave
+    from ampform.dynamics.phasespace import chew_mandelstam_s_wave
 
     s, m_a, m_b = sp.symbols("s m_a m_b")
     expr = chew_mandelstam_s_wave(s, m_a, m_b)

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -369,7 +369,8 @@
    "outputs": [],
    "source": [
     "from ampform.dynamics import PhaseSpaceFactor  # noqa: F401\n",
-    "from ampform.dynamics import BreakupMomentumSquared, ComplexSqrt\n",
+    "from ampform.dynamics import BreakupMomentumSquared\n",
+    "from ampform.sympy.math import ComplexSqrt\n",
     "\n",
     "\n",
     "def breakup_momentum(s: sp.Symbol, m_a: sp.Symbol, m_b: sp.Symbol) -> sp.Expr:\n",

--- a/docs/usage/dynamics/analytic-continuation.ipynb
+++ b/docs/usage/dynamics/analytic-continuation.ipynb
@@ -347,7 +347,7 @@
    },
    "outputs": [],
    "source": [
-    "from ampform.dynamics import ComplexSqrt\n",
+    "from ampform.sympy.math import ComplexSqrt\n",
     "\n",
     "m = sp.Symbol(\"m\", real=True)\n",
     "rho_c = PhaseSpaceFactorComplex(m**2, m_a, m_b)\n",

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -1,7 +1,5 @@
-# cspell:ignore Asner mhash
-# pylint: disable=arguments-differ,protected-access,unbalanced-tuple-unpacking,
-# pylint: disable=unused-argument, W0223
-# https://stackoverflow.com/a/22224042
+# cspell:ignore asner mhash
+# pylint: disable=abstract-method, arguments-differ, protected-access
 """Lineshape functions that describe the dynamics of an interaction.
 
 .. seealso:: :doc:`/usage/dynamics` and
@@ -9,12 +7,7 @@
 """
 from __future__ import annotations
 
-import re
-import sys
-from typing import Sequence
-
 import sympy as sp
-from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter
 
 from ampform.sympy import (
@@ -22,12 +15,19 @@ from ampform.sympy import (
     create_expression,
     implement_doit_method,
 )
-from ampform.sympy.math import ComplexSqrt
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol  # pragma: no cover
+# pyright: reportUnusedImport=false
+from .phasespace import (
+    BreakupMomentumSquared,
+    EqualMassPhaseSpaceFactor,
+    PhaseSpaceFactor,
+    PhaseSpaceFactorAbs,
+    PhaseSpaceFactorComplex,
+    PhaseSpaceFactorProtocol,
+    PhaseSpaceFactorSWave,
+    _determine_indices,
+    _indices_to_subscript,
+)
 
 
 @implement_doit_method
@@ -41,7 +41,7 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
         z: Argument of the Blatt-Weisskopf function :math:`B_L^2(z)`. A usual
             choice is :math:`z = (d q)^2` with :math:`d` the impact parameter
             and :math:`q` the breakup-momentum (see
-            :func:`BreakupMomentumSquared`).
+            `.BreakupMomentumSquared`).
 
     Note that equal powers of :math:`z` appear in the nominator and the
     denominator, while some sources have nominator :math:`1`, instead of
@@ -149,220 +149,13 @@ class BlattWeisskopfSquared(UnevaluatedExpression):
         return Rf"B_{{{angular_momentum}}}^2\left({z}\right)"
 
 
-class PhaseSpaceFactorProtocol(Protocol):
-    """Protocol that is used by `.EnergyDependentWidth`.
-
-    Use this `~typing.Protocol` when defining other implementations of a phase
-    space factor. Compare for instance `.PhaseSpaceFactor` and
-    `.EqualMassPhaseSpaceFactor`.
-    """
-
-    def __call__(self, s, m_a, m_b) -> sp.Expr:
-        """Expected `~inspect.signature`."""
-
-
-@implement_doit_method
-class PhaseSpaceFactor(UnevaluatedExpression):
-    """Standard phase-space factor, using :func:`BreakupMomentumSquared`.
-
-    See :pdg-review:`2021; Resonances; p.6`, Equation (50.9).
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactor:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        q_squared = BreakupMomentumSquared(s, m_a, m_b)
-        denominator = _phase_space_factor_denominator(s)
-        return sp.sqrt(q_squared) / denominator
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = R"\rho" + subscript if self._name is None else self._name
-        return Rf"{name}\left({s}\right)"
-
-
-@implement_doit_method
-class PhaseSpaceFactorAbs(UnevaluatedExpression):
-    r"""Phase space factor square root over the absolute value.
-
-    As opposed to `.PhaseSpaceFactor`, this takes the
-    `~sympy.functions.elementary.complexes.Abs` value of
-    `.BreakupMomentumSquared`, then the
-    :func:`~sympy.functions.elementary.miscellaneous.sqrt`.
-
-    This version of the phase space factor is often denoted as
-    :math:`\hat{\rho}` and is used in analytic continuation
-    (`.EqualMassPhaseSpaceFactor`).
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorAbs:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        q_squared = BreakupMomentumSquared(s, m_a, m_b)
-        denominator = _phase_space_factor_denominator(s)
-        return sp.sqrt(sp.Abs(q_squared)) / denominator
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = R"\hat{\rho}" + subscript if self._name is None else self._name
-        return Rf"{name}\left({s}\right)"
-
-
-@implement_doit_method
-class PhaseSpaceFactorSWave(UnevaluatedExpression):
-    r"""Phase space factor using :func:`chew_mandelstam_s_wave`.
-
-    This `PhaseSpaceFactor` provides an analytic continuation for decay
-    products with both equal and unequal masses (compare
-    `EqualMassPhaseSpaceFactor`).
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorSWave:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        chew_mandelstam = chew_mandelstam_s_wave(s, m_a, m_b)
-        return -sp.I * chew_mandelstam
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = (
-            R"\rho^\mathrm{CM}" + subscript
-            if self._name is None
-            else self._name
-        )
-        return Rf"{name}\left({s}\right)"
-
-
-def chew_mandelstam_s_wave(s, m_a, m_b):
-    """Chew-Mandelstam function for :math:`S`-waves (no angular momentum)."""
-    q_squared = BreakupMomentumSquared(s, m_a, m_b)
-    q = ComplexSqrt(q_squared)
-    left_term = sp.Mul(
-        2 * q / sp.sqrt(s),
-        sp.log(
-            (m_a**2 + m_b**2 - s + 2 * sp.sqrt(s) * q) / (2 * m_a * m_b)
-        ),
-        evaluate=False,
-    )
-    right_term = (
-        (m_a**2 - m_b**2)
-        * (1 / s - 1 / (m_a + m_b) ** 2)
-        * sp.log(m_a / m_b)
-    )
-    # evaluate=False in order to keep same style as PDG
-    return sp.Mul(
-        1 / (16 * sp.pi**2),
-        left_term - right_term,
-        evaluate=False,
-    )
-
-
-@implement_doit_method
-class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
-    """Analytic continuation for the :func:`PhaseSpaceFactor`.
-
-    See :pdg-review:`2018; Resonances; p.9` and
-    :doc:`/usage/dynamics/analytic-continuation`.
-
-    **Warning**: The PDG specifically derives this formula for a two-body decay
-    *with equal masses*.
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> EqualMassPhaseSpaceFactor:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
-        s_threshold = (m_a + m_b) ** 2  # type: ignore[operator]
-        return _analytic_continuation(rho_hat, s, s_threshold)
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = (
-            R"\rho^\mathrm{eq}" + subscript
-            if self._name is None
-            else self._name
-        )
-        return Rf"{name}\left({s}\right)"
-
-
-@implement_doit_method
-class PhaseSpaceFactorComplex(UnevaluatedExpression):
-    """Phase-space factor with `.ComplexSqrt`.
-
-    Same as :func:`PhaseSpaceFactor`, but using a `.ComplexSqrt` that does have
-    defined behavior for defined for negative input values.
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorComplex:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        q_squared = BreakupMomentumSquared(s, m_a, m_b)
-        denominator = _phase_space_factor_denominator(s)
-        return ComplexSqrt(q_squared) / denominator
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = (
-            R"\rho^\mathrm{c}" + subscript
-            if self._name is None
-            else self._name
-        )
-        return Rf"{name}\left({s}\right)"
-
-
-def _analytic_continuation(rho, s, s_threshold) -> sp.Piecewise:
-    return sp.Piecewise(
-        (
-            sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
-            s < 0,
-        ),
-        (
-            rho + sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
-            s > s_threshold,
-        ),
-        (
-            2 * sp.I * rho / sp.pi * sp.atan(1 / rho),
-            True,
-        ),
-    )
-
-
-def _phase_space_factor_denominator(s) -> sp.Mul:
-    return 8 * sp.pi * sp.sqrt(s)
-
-
 @implement_doit_method
 class EnergyDependentWidth(UnevaluatedExpression):
     r"""Mass-dependent width, coupled to the pole position of the resonance.
 
     See Equation (50.28) in :pdg-review:`2021; Resonances; p.9` and
     :cite:`asnerDalitzPlotAnalysis2006`, equation (6). Default value for
-    :code:`phsp_factor` is :meth:`PhaseSpaceFactor`.
+    :code:`phsp_factor` is `.PhaseSpaceFactor`.
 
     Note that the `.BlattWeisskopfSquared` of AmpForm is normalized in the
     sense that equal powers of :math:`z` appear in the nominator and the
@@ -436,43 +229,6 @@ class EnergyDependentWidth(UnevaluatedExpression):
         return Rf"{name}\left({s}\right)"
 
 
-@implement_doit_method
-class BreakupMomentumSquared(UnevaluatedExpression):
-    r"""Squared value of the two-body break-up momentum.
-
-    For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
-    absolute value of the momentum of both :math:`a` and :math:`b` in the rest
-    frame of :math:`R`.
-
-    Args:
-        s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
-            Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
-            invariant mass of decaying particle :math:`R`.
-
-        m_a: Mass of decay product :math:`a`.
-        m_b: Mass of decay product :math:`b`.
-
-    It's up to the caller in which way to take the square root of this break-up
-    momentum.See :doc:`/usage/dynamics/analytic-continuation` and
-    `.ComplexSqrt`.
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> BreakupMomentumSquared:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)  # type: ignore[operator]
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = "q^2" + subscript if self._name is None else self._name
-        return Rf"{name}\left({s}\right)"
-
-
 def relativistic_breit_wigner(s, mass0, gamma0) -> sp.Expr:
     """Relativistic Breit-Wigner lineshape.
 
@@ -523,49 +279,3 @@ def formulate_form_factor(
         angular_momentum, z=q_squared * meson_radius**2
     )
     return sp.sqrt(ff_squared)
-
-
-def _indices_to_subscript(indices: Sequence[int]) -> str:
-    """Create a LaTeX subscript from a list of indices.
-
-    >>> _indices_to_subscript([])
-    ''
-    >>> _indices_to_subscript([1])
-    '_{1}'
-    >>> _indices_to_subscript([1, 2])
-    '_{1,2}'
-    """
-    if len(indices) == 0:
-        return ""
-    subscript = ",".join(map(str, indices))
-    return "_{" + subscript + "}"
-
-
-def _determine_indices(symbol) -> list[int]:
-    r"""Extract any indices if available from a `~sympy.core.symbol.Symbol`.
-
-    >>> _determine_indices(sp.Symbol("m1"))
-    [1]
-    >>> _determine_indices(sp.Symbol("m_a2"))
-    [2]
-    >>> _determine_indices(sp.Symbol(R"\alpha_{i2, 5}"))
-    [2, 5]
-    >>> _determine_indices(sp.Symbol("m"))
-    []
-
-    `~sympy.tensor.indexed.Indexed` instances can also be handled:
-    >>> m_a = sp.IndexedBase("m_a")
-    >>> _determine_indices(m_a[0])
-    [0]
-    """
-    _, _, subscripts = split_super_sub(sp.latex(symbol))
-    if not subscripts:
-        return []
-    subscript: str = subscripts[-1]
-    subscript = re.sub(r"[^0-9^\,]", "", subscript)
-    subscript = f"[{subscript}]"
-    try:
-        indices = eval(subscript)  # pylint: disable=eval-used
-    except SyntaxError:
-        return []
-    return list(indices)

--- a/src/ampform/dynamics/phasespace.py
+++ b/src/ampform/dynamics/phasespace.py
@@ -33,7 +33,16 @@ class PhaseSpaceFactorProtocol(Protocol):
     """
 
     def __call__(self, s, m_a, m_b) -> sp.Expr:
-        """Expected `~inspect.signature`."""
+        """Expected `~inspect.signature`.
+
+        Args:
+            s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
+                Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
+                invariant mass of decaying particle :math:`R`.
+
+            m_a: Mass of decay product :math:`a`.
+            m_b: Mass of decay product :math:`b`.
+        """
 
 
 @implement_doit_method
@@ -43,14 +52,6 @@ class BreakupMomentumSquared(UnevaluatedExpression):
     For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
     absolute value of the momentum of both :math:`a` and :math:`b` in the rest
     frame of :math:`R`.
-
-    Args:
-        s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
-            Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
-            invariant mass of decaying particle :math:`R`.
-
-        m_a: Mass of decay product :math:`a`.
-        m_b: Mass of decay product :math:`b`.
 
     It's up to the caller in which way to take the square root of this break-up
     momentum. See :doc:`/usage/dynamics/analytic-continuation` and

--- a/src/ampform/dynamics/phasespace.py
+++ b/src/ampform/dynamics/phasespace.py
@@ -53,7 +53,7 @@ class BreakupMomentumSquared(UnevaluatedExpression):
         m_b: Mass of decay product :math:`b`.
 
     It's up to the caller in which way to take the square root of this break-up
-    momentum.See :doc:`/usage/dynamics/analytic-continuation` and
+    momentum. See :doc:`/usage/dynamics/analytic-continuation` and
     `.ComplexSqrt`.
     """
 

--- a/src/ampform/dynamics/phasespace.py
+++ b/src/ampform/dynamics/phasespace.py
@@ -1,6 +1,16 @@
 # pylint: disable=abstract-method, arguments-differ, protected-access
 # pylint: disable=unbalanced-tuple-unpacking
-"""Different phase space factors to handle analytic continuation."""
+"""Different parametrizations of phase space factors.
+
+Phase space factors are computed by integrating over the phase space element
+given by Equation (49.12) in :pdg-review:`2021; Kinematics; p.2`. See also
+Equation (50.9) on :pdg-review:`2021; Resonances; p.6`. This integral is not
+always easy to solve, which leads to different parametrizations.
+
+This module provides several parametrizations. They all comply with the
+`PhaseSpaceFactorProtocol`, so that they can be used in parametrizations like
+`.EnergyDependentWidth`.
+"""
 from __future__ import annotations
 
 import re
@@ -28,8 +38,16 @@ class PhaseSpaceFactorProtocol(Protocol):
     """Protocol that is used by `.EnergyDependentWidth`.
 
     Use this `~typing.Protocol` when defining other implementations of a phase
-    space factor. Compare for instance `.PhaseSpaceFactor` and
-    `.EqualMassPhaseSpaceFactor`.
+    space factor. Some implementations:
+
+    - `PhaseSpaceFactor`
+    - `PhaseSpaceFactorAbs`
+    - `PhaseSpaceFactorComplex`
+    - `PhaseSpaceFactorSWave`
+    - `EqualMassPhaseSpaceFactor`
+
+    Even `BreakupMomentumSquared` and :func:`chew_mandelstam_s_wave` comply
+    with this protocol, but are technically speaking not phase space factors.
     """
 
     def __call__(self, s, m_a, m_b) -> sp.Expr:
@@ -51,11 +69,13 @@ class BreakupMomentumSquared(UnevaluatedExpression):
 
     For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
     absolute value of the momentum of both :math:`a` and :math:`b` in the rest
-    frame of :math:`R`.
+    frame of :math:`R`. See Equation (49.17) on :pdg-review:`2021; Kinematics;
+    p.3`, as well as Equation (50.5) on :pdg-review:`2021; Resonances; p.5`.
 
     It's up to the caller in which way to take the square root of this break-up
-    momentum. See :doc:`/usage/dynamics/analytic-continuation` and
-    `.ComplexSqrt`.
+    momentum, because :math:`q^2` can have negative values for non-zero
+    :math:`m_a,m_b`. In this case, one may want to use `.ComplexSqrt` instead
+    of the standard :func:`~sympy.functions.elementary.miscellaneous.sqrt`.
     """
 
     is_commutative = True
@@ -109,8 +129,7 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
     :func:`~sympy.functions.elementary.miscellaneous.sqrt`.
 
     This version of the phase space factor is often denoted as
-    :math:`\hat{\rho}` and is used in analytic continuation
-    (`.EqualMassPhaseSpaceFactor`).
+    :math:`\hat{\rho}` and is used in `.EqualMassPhaseSpaceFactor`.
     """
 
     is_commutative = True

--- a/src/ampform/dynamics/phasespace.py
+++ b/src/ampform/dynamics/phasespace.py
@@ -132,6 +132,36 @@ class PhaseSpaceFactorAbs(UnevaluatedExpression):
 
 
 @implement_doit_method
+class PhaseSpaceFactorComplex(UnevaluatedExpression):
+    """Phase-space factor with `.ComplexSqrt`.
+
+    Same as :func:`PhaseSpaceFactor`, but using a `.ComplexSqrt` that does have
+    defined behavior for defined for negative input values.
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorComplex:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        q_squared = BreakupMomentumSquared(s, m_a, m_b)
+        denominator = _phase_space_factor_denominator(s)
+        return ComplexSqrt(q_squared) / denominator
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = (
+            R"\rho^\mathrm{c}" + subscript
+            if self._name is None
+            else self._name
+        )
+        return Rf"{name}\left({s}\right)"
+
+
+@implement_doit_method
 class PhaseSpaceFactorSWave(UnevaluatedExpression):
     r"""Phase space factor using :func:`chew_mandelstam_s_wave`.
 
@@ -212,36 +242,6 @@ class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
         subscript = _indices_to_subscript(_determine_indices(s))
         name = (
             R"\rho^\mathrm{eq}" + subscript
-            if self._name is None
-            else self._name
-        )
-        return Rf"{name}\left({s}\right)"
-
-
-@implement_doit_method
-class PhaseSpaceFactorComplex(UnevaluatedExpression):
-    """Phase-space factor with `.ComplexSqrt`.
-
-    Same as :func:`PhaseSpaceFactor`, but using a `.ComplexSqrt` that does have
-    defined behavior for defined for negative input values.
-    """
-
-    is_commutative = True
-
-    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorComplex:
-        return create_expression(cls, s, m_a, m_b, **hints)
-
-    def evaluate(self) -> sp.Expr:
-        s, m_a, m_b = self.args
-        q_squared = BreakupMomentumSquared(s, m_a, m_b)
-        denominator = _phase_space_factor_denominator(s)
-        return ComplexSqrt(q_squared) / denominator
-
-    def _latex(self, printer: LatexPrinter, *args) -> str:
-        s = printer._print(self.args[0])
-        subscript = _indices_to_subscript(_determine_indices(s))
-        name = (
-            R"\rho^\mathrm{c}" + subscript
             if self._name is None
             else self._name
         )

--- a/src/ampform/dynamics/phasespace.py
+++ b/src/ampform/dynamics/phasespace.py
@@ -1,0 +1,314 @@
+# pylint: disable=abstract-method, arguments-differ, protected-access
+# pylint: disable=unbalanced-tuple-unpacking
+"""Different phase space factors to handle analytic continuation."""
+from __future__ import annotations
+
+import re
+import sys
+from typing import Sequence
+
+import sympy as sp
+from sympy.printing.conventions import split_super_sub
+from sympy.printing.latex import LatexPrinter
+
+from ampform.sympy import (
+    UnevaluatedExpression,
+    create_expression,
+    implement_doit_method,
+)
+from ampform.sympy.math import ComplexSqrt
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol  # pragma: no cover
+
+
+class PhaseSpaceFactorProtocol(Protocol):
+    """Protocol that is used by `.EnergyDependentWidth`.
+
+    Use this `~typing.Protocol` when defining other implementations of a phase
+    space factor. Compare for instance `.PhaseSpaceFactor` and
+    `.EqualMassPhaseSpaceFactor`.
+    """
+
+    def __call__(self, s, m_a, m_b) -> sp.Expr:
+        """Expected `~inspect.signature`."""
+
+
+@implement_doit_method
+class BreakupMomentumSquared(UnevaluatedExpression):
+    r"""Squared value of the two-body break-up momentum.
+
+    For a two-body decay :math:`R \to ab`, the *break-up momentum* is the
+    absolute value of the momentum of both :math:`a` and :math:`b` in the rest
+    frame of :math:`R`.
+
+    Args:
+        s: :ref:`Mandelstam variable <pwa:mandelstam-variables>` :math:`s`.
+            Commonly, this is just :math:`s = m_R^2`, with :math:`m_R` the
+            invariant mass of decaying particle :math:`R`.
+
+        m_a: Mass of decay product :math:`a`.
+        m_b: Mass of decay product :math:`b`.
+
+    It's up to the caller in which way to take the square root of this break-up
+    momentum.See :doc:`/usage/dynamics/analytic-continuation` and
+    `.ComplexSqrt`.
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> BreakupMomentumSquared:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        return (s - (m_a + m_b) ** 2) * (s - (m_a - m_b) ** 2) / (4 * s)  # type: ignore[operator]
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = "q^2" + subscript if self._name is None else self._name
+        return Rf"{name}\left({s}\right)"
+
+
+@implement_doit_method
+class PhaseSpaceFactor(UnevaluatedExpression):
+    """Standard phase-space factor, using :func:`BreakupMomentumSquared`.
+
+    See :pdg-review:`2021; Resonances; p.6`, Equation (50.9).
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactor:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        q_squared = BreakupMomentumSquared(s, m_a, m_b)
+        denominator = _phase_space_factor_denominator(s)
+        return sp.sqrt(q_squared) / denominator
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = R"\rho" + subscript if self._name is None else self._name
+        return Rf"{name}\left({s}\right)"
+
+
+@implement_doit_method
+class PhaseSpaceFactorAbs(UnevaluatedExpression):
+    r"""Phase space factor square root over the absolute value.
+
+    As opposed to `.PhaseSpaceFactor`, this takes the
+    `~sympy.functions.elementary.complexes.Abs` value of
+    `.BreakupMomentumSquared`, then the
+    :func:`~sympy.functions.elementary.miscellaneous.sqrt`.
+
+    This version of the phase space factor is often denoted as
+    :math:`\hat{\rho}` and is used in analytic continuation
+    (`.EqualMassPhaseSpaceFactor`).
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorAbs:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        q_squared = BreakupMomentumSquared(s, m_a, m_b)
+        denominator = _phase_space_factor_denominator(s)
+        return sp.sqrt(sp.Abs(q_squared)) / denominator
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = R"\hat{\rho}" + subscript if self._name is None else self._name
+        return Rf"{name}\left({s}\right)"
+
+
+@implement_doit_method
+class PhaseSpaceFactorSWave(UnevaluatedExpression):
+    r"""Phase space factor using :func:`chew_mandelstam_s_wave`.
+
+    This `PhaseSpaceFactor` provides an analytic continuation for decay
+    products with both equal and unequal masses (compare
+    `EqualMassPhaseSpaceFactor`).
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorSWave:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        chew_mandelstam = chew_mandelstam_s_wave(s, m_a, m_b)
+        return -sp.I * chew_mandelstam
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = (
+            R"\rho^\mathrm{CM}" + subscript
+            if self._name is None
+            else self._name
+        )
+        return Rf"{name}\left({s}\right)"
+
+
+def chew_mandelstam_s_wave(s, m_a, m_b):
+    """Chew-Mandelstam function for :math:`S`-waves (no angular momentum)."""
+    q_squared = BreakupMomentumSquared(s, m_a, m_b)
+    q = ComplexSqrt(q_squared)
+    left_term = sp.Mul(
+        2 * q / sp.sqrt(s),
+        sp.log(
+            (m_a**2 + m_b**2 - s + 2 * sp.sqrt(s) * q) / (2 * m_a * m_b)
+        ),
+        evaluate=False,
+    )
+    right_term = (
+        (m_a**2 - m_b**2)
+        * (1 / s - 1 / (m_a + m_b) ** 2)
+        * sp.log(m_a / m_b)
+    )
+    # evaluate=False in order to keep same style as PDG
+    return sp.Mul(
+        1 / (16 * sp.pi**2),
+        left_term - right_term,
+        evaluate=False,
+    )
+
+
+@implement_doit_method
+class EqualMassPhaseSpaceFactor(UnevaluatedExpression):
+    """Analytic continuation for the :func:`PhaseSpaceFactor`.
+
+    See :pdg-review:`2018; Resonances; p.9` and
+    :doc:`/usage/dynamics/analytic-continuation`.
+
+    **Warning**: The PDG specifically derives this formula for a two-body decay
+    *with equal masses*.
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> EqualMassPhaseSpaceFactor:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        rho_hat = PhaseSpaceFactorAbs(s, m_a, m_b)
+        s_threshold = (m_a + m_b) ** 2  # type: ignore[operator]
+        return _analytic_continuation(rho_hat, s, s_threshold)
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = (
+            R"\rho^\mathrm{eq}" + subscript
+            if self._name is None
+            else self._name
+        )
+        return Rf"{name}\left({s}\right)"
+
+
+@implement_doit_method
+class PhaseSpaceFactorComplex(UnevaluatedExpression):
+    """Phase-space factor with `.ComplexSqrt`.
+
+    Same as :func:`PhaseSpaceFactor`, but using a `.ComplexSqrt` that does have
+    defined behavior for defined for negative input values.
+    """
+
+    is_commutative = True
+
+    def __new__(cls, s, m_a, m_b, **hints) -> PhaseSpaceFactorComplex:
+        return create_expression(cls, s, m_a, m_b, **hints)
+
+    def evaluate(self) -> sp.Expr:
+        s, m_a, m_b = self.args
+        q_squared = BreakupMomentumSquared(s, m_a, m_b)
+        denominator = _phase_space_factor_denominator(s)
+        return ComplexSqrt(q_squared) / denominator
+
+    def _latex(self, printer: LatexPrinter, *args) -> str:
+        s = printer._print(self.args[0])
+        subscript = _indices_to_subscript(_determine_indices(s))
+        name = (
+            R"\rho^\mathrm{c}" + subscript
+            if self._name is None
+            else self._name
+        )
+        return Rf"{name}\left({s}\right)"
+
+
+def _analytic_continuation(rho, s, s_threshold) -> sp.Piecewise:
+    return sp.Piecewise(
+        (
+            sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
+            s < 0,
+        ),
+        (
+            rho + sp.I * rho / sp.pi * sp.log(sp.Abs((1 + rho) / (1 - rho))),
+            s > s_threshold,
+        ),
+        (
+            2 * sp.I * rho / sp.pi * sp.atan(1 / rho),
+            True,
+        ),
+    )
+
+
+def _phase_space_factor_denominator(s) -> sp.Mul:
+    return 8 * sp.pi * sp.sqrt(s)
+
+
+def _indices_to_subscript(indices: Sequence[int]) -> str:
+    """Create a LaTeX subscript from a list of indices.
+
+    >>> _indices_to_subscript([])
+    ''
+    >>> _indices_to_subscript([1])
+    '_{1}'
+    >>> _indices_to_subscript([1, 2])
+    '_{1,2}'
+    """
+    if len(indices) == 0:
+        return ""
+    subscript = ",".join(map(str, indices))
+    return "_{" + subscript + "}"
+
+
+def _determine_indices(symbol) -> list[int]:
+    r"""Extract any indices if available from a `~sympy.core.symbol.Symbol`.
+
+    >>> _determine_indices(sp.Symbol("m1"))
+    [1]
+    >>> _determine_indices(sp.Symbol("m_a2"))
+    [2]
+    >>> _determine_indices(sp.Symbol(R"\alpha_{i2, 5}"))
+    [2, 5]
+    >>> _determine_indices(sp.Symbol("m"))
+    []
+
+    `~sympy.tensor.indexed.Indexed` instances can also be handled:
+    >>> m_a = sp.IndexedBase("m_a")
+    >>> _determine_indices(m_a[0])
+    [0]
+    """
+    _, _, subscripts = split_super_sub(sp.latex(symbol))
+    if not subscripts:
+        return []
+    subscript: str = subscripts[-1]
+    subscript = re.sub(r"[^0-9^\,]", "", subscript)
+    subscript = f"[{subscript}]"
+    try:
+        indices = eval(subscript)  # pylint: disable=eval-used
+    except SyntaxError:
+        return []
+    return list(indices)

--- a/tests/sympy/test_math.py
+++ b/tests/sympy/test_math.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import sympy as sp
 
-from ampform.dynamics import ComplexSqrt
+from ampform.sympy.math import ComplexSqrt
 
 
 class TestComplexSqrt:


### PR DESCRIPTION
This PR moves all functions and classes related to phase space factors to a new module, [`ampform.dymamics.phasespace`](), so that the [`ampform.dymamics`]() becomes easier to understand. This has become even more important since the addition of yet another phase space factor in #265 and potentially even more when implementing the [dispersion integral](https://compwa-org.readthedocs.io/report/003.html#general-dispersion-integral) from [TR-003](https://compwa-org.readthedocs.io/report/003.html).