### PR TITLE
refactor: rename two-body Wigner-D and CG functions

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -497,22 +497,22 @@ def extend_chew_mandelstam_s_wave() -> None:
     )
 
 
-def extend_formulate_clebsch_gordan_coefficients() -> None:
-    from ampform.helicity import formulate_clebsch_gordan_coefficients
+def extend_formulate_isobar_cg_coefficients() -> None:
+    from ampform.helicity import formulate_isobar_cg_coefficients
 
     _append_to_docstring(
-        formulate_clebsch_gordan_coefficients,
+        formulate_isobar_cg_coefficients,
         __get_graphviz_state_transition_example(
             formalism="canonical-helicity", transition_number=1
         ),
     )
 
 
-def extend_formulate_wigner_d() -> None:
-    from ampform.helicity import formulate_wigner_d
+def extend_formulate_isobar_wigner_d() -> None:
+    from ampform.helicity import formulate_isobar_wigner_d
 
     _append_to_docstring(
-        formulate_wigner_d,
+        formulate_isobar_wigner_d,
         __get_graphviz_state_transition_example("helicity"),
     )
 

--- a/docs/usage/helicity/formalism.ipynb
+++ b/docs/usage/helicity/formalism.ipynb
@@ -335,7 +335,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See {func}`.formulate_wigner_d` and {func}`.formulate_clebsch_gordan_coefficients` for how these Wigner-$D$ functions and Clebsch-Gordan coefficients are computed for each node on a {class}`~qrules.transition.StateTransition`.\n",
+    "See {func}`.formulate_isobar_wigner_d` and {func}`.formulate_isobar_cg_coefficients` for how these Wigner-$D$ functions and Clebsch-Gordan coefficients are computed for each node on a {class}`~qrules.transition.StateTransition`.\n",
     "\n",
     "We can see this also from the original {class}`~qrules.transition.ReactionInfo` objects. Let's select only the {attr}`~qrules.transition.ReactionInfo.transitions` where the $a_1(1260)^+$ resonance has spin projection $-1$ (taken to be helicity $-1$ in the helicity formalism). We then see just one {class}`~qrules.transition.StateTransition` in the helicity basis and three transitions in the canonical basis:"
    ]

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -672,7 +672,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
     def _formulate_partial_decay(
         self, transition: StateTransition, node_id: int
     ) -> sp.Expr:
-        wigner_d = formulate_wigner_d(transition, node_id)
+        wigner_d = formulate_isobar_wigner_d(transition, node_id)
         dynamics = self.__formulate_dynamics(transition, node_id)
         if self.use_helicity_couplings:
             coupling = self.__generate_helicity_coupling(transition, node_id)
@@ -801,14 +801,14 @@ class CanonicalAmplitudeBuilder(HelicityAmplitudeBuilder):
         self, transition: StateTransition, node_id: int
     ) -> sp.Expr:
         amplitude = super()._formulate_partial_decay(transition, node_id)
-        cg_coefficients = formulate_clebsch_gordan_coefficients(transition, node_id)
+        cg_coefficients = formulate_isobar_cg_coefficients(transition, node_id)
         return cg_coefficients * amplitude
 
 
