### PR TITLE
MAINT: update pip constraints and pre-commit

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -154,7 +154,7 @@ rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
 scipy==1.13.0
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -153,7 +153,7 @@ rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
 scipy==1.13.0
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -153,7 +153,7 @@ rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
 scipy==1.13.0
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -157,7 +157,7 @@ rich==13.7.1
 rope==1.9.0
 ruff==0.1.15
 scipy==1.7.3
-send2trash==1.8.2
+send2trash==1.8.3
 singledispatchmethod==1.0
 six==1.16.0
 smmap==5.0.1

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -159,7 +159,7 @@ rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
 scipy==1.10.1
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -155,7 +155,7 @@ rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
 scipy==1.13.0
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.4
+    rev: 0.3.5
     hooks:
       - id: check-dev-files
         args:
@@ -68,7 +68,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-case-conflict


### PR DESCRIPTION
This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow.