### PR TITLE
refactor!: remove `set_dynamics()` method

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -227,7 +227,7 @@
     "\n",
     "builder = ampform.get_builder(reaction)\n",
     "for particle in reaction.get_intermediate_particles():\n",
-    "    builder.set_dynamics(particle.name, create_relativistic_breit_wigner)\n",
+    "    builder.dynamics.assign(particle.name, create_relativistic_breit_wigner)\n",
     "model = builder.formulate()\n",
     "model.intensity"
    ]

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -561,9 +561,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To set dynamics for specific resonances, use {meth}`.set_dynamics` on the same {class}`.HelicityAmplitudeBuilder` instance.  You can set the dynamics to be any kind of {class}`~sympy.core.expr.Expr`, as long as you keep track of which {class}`~sympy.core.symbol.Symbol` names you use (see {doc}`/usage/dynamics/custom`).\n",
+    "To set dynamics for specific resonances, use {meth}`.DynamicsSelector.assign` on the same {attr}`.HelicityAmplitudeBuilder.dynamics` attribute.  You can set the dynamics to be any kind of {class}`~sympy.core.expr.Expr`, as long as you keep track of which {class}`~sympy.core.symbol.Symbol` names you use (see {doc}`/usage/dynamics/custom`).\n",
     "\n",
-    "AmpForm does provide a few common {mod}`.dynamics` functions, which can be constructed as {class}`~sympy.core.expr.Expr` with the correct {class}`~sympy.core.symbol.Symbol` names using {meth}`.set_dynamics`. This function takes specific {mod}`.dynamics.builder` functions and classes, such as {class}`.RelativisticBreitWignerBuilder`, which can create {func}`.relativistic_breit_wigner` functions for specific resonances. Here's an example for a relativistic Breit-Wigner _with form factor_ for the intermediate resonances and use a Blatt-Weisskopf barrier factor for the production decay:"
+    "AmpForm does provide a few common {mod}`.dynamics` functions, which can be constructed as {class}`~sympy.core.expr.Expr` with the correct {class}`~sympy.core.symbol.Symbol` names using {meth}`.DynamicsSelector.assign`. This function takes specific {mod}`.dynamics.builder` functions and classes, such as {class}`.RelativisticBreitWignerBuilder`, which can create {func}`.relativistic_breit_wigner` functions for specific resonances. Here's an example for a relativistic Breit-Wigner _with form factor_ for the intermediate resonances and use a Blatt-Weisskopf barrier factor for the production decay:"
    ]
   },
   {
@@ -581,7 +581,7 @@
     "    phsp_factor=PhaseSpaceFactor,  # optional\n",
     ")\n",
     "for name in reaction.get_intermediate_particles().names:\n",
-    "    model_builder.set_dynamics(name, bw_builder)"
+    "    model_builder.dynamics.assign(name, bw_builder)"
    ]
   },
   {

--- a/docs/usage/dynamics.ipynb
+++ b/docs/usage/dynamics.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the dynamic terms in an amplitude model are set to $1$ by the {class}`.HelicityAmplitudeBuilder`. The method {meth}`.set_dynamics` can then be used to set dynamics lineshapes for specific resonances. The {mod}`.dynamics.builder` module provides some tools to set standard lineshapes (see below), but it is also possible to set {doc}`custom dynamics </usage/dynamics/custom>`.\n",
+    "By default, the dynamic terms in an amplitude model are set to $1$ by the {class}`.HelicityAmplitudeBuilder`. The method {meth}`~.DynamicsSelector.assign` of the {attr}`~.HelicityAmplitudeBuilder.dynamics` attribute can then be used to set dynamics lineshapes for specific resonances. The {mod}`.dynamics.builder` module provides some tools to set standard lineshapes (see below), but it is also possible to set {doc}`custom dynamics </usage/dynamics/custom>`.\n",
     "\n",
     "The standard lineshapes provided by AmpForm are illustrated below. For more info, have a look at the following pages:\n",
     "\n",

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -146,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In {doc}`/usage/amplitude`, we used {meth}`.set_dynamics` with some standard lineshape builders from the {mod}`.builder` module. These builders have a signature that follows the {class}`.ResonanceDynamicsBuilder` {class}`~typing.Protocol`:"
+    "In {doc}`/usage/amplitude`, we used {meth}`.DynamicsSelector.assign` with some standard lineshape builders from the {mod}`.builder` module. These builders have a signature that follows the {class}`.ResonanceDynamicsBuilder` {class}`~typing.Protocol`:"
    ]
   },
   {
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A function that behaves like a {class}`.ResonanceDynamicsBuilder` should return a {class}`tuple` of some {class}`~sympy.core.expr.Expr` (which formulates your lineshape) and a {class}`dict` of {class}`~sympy.core.symbol.Symbol`s to some suggested initial values. This signature is required so that {meth}`.set_dynamics` knows how to extract the correct symbol names and their suggested initial values from a {class}`~qrules.transition.StateTransition`."
+    "A function that behaves like a {class}`.ResonanceDynamicsBuilder` should return a {class}`tuple` of some {class}`~sympy.core.expr.Expr` (which formulates your lineshape) and a {class}`dict` of {class}`~sympy.core.symbol.Symbol`s to some suggested initial values. This signature is required so the builder knows how to extract the correct symbol names and their suggested initial values from a {class}`~qrules.transition.StateTransition`."
    ]
   },
   {
@@ -246,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, just like in {ref}`usage/amplitude:Set dynamics`, it's simply a matter of plugging this builder into {meth}`.set_dynamics` and we can {meth}`~.HelicityAmplitudeBuilder.formulate` a model with this custom lineshape:"
+    "Now, just like in {ref}`usage/amplitude:Set dynamics`, it's simply a matter of plugging this builder into {meth}`.DynamicsSelector.assign` and we can {meth}`~.HelicityAmplitudeBuilder.formulate` a model with this custom lineshape:"
    ]
   },
   {
@@ -256,7 +256,7 @@
    "outputs": [],
    "source": [
     "for name in reaction.get_intermediate_particles().names:\n",
-    "    model_builder.set_dynamics(name, create_my_dynamics)\n",
+    "    model_builder.dynamics.assign(name, create_my_dynamics)\n",
     "model = model_builder.formulate()"
    ]
   },