-def formulate_clebsch_gordan_coefficients(
+def formulate_isobar_cg_coefficients(
     transition: StateTransition, node_id: int
 ) -> sp.Expr:
-    r"""Compute the two Clebsch-Gordan coefficients for a state transition node.
+    r"""Compute the two Clebsch-Gordan coefficients for an isobar node.
 
     In the **canonical basis** (also called **partial wave basis**),
     :doc:`Clebsch-Gordan coefficients <sympy:modules/physics/quantum/cg>` ensure that
@@ -824,7 +824,7 @@ def formulate_clebsch_gordan_coefficients(
     \to 2, 3`, we get:
 
     .. math:: C^{s_1,\lambda}_{L,0,S,\lambda} C^{S,\lambda}_{s_2,\lambda_2,s_3,-\lambda_3}
-        :label: formulate_clebsch_gordan_coefficients
+        :label: formulate_isobar_cg_coefficients
 
     with:
 
@@ -849,7 +849,7 @@ def formulate_clebsch_gordan_coefficients(
     ...     final_state=[("gamma", [-1]), "f(0)(980)"],
     ... )
     >>> transition = reaction.transitions[1]  # angular momentum 2
-    >>> formulate_clebsch_gordan_coefficients(transition, node_id=0)
+    >>> formulate_isobar_cg_coefficients(transition, node_id=0)
     CG(1, -1, 0, 0, 1, -1)*CG(2, 0, 1, -1, 1, -1)
 
     .. math::
@@ -888,14 +888,14 @@ def formulate_clebsch_gordan_coefficients(
     return sp.Mul(cg_ls, cg_ss, evaluate=False)
 
 
-def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
-    r"""Compute `~sympy.physics.quantum.spin.WignerD` for a transition node.
+def formulate_isobar_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
+    r"""Compute `~sympy.physics.quantum.spin.WignerD` for an isobar node.
 
     Following :cite:`kutschkeAngularDistributionCookbook1996`, Eq. (10). For a two-body
     decay :math:`1 \to 2, 3`, we get
 
     .. math:: D^{s_1}_{m_1,\lambda_2-\lambda_3}(-\phi,\theta,0)
-        :label: formulate_wigner_d
+        :label: formulate_isobar_wigner_d
 
     with:
 
@@ -923,7 +923,7 @@ def formulate_wigner_d(transition: StateTransition, node_id: int) -> sp.Expr:
     ...     final_state=[("gamma", [-1]), "f(0)(980)"],
     ... )
     >>> transition = reaction.transitions[0]
-    >>> formulate_wigner_d(transition, node_id=0)
+    >>> formulate_isobar_wigner_d(transition, node_id=0)
     WignerD(1, 1, -1, -phi_0, theta_0, 0)
 
     .. math::

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -37,8 +37,8 @@ class TwoBodyDecay:
        decay
 
     2. its two `.children` are sorted by whether they decay further or not (see
-       `.get_helicity_angle_symbols`, `.formulate_wigner_d`, and
-       `.formulate_clebsch_gordan_coefficients`).
+       `.get_helicity_angle_symbols`, `.formulate_isobar_wigner_d`, and
+       `.formulate_isobar_cg_coefficients`).
 
     3. the `.TwoBodyDecay` is hashable, so that it can be used as a key (see
        `.set_dynamics`.)
@@ -130,8 +130,8 @@ def is_opposite_helicity_state(topology: Topology, state_id: int) -> bool:
     minus sign the **"opposite helicity" state**. The other state is called **helicity
     state**. The choice of (opposite) helicity state affects not only the sign in the
     Wigner-:math:`D` function, but also the choice of angles: the argument of the
-    Wigner-:math:`D` function returned by :func:`.formulate_wigner_d` are the angles of
-    the helicity state.
+    Wigner-:math:`D` function returned by :func:`.formulate_isobar_wigner_d` are the
+    angles of the helicity state.
     """
     sibling_id = get_sibling_state_id(topology, state_id)
     state_fs_ids = determine_attached_final_state(topology, state_id)

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -16,7 +16,7 @@ from ampform.helicity import (
     ParameterValue,
     ParameterValues,
     _generate_kinematic_variables,
-    formulate_wigner_d,
+    formulate_isobar_wigner_d,
     group_by_spin_projection,
 )
 
@@ -346,7 +346,7 @@ def test_generate_kinematic_variables(
         (2, 1, "WignerD(0, 0, 0, -phi_1^12, theta_1^12, 0)"),
     ],
 )
-def test_formulate_wigner_d(
+def test_formulate_isobar_wigner_d(
     reaction: ReactionInfo, transition: int, node_id: int, expected: str
 ):
     if reaction.formalism == "canonical-helicity":
@@ -355,7 +355,7 @@ def test_formulate_wigner_d(
         t for t in reaction.transitions if t.states[3].particle.name == "f(0)(980)"
     ]
     some_transition = transitions[transition]
-    wigner_d = formulate_wigner_d(some_transition, node_id)
+    wigner_d = formulate_isobar_wigner_d(some_transition, node_id)
     assert str(wigner_d) == expected
 
 


### PR DESCRIPTION
- Renamed [`formulate_wigner_d()`](https://ampform.readthedocs.io/en/0.14.1/api/ampform.helicity.html#ampform.helicity.formulate_wigner_d) to `formulate_isobar_wigner_d()`
- Renamed [`formulate_clebsch_gordan_coefficients()`](https://ampform.readthedocs.io/en/0.14.1/api/ampform.helicity.html#ampform.helicity.formulate_clebsch_gordan_coefficients) to `formulate_isobar_cg_coefficients()`

This is to distinguish from methods that generate Wigner-$D$ functions for spin alignment.