### PR TITLE
refactor: return sympy.Symbol instead of str

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -296,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As can be seen, the expression contains several {class}`~sympy.core.symbol.Symbol`s. Some of these represent (kinematic) **variables**, such as the helicity angles $\\phi_0$ and $\\theta_0$ (see {func}`.get_helicity_angle_label` for the meaning of their subscripts). Others will later on be interpreted **parameters** when fitting the model to data.\n",
+    "As can be seen, the expression contains several {class}`~sympy.core.symbol.Symbol`s. Some of these represent (kinematic) **variables**, such as the helicity angles $\\phi_0$ and $\\theta_0$ (see {func}`.get_helicity_angle_symbols` for the meaning of their subscripts). Others will later on be interpreted **parameters** when fitting the model to data.\n",
     "\n",
     "The {class}`.HelicityModel` comes with expressions for these {attr}`~.HelicityModel.kinematic_variables`, so that it's possible to compute them from 4-momentum data."
    ]
@@ -732,7 +732,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case ($J/\\psi \\to \\gamma f_0, f_0 \\to \\pi^0\\pi^0$) _without dynamics_, the total intensity is only dependent on the $\\theta$ angle of $\\gamma$ in the center of mass frame (see {func}`.get_helicity_angle_label`):"
+    "In this case ($J/\\psi \\to \\gamma f_0, f_0 \\to \\pi^0\\pi^0$) _without dynamics_, the total intensity is only dependent on the $\\theta$ angle of $\\gamma$ in the center of mass frame (see {func}`.get_helicity_angle_symbols`):"
    ]
   },
   {

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -39,7 +39,7 @@ class TwoBodyDecay:
        1-to-2 body decay
 
     2. its two `.children` are sorted by whether they decay further or not (see
-       `.get_helicity_angle_label`, `.formulate_wigner_d`, and
+       `.get_helicity_angle_symbols`, `.formulate_wigner_d`, and
        `.formulate_clebsch_gordan_coefficients`).
 
     3. the `.TwoBodyDecay` is hashable, so that it can be used as a key (see

--- a/src/ampform/helicity/naming.py
+++ b/src/ampform/helicity/naming.py
@@ -316,15 +316,18 @@ def generate_transition_label(transition: StateTransition) -> str:
     )
 
 
-def get_helicity_angle_label(
+def get_helicity_angle_symbols(
     topology: Topology, state_id: int
-) -> tuple[str, str]:
+) -> tuple[sp.Symbol, sp.Symbol]:
     r"""Generate a nested helicity angle label for :math:`\phi,\theta`.
 
     See :func:`get_boost_chain_suffix` for the meaning of the suffix.
     """
     suffix = get_boost_chain_suffix(topology, state_id)
-    return f"phi{suffix}", f"theta{suffix}"
+    return (
+        sp.Symbol(f"phi{suffix}", real=True),
+        sp.Symbol(f"theta{suffix}", real=True),
+    )
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Some renames:
- [`get_helicity_angle_label()`](https://ampform.readthedocs.io/en/0.13.3/api/ampform.helicity.naming.html#ampform.helicity.naming.get_helicity_angle_label) → [`get_helicity_angle_symbols()` ](https://ampform--269.org.readthedocs.build/en/269/api/ampform.helicity.naming.html#ampform.helicity.naming.get_helicity_angle_symbols)
- [`get_invariant_mass_label()`](https://ampform.readthedocs.io/en/0.13.3/api/ampform.kinematics.html#ampform.kinematics.get_invariant_mass_label) → [`get_invariant_mass_symbol()`](https://ampform--269.org.readthedocs.build/en/269/api/ampform.kinematics.html#ampform.kinematics.get_invariant_mass_symbol)

They now return [`sympy.Symbol`](https://docs.sympy.org/latest/modules/core.html#sympy.core.symbol.Symbol)s instead of strings, so that assumptions can be set consistently (see #268).