### PR TITLE
refactor: block ComplexSqrt from evaluating

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -171,7 +171,7 @@ def extend_ComplexSqrt() -> None:
     _append_to_docstring(
         ComplexSqrt,
         Rf"""
-    .. math:: {sp.latex(expr)} = {sp.latex(expr.evaluate())}
+    .. math:: {sp.latex(expr)} = {sp.latex(expr.get_definition())}
         :label: ComplexSqrt
     """,
     )

--- a/tests/sympy/test_math.py
+++ b/tests/sympy/test_math.py
@@ -5,11 +5,25 @@ import sympy as sp
 
 from ampform.sympy.math import ComplexSqrt
 
+a, b = sp.symbols("a b")
+
 
 class TestComplexSqrt:
-    def test_evaluate(self):
+    @pytest.mark.parametrize(
+        "arg",
+        [
+            sp.Symbol("x"),
+            sp.Symbol("x", real=True),
+            sp.Symbol("x", positive=True),
+            a + b**2,
+        ],
+    )
+    def test_blocked_doit_for_expressions(self, arg):
+        assert ComplexSqrt(arg).doit() == ComplexSqrt(arg)
+
+    def test_get_definition(self):
         x = sp.Symbol("x")
-        expr = ComplexSqrt(x).evaluate()
+        expr = ComplexSqrt(x).get_definition()
         assert expr == sp.Piecewise(
             (sp.I * sp.sqrt(-x), x < 0),
             (sp.sqrt(x), True),


### PR DESCRIPTION
This prevents [ComplexSqrt](https://ampform.readthedocs.io/en/0.13.3/api/ampform.sympy.math.html#ampform.sympy.math.ComplexSqrt) from evaluating on `sympy.Expr` input, which is important when `Symbol` assumptions are changed (#268).