### PR TITLE
feat: implement `improve_latex_rendering()`

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -101,8 +101,11 @@
     "\n",
     "from IPython.display import Math\n",
     "\n",
+    "from ampform.io import improve_latex_rendering\n",
+    "\n",
     "LOGGER = logging.getLogger()\n",
-    "LOGGER.setLevel(logging.ERROR)"
+    "LOGGER.setLevel(logging.ERROR)\n",
+    "improve_latex_rendering()"
    ]
   },
   {

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -82,7 +82,9 @@
     "import sympy as sp\n",
     "from IPython.display import Math\n",
     "\n",
-    "from ampform.io import aslatex"
+    "from ampform.io import aslatex, improve_latex_rendering\n",
+    "\n",
+    "improve_latex_rendering()"
    ]
   },
   {

--- a/docs/usage/helicity/spin-alignment.ipynb
+++ b/docs/usage/helicity/spin-alignment.ipynb
@@ -89,9 +89,11 @@
     "from IPython.display import Math\n",
     "\n",
     "import ampform\n",
+    "from ampform.io import improve_latex_rendering\n",
     "\n",
     "LOGGER = logging.getLogger()\n",
-    "LOGGER.setLevel(logging.ERROR)"
+    "LOGGER.setLevel(logging.ERROR)\n",
+    "improve_latex_rendering()"
    ]
   },
   {

--- a/src/ampform/io/__init__.py
+++ b/src/ampform/io/__init__.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name protected-access unused-argument
 """Input-output functions for `ampform` and `sympy` objects.
 
 .. tip:: This function are registered with :func:`functools.singledispatch` and can be
@@ -70,3 +71,14 @@ def _(obj: Iterable) -> str:
         latex += Rf"  {item} \\" + "\n"
     latex += R"\end{array}"
     return latex
+
+
+def improve_latex_rendering() -> None:
+    """Improve LaTeX rendering of an `~sympy.tensor.indexed.Indexed` object."""
+
+    def _print_Indexed_latex(self, printer, *args):  # noqa: N802
+        base = printer._print(self.base)
+        indices = ", ".join(map(printer._print, self.indices))
+        return f"{base}_{{{indices}}}"
+
+    sp.Indexed._latex = _print_Indexed_latex  # type: ignore[attr-defined]


### PR DESCRIPTION
Implemented `ampform.io.improve_latex_rendering()` in order to avoid import side-effects. To improve the rendering of indices of `sympy.Indexed` instances, call:

```python
from ampform.io import improve_latex_rendering

improve_latex_rendering()
```