### PR TITLE
DOC: hide sympified attributes from expression classes

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -720,8 +720,10 @@ def _create_latex_doit_definition(expr: sp.Expr, deep: bool = False) -> str:
 
 
 def _append_to_docstring(class_type: Callable | type, appended_text: str) -> None:
-    assert class_type.__doc__ is not None
-    class_type.__doc__ += appended_text
+    if class_type.__doc__ is None:
+        class_type.__doc__ = appended_text
+    else:
+        class_type.__doc__ += appended_text
 
 
 def __generate_transitions_cached(

--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -300,13 +300,7 @@ def extend_FormFactor() -> None:
 
     s, m_a, m_b, L, d = sp.symbols("s m_a m_b L d")
     form_factor = FormFactor(s, m_a, m_b, angular_momentum=L, meson_radius=d)
-    _append_to_docstring(
-        FormFactor,
-        f"""
-    .. math:: {sp.latex(form_factor)}
-        :label: FormFactor
-    """,
-    )
+    _append_latex_doit_definition(form_factor)
 
 
 def extend_Kallen() -> None:

--- a/src/ampform/sympy/_decorator.py
+++ b/src/ampform/sympy/_decorator.py
@@ -251,12 +251,11 @@ def _implement_new_method(cls: type[ExprClass]) -> type[ExprClass]:
         frozen=False,
     )(cls)
     cls = _update_field_metadata(cls)
-    sympy_fields = _get_sympy_fields(cls)
     non_sympy_fields = tuple(f for f in _get_fields(cls) if not _is_sympify(f))  # type: ignore[arg-type]
     cls.__slots__ = tuple(f.name for f in non_sympy_fields)  # type: ignore[arg-type]
 
     @functools.wraps(cls.__new__)
-    @_insert_args_in_signature([f.name for f in sympy_fields], idx=1)
+    @_insert_args_in_signature([f.name for f in _get_fields(cls)], idx=1)  # type:ignore[arg-type]
     def new_method(cls, *args, evaluate: bool = False, **kwargs) -> type[ExprClass]:
         fields_with_values, hints = _extract_field_values(cls, *args, **kwargs)
         fields_with_sympified_values = {
@@ -548,7 +547,7 @@ def _xreplace_method(self, rule) -> tuple[sp.Expr, bool]:
     return self, False
 
 
-def _get_sympy_fields(cls) -> tuple[Field, ...]:
+def get_sympy_fields(cls) -> tuple[Field, ...]:
     return tuple(f for f in _get_fields(cls) if _is_sympify(f))
 
 

--- a/src/ampform/sympy/_decorator.py
+++ b/src/ampform/sympy/_decorator.py
@@ -548,7 +548,7 @@ def _xreplace_method(self, rule) -> tuple[sp.Expr, bool]:
     return self, False
 
 
-def _get_sympy_fields(cls) -> tuple:
+def _get_sympy_fields(cls) -> tuple[Field, ...]:
     return tuple(f for f in _get_fields(cls) if _is_sympify(f))
 
 


### PR DESCRIPTION
Arguments that are sympified were previously rendered as class attributes. This PR hides them from API of the expression classes (if they do not have a `__doc__` docstring), because they are already visible in the signature of the class.

![image](https://github.com/ComPWA/ampform/assets/29308176/d738e59d-a508-459c-8575-9d81e9f84d0e)
