### PR TITLE
refactor: deactivate default spin alignment

### DIFF
--- a/docs/usage/helicity/spin-alignment.ipynb
+++ b/docs/usage/helicity/spin-alignment.ipynb
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As described in {doc}`compwa-org:report/015`, the {doc}`'standard' helicity formalism </usage/helicity/formalism>` is not suited for state transitions that have different decay topologies. For this reason, the {class}`.HelicityAmplitudeBuilder` insert a number of Wigner-$D$ function into the amplitude model in case there is more than one underlying {class}`~qrules.topology.Topology`. It is easiest to see this by inspecting the resulting {attr}`.HelicityModel.intensity` and its {attr}`~.HelicityModel.amplitudes`:"
+    "As described in {doc}`compwa-org:report/015`, the {doc}`'standard' helicity formalism </usage/helicity/formalism>` is not suited for state transitions that have different decay topologies. For this reason, the {class}`.HelicityAmplitudeBuilder` can insert a number of Wigner-$D$ function into the amplitude model in case there is more than one underlying {class}`~qrules.topology.Topology`. It is easiest to see this by inspecting the resulting {attr}`.HelicityModel.intensity` and its {attr}`~.HelicityModel.amplitudes`:"
    ]
   },
   {
@@ -136,6 +136,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "'Spin alignment' can be now switched off or on by setting {attr}`.HelicityAmplitudeBuilder.align_spin`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -146,6 +153,7 @@
    "outputs": [],
    "source": [
     "builder = ampform.get_builder(reaction)\n",
+    "builder.align_spin = True\n",
     "model = builder.formulate()\n",
     "model.intensity"
    ]
@@ -195,7 +203,7 @@
    "source": [
     "For more information about these angles, see {ref}`compwa-org:report/015:Compute Wigner rotation angles` in TR-015.\n",
     "\n",
-    "Spin alignment can be switched off or on by setting {attr}`.HelicityAmplitudeBuilder.align_spin`:"
+    "By default, {attr}`~.HelicityAmplitudeBuilder.align_spin` is set to {obj}`False` and the total {attr}`.HelicityModel.intensity` does not contain alignment Wigner-$D$ functions:"
    ]
   },
   {
@@ -219,8 +227,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.8.12"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -147,13 +147,6 @@ def is_opposite_helicity_state(topology: Topology, state_id: int) -> bool:
     return tuple(state_fs_ids) > tuple(sibling_fs_ids)
 
 
-@lru_cache(maxsize=None)
-def collect_topologies(
-    transitions: tuple[StateTransition, ...]
-) -> list[Topology]:
-    return sorted({t.topology for t in transitions})
-
-
 def get_sibling_state_id(topology: Topology, state_id: int) -> int:
     r"""Get the sibling state ID for a state in an isobar decay.
 


### PR DESCRIPTION
`HelicityModelBuilder.align_spin` now needs to be set specifically to activate spin alignment for multiple topologies.