### PR TITLE
docs: show unaligned amplitudes in spin alignment page

### DIFF
--- a/docs/usage/helicity/spin-alignment.ipynb
+++ b/docs/usage/helicity/spin-alignment.ipynb
@@ -89,6 +89,7 @@
     "from IPython.display import Math\n",
     "\n",
     "import ampform\n",
+    "from ampform.helicity import HelicityModel\n",
     "from ampform.io import aslatex, improve_latex_rendering\n",
     "\n",
     "LOGGER = logging.getLogger()\n",
@@ -164,6 +165,41 @@
     "builder.config.spin_alignment = NoAlignment()\n",
     "non_aligned_model = builder.formulate()\n",
     "non_aligned_model.intensity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The symbols for the amplitudes are defined through {attr}`.HelicityModel.amplitudes`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "full-width",
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def render_amplitudes(model: HelicityModel) -> Math:\n",
+    "    selected_amplitudes = {\n",
+    "        symbol: expr\n",
+    "        for i, (symbol, expr) in enumerate(model.amplitudes.items())\n",
+    "        if i % 5 == 0\n",
+    "    }\n",
+    "    src = aslatex(selected_amplitudes)\n",
+    "    src = src.replace(R\"\\end{array}\", R\"& \\dots \\\\ \\end{array}\")\n",
+    "    return Math(src)\n",
+    "\n",
+    "\n",
+    "render_amplitudes(non_aligned_model)"
    ]
   },
   {
@@ -262,6 +298,34 @@
     "}\n",
     "src = aslatex(dpd_angles)\n",
     "Math(src)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the amplitudes are the same as those in the non-aligned model:\n",
+    "\n",
+    ":::{warning}\n",
+    "This behavior is a bug that will be fixed through [ComPWA/ampform#318](https://github.com/ComPWA/ampform/issues/318).\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "full-width",
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "render_amplitudes(dpd_model)"
    ]
   },
   {


### PR DESCRIPTION
Renders the unaligned amplitudes on the spin alignment page as LaTeX, i.e.:

![](https://user-images.githubusercontent.com/29308176/183639470-b802b622-2475-4b98-8d93-fc8789e29eab.svg)

Also added warnings about #309 and #318