### PR TITLE
FIX: pass `kwargs` in `aslatex` iterable implementation

### DIFF
--- a/src/ampform/io/__init__.py
+++ b/src/ampform/io/__init__.py
@@ -116,7 +116,7 @@ def _(obj: Iterable, **kwargs) -> str:
         msg = "Need at least one item to render as LaTeX"
         raise ValueError(msg)
     latex = R"\begin{array}{c}" + "\n"
-    for item in map(aslatex, obj):
+    for item in (aslatex(i, **kwargs) for i in obj):
         latex += Rf"  {item} \\" + "\n"
     latex += R"\end{array}"
     return latex


### PR DESCRIPTION
Follow-up to #413 that allows passing keyword arguments to the [`Iterable`](https://docs.python.org/3/library/typing.html#typing.Iterable) implementation of [`aslatex()`](https://ampform.readthedocs.io/0.15.x/api/ampform.io/#ampform.io.aslatex).