--- a/docs/usage/interactive.ipynb
+++ b/docs/usage/interactive.ipynb
@@ -117,9 +117,9 @@
     ")\n",
     "model_builder = get_builder(reaction)\n",
     "initial_state_particle = reaction.initial_state[-1]\n",
-    "model_builder.set_dynamics(initial_state_particle, create_non_dynamic_with_ff)\n",
+    "model_builder.dynamics.assign(initial_state_particle, create_non_dynamic_with_ff)\n",
     "for name in reaction.get_intermediate_particles().names:\n",
-    "    model_builder.set_dynamics(name, create_relativistic_breit_wigner_with_ff)\n",
+    "    model_builder.dynamics.assign(name, create_relativistic_breit_wigner_with_ff)\n",
     "model = model_builder.formulate()"
    ]
   },

--- a/src/ampform/dynamics/builder.py
+++ b/src/ampform/dynamics/builder.py
@@ -29,7 +29,7 @@ class TwoBodyKinematicVariableSet:
     """Data container for the essential variables of a two-body decay.
 
     This data container is inserted into a `.ResonanceDynamicsBuilder`, so that it can
-    build some lineshape expression from the `.dynamics` module. It also allows to
+    build some lineshape expression from the :mod:`.dynamics` module. It also allows to
     insert :doc:`custom dynamics </usage/dynamics/custom>` into the amplitude model.
     """
 
@@ -52,10 +52,10 @@ that appear in the `sympy.Expr <sympy.core.expr.Expr>`.
 
 
 class ResonanceDynamicsBuilder(Protocol):
-    """Protocol that is used by `.set_dynamics`.
+    """Protocol that is used by `.DynamicsSelector.assign`.
 
     Follow this `~typing.Protocol` when defining a builder function that is to be used
-    by `.set_dynamics`. For an example, see the source code
+    by `.DynamicsSelector.assign`. For an example, see the source code
     `.create_relativistic_breit_wigner`, which creates a `.relativistic_breit_wigner`.
 
     .. seealso:: :doc:`/usage/dynamics/custom`
