### PR TITLE
refactor: remove `HelicityModel.sum_components()`

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -828,17 +828,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ":::{tip}\n",
-    "\n",
-    "Use {meth}`.HelicityModel.sum_components` for adding up separate components of the model.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Plot the model"
    ]
   },

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -12,7 +12,6 @@ import logging
 import operator
 import sys
 from collections import OrderedDict, abc
-from difflib import get_close_matches
 from functools import reduce, singledispatch
 from typing import (
     TYPE_CHECKING,
@@ -217,38 +216,6 @@ class HelicityModel:  # noqa: R701
         for expr in self.kinematic_variables.values():
             symbols |= expr.free_symbols  # type: ignore[arg-type]
         return symbols
-
-    def sum_components(self, components: Iterable[str]) -> sp.Expr:  # noqa: R701
-        """Coherently or incoherently add components of a helicity model."""
-        components = list(components)  # copy
-        for component in components:
-            if component not in self.components:
-                first_letter = component[0]
-                # pylint: disable=cell-var-from-loop
-                candidates = get_close_matches(
-                    component,
-                    filter(lambda c: c.startswith(first_letter), self.components),
-                )
-                raise KeyError(
-                    f'Component "{component}" not in model components. '
-                    "Did you mean any of these?",
-                    candidates,
-                )
-        if any(c.startswith("I") for c in components) and any(
-            c.startswith("A") for c in components
-        ):
-            intensity_sum = self.sum_components(
-                components=filter(lambda c: c.startswith("I"), components),
-            )
-            amplitude_sum = self.sum_components(
-                components=filter(lambda c: c.startswith("A"), components),
-            )
-            return intensity_sum + amplitude_sum
-        if all(c.startswith("I") for c in components):
-            return sum(self.components[c] for c in components)  # type: ignore[return-value]
-        if all(c.startswith("A") for c in components):
-            return abs(sum(self.components[c] for c in components)) ** 2
-        raise ValueError('Not all component names started with either "A" or "I"')
 
 
 class ParameterValues(abc.Mapping):

--- a/tests/helicity/test_helicity.py
+++ b/tests/helicity/test_helicity.py
@@ -241,34 +241,6 @@ class TestHelicityModel:
         assert old_name in caplog.records[-1].msg
         assert new_model == model
 
-    def test_sum_components(self, amplitude_model: tuple[str, HelicityModel]):
-        # pylint: disable=cell-var-from-loop, line-too-long
-        _, model = amplitude_model
-        from_intensities = model.sum_components(
-            components=filter(lambda c: c.startswith("I"), model.components),
-        )
-        assert from_intensities == model.expression
-        for spin_jpsi in ["-1", "+1"]:
-            for spin_gamma in ["-1", "+1"]:
-                jpsi_with_spin = Rf"J/\psi(1S)_{{{spin_jpsi}}}"
-                gamma_with_spin = Rf"\gamma_{{{spin_gamma}}}"
-                from_amplitudes = model.sum_components(
-                    components=filter(
-                        lambda c: c.startswith("A")
-                        and jpsi_with_spin in c
-                        and gamma_with_spin in c,
-                        model.components,
-                    )
-                )
-                selected_intensities = filter(
-                    lambda c: c.startswith("I")
-                    and jpsi_with_spin in c
-                    and gamma_with_spin in c,
-                    model.components,
-                )
-                selected_intensity = next(selected_intensities)
-                assert from_amplitudes == model.components[selected_intensity]
-
     @pytest.mark.parametrize("formalism", ["canonical-helicity", "helicity"])
     def test_amplitudes(self, formalism: str):
         reaction = qrules.generate_transitions(


### PR DESCRIPTION
Closes #296 and further cleans up the `ampform.helicity` module.