### PR TITLE
FIX: use squared `FormFactor` in `EnergyDependentWidth`

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -258,7 +258,7 @@ def extend_EnergyDependentWidth() -> None:
     _append_to_docstring(
         EnergyDependentWidth,
         R"""
-    where :math:`B_L^2` is defined by :eq:`BlattWeisskopfSquared`, :math:`q` is defined
+    where :math:`F_L` is defined by :eq:`FormFactor`, :math:`q` is defined
     by :eq:`BreakupMomentumSquared`, and :math:`\rho` is (by default) defined by
     :eq:`PhaseSpaceFactor`.
     """,

--- a/src/ampform/dynamics/__init__.py
+++ b/src/ampform/dynamics/__init__.py
@@ -61,11 +61,11 @@ class EnergyDependentWidth(sp.Expr):
 
     def evaluate(self) -> sp.Expr:
         s, m0, width0, m1, m2, angular_momentum, meson_radius = self.args
-        ff2 = FormFactor(s, m1, m2, angular_momentum, meson_radius)
-        ff2_0 = FormFactor(m0**2, m1, m2, angular_momentum, meson_radius)  # type: ignore[operator]
+        ff = FormFactor(s, m1, m2, angular_momentum, meson_radius)
+        ff0 = FormFactor(m0**2, m1, m2, angular_momentum, meson_radius)  # type: ignore[operator]
         rho = self.phsp_factor(s, m1, m2)
         rho0 = self.phsp_factor(m0**2, m1, m2)  # type: ignore[operator]
-        return width0 * (ff2 / ff2_0) * (rho / rho0)
+        return width0 * (ff / ff0) ** 2 * (rho / rho0)
 
     def _latex_repr_(self, printer: LatexPrinter, *args) -> str:
         s = printer._print(self.args[0])


### PR DESCRIPTION
Fix-up to #422, which redefined `EnergyDependentWidth` as (see [v0.15.2](https://ampform.readthedocs.io/0.15.2/api/ampform.dynamics/#ampform.dynamics.EnergyDependentWidth))

```math
\Gamma_{0}\left(s\right) = \frac{\Gamma_{0} \mathcal{F}_{L}\left(s, m_{a}, m_{b}\right) \rho\left(s\right)}{\mathcal{F}_{L}\left(m_{0}^{2}, m_{a}, m_{b}\right) \rho_{0}\left(m_{0}^{2}\right)}
```

instead of  (see [v0.15.1](https://ampform.readthedocs.io/0.15.1/api/ampform.dynamics/#ampform.dynamics.EnergyDependentWidth))

```math
\Gamma_{0}\left(s\right) = \frac{\Gamma_{0} B_{L}^2\left(q^2\left(s\right)\right) \rho\left(s\right)}{B_{L}^2\left(q^2_{0}\left(m_{0}^{2}\right)\right) \rho_{0}\left(m_{0}^{2}\right)}\,.
```

This is not equivalent, because [`FormFactor`](https://ampform.readthedocs.io/0.15.2/api/ampform.dynamics.form_factor.html#ampform.dynamics.form_factor.FormFactor) is defined as:

```math
\mathcal{F}_{L}\left(s, m_{a}, m_{b}\right) = \sqrt{B_{L}^2\left(d^{2} q^2\left(s\right)\right)}\,.
```