@@ -104,7 +104,7 @@ class RelativisticBreitWignerBuilder:
     """Factory for building relativistic Breit-Wigner expressions.
 
     The :meth:`__call__` of this builder complies with the `.ResonanceDynamicsBuilder`,
-    so instances of this class can be used in :meth:`.set_dynamics`.
+    so instances of this class can be used in :meth:`.DynamicsSelector.assign`.
 
     Args:
         form_factor: Formulate a relativistic Breit-Wigner function multiplied

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -335,7 +335,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
             stable_final_state_ids=None,
             use_helicity_couplings=False,
         )
-        self.__dynamics_choices = DynamicsSelector(reaction)
+        self.__dynamics = DynamicsSelector(reaction)
         self._naming: NameGenerator = HelicityAmplitudeNameGenerator(reaction)
         self.__ingredients = _HelicityModelIngredients()
 
@@ -349,8 +349,8 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
         return self.__config
 
     @property
-    def dynamics_choices(self) -> DynamicsSelector:
-        return self.__dynamics_choices
+    def dynamics(self) -> DynamicsSelector:
+        return self.__dynamics
 
     @property
     def naming(self) -> NameGenerator:
@@ -359,11 +359,6 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
     @property
     def reaction(self) -> ReactionInfo:
         return self.__reaction
-
-    def set_dynamics(
-        self, particle_name: str, dynamics_builder: ResonanceDynamicsBuilder
-    ) -> None:
-        self.dynamics_choices.assign(particle_name, dynamics_builder)
 
     def formulate(self) -> HelicityModel:
         self.__ingredients.reset()
@@ -504,10 +499,10 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
         self, transition: StateTransition, node_id: int
     ) -> sp.Expr:
         decay = TwoBodyDecay.from_transition(transition, node_id)
-        if decay not in self.dynamics_choices:
+        if decay not in self.dynamics:
             return sp.S.One
 
-        builder = self.dynamics_choices[decay]
+        builder = self.dynamics[decay]
         variable_set = _generate_kinematic_variable_set(transition, node_id)
         expression, parameters = builder(decay.parent.particle, variable_set)
         for par, value in parameters.items():

--- a/src/ampform/helicity/decay.py
+++ b/src/ampform/helicity/decay.py
@@ -41,7 +41,7 @@ class TwoBodyDecay:
        `.formulate_isobar_cg_coefficients`).
 
     3. the `.TwoBodyDecay` is hashable, so that it can be used as a key (see
-       `.set_dynamics`.)
+       `.DynamicsSelector.assign`.)
     """
 
     parent: StateWithID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def reaction(request: SubRequest) -> ReactionInfo:
 def amplitude_model(reaction: ReactionInfo) -> tuple[str, HelicityModel]:
     model_builder = get_builder(reaction)
     for name in reaction.get_intermediate_particles().names:
-        model_builder.set_dynamics(name, create_relativistic_breit_wigner_with_ff)
+        model_builder.dynamics.assign(name, create_relativistic_breit_wigner_with_ff)
     model = model_builder.formulate()
     return reaction.formalism, model
 


### PR DESCRIPTION
- Renamed [`HelicityAmplitudeBuilder.dynamics_choices`](https://ampform.readthedocs.io/en/0.14.1/api/ampform.helicity.html#ampform.helicity.HelicityAmplitudeBuilder.dynamics_choices) to `HelicityAmplitudeBuilder.dynamics`
- Use [`DynamicsSelector.assign`](https://ampform.readthedocs.io/en/0.14.1/api/ampform.helicity.html#ampform.helicity.DynamicsSelector.assign) instead of [`HelicityAmplitudeBuilder.set_dynamics()`](https://ampform.readthedocs.io/en/0.14.1/api/ampform.helicity.html#ampform.helicity.HelicityAmplitudeBuilder.set_dynamics):
  ```python
  model.dynamics.assign("f(0)(980)", create_relativistic_breit_wigner)
  
  # used to be:
  # model.set_dynamics("f(0)(980)", create_relativistic_breit_wigner)
  ```
