### PR TITLE
feat: implement `logging` hierarchy

### DIFF
--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -73,6 +73,8 @@ else:
 if TYPE_CHECKING:
     from IPython.lib.pretty import PrettyPrinter
 
+_LOGGER = logging.getLogger(__name__)
+
 
 def _order_component_mapping(
     mapping: Mapping[str, sp.Expr]
@@ -186,7 +188,7 @@ class HelicityModel:  # noqa: R701
         symbol_names = {s.name for s in symbols}
         for name in renames:
             if name not in symbol_names:
-                logging.warning(f"There is no symbol with name {name}")
+                _LOGGER.warning(f"There is no symbol with name {name}")
         symbol_mapping = {
             s: sp.Symbol(renames[s.name], **s.assumptions0) if s.name in renames else s
             for s in symbols
@@ -503,7 +505,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
             if par in self.__ingredients.parameter_defaults:
                 previous_value = self.__ingredients.parameter_defaults[par]
                 if value != previous_value:
-                    logging.warning(
+                    _LOGGER.warning(
                         f'New default value {value} for parameter "{par.name}"'
                         " is inconsistent with existing value"
                         f" {previous_value}"
@@ -675,7 +677,7 @@ class DynamicsSelector(abc.Mapping):
                 self.__choices[decay] = builder
                 found_particle = True
         if not found_particle:
-            logging.warning(f'Model contains no resonance with name "{particle_name}"')
+            _LOGGER.warning(f'Model contains no resonance with name "{particle_name}"')
 
     @assign.register(Particle)
     def _(self, particle: Particle, builder: ResonanceDynamicsBuilder) -> None:

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:  # pragma: no cover
     else:
         from typing_extensions import TypeGuard
 
+_LOGGER = logging.getLogger(__name__)
 
 Slider = Union[FloatSlider, IntSlider]
 """Allowed :doc:`ipywidgets <ipywidgets:index>` slider types."""
@@ -164,7 +165,7 @@ class SliderKwargs(abc.Mapping):
             try:
                 self[keyword].value = value
             except KeyError:
-                logging.warning(f'There is no slider with name or symbol "{keyword}"')
+                _LOGGER.warning(f'There is no slider with name or symbol "{keyword}"')
                 continue
 
     def set_ranges(  # noqa: R701


### PR DESCRIPTION
Implemented a [`logging` hierarchy](https://docs.python.org/3/library/logging.html#logger-objects), so that `logging` levels can be set per module, for example:

```python
import logging

logging.basicConfig()
AMPFORM_LOGGER = logging.getLogger("ampform")
AMPFORM_LOGGER.setLevel(logging.ERROR)
```