### PR TITLE
FEAT: implement `partial_doit()` function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
   "ruff.importStrategy": "fromEnvironment",
   "ruff.organizeImports": true,
   "search.exclude": {
+    "**/.*cache": true,
     "**/benchmarks/**/__init__.py": true,
     "**/tests/**/__init__.py": true,
     "**/uv.lock": true,

--- a/docs/usage/sympy.ipynb
+++ b/docs/usage/sympy.ipynb
@@ -488,6 +488,84 @@
     "expr = abs(PoolSum(A[λ, μ], (λ, to_range(-0.5, +0.5)), (μ, to_range(-1, +1)))) ** 2\n",
     "Math(aslatex({expr: expr.doit()}))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Partial `doit()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes you want to evaluate ('unfold') only certain definitions in an expression tree. This can be done with the {func}`ampform.sympy.partial_doit` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x, m, n = sp.symbols(\"x m n\")\n",
+    "expr = (\n",
+    "    sp.Integral(sp.Sum(sp.sin(x) / n, (n, 1, 3)), x)\n",
+    "    + sp.Derivative(sp.Product(sp.cos(x) * sp.exp(-x) / n, (n, 1, 3)), x)\n",
+    "    + sp.Sum(sp.Integral(1 / n**2, (n, 1, 10)), (n, 1, 3))\n",
+    "    + sp.Sum(sp.sin(sp.Sum(1 / (n * m), (m, 1, 5))), (n, 1, 5))\n",
+    ")\n",
+    "expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from ampform.sympy import partial_doit\n",
+    "\n",
+    "partial_doit(expr, sp.Sum)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "partial_doit(expr, sp.Sum, recursive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "partial_doit(expr, (sp.Integral, sp.Sum), recursive=True)"
+   ]
   }
  ],
  "metadata": {
@@ -509,7 +587,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/src/ampform/helicity/__init__.py
+++ b/src/ampform/helicity/__init__.py
@@ -59,7 +59,7 @@ from ampform.kinematics.lorentz import (
     create_four_momentum_symbols,
     get_invariant_mass_symbol,
 )
-from ampform.sympy import PoolSum, determine_indices
+from ampform.sympy import PoolSum, determine_indices, partial_doit
 from ampform.sympy._array_expressions import ArraySum
 
 if sys.version_info >= (3, 12):
@@ -156,16 +156,7 @@ class HelicityModel:
         Constructed from `intensity` by substituting its amplitude symbols with the
         definitions with `amplitudes`.
         """
-
-        def unfold_poolsums(expr: sp.Expr) -> sp.Expr:
-            new_expr = expr
-            for node in sp.postorder_traversal(expr):
-                if isinstance(node, PoolSum):
-                    new_expr = new_expr.xreplace({node: node.evaluate()})
-            return new_expr
-
-        intensity = self.intensity.evaluate()
-        intensity = unfold_poolsums(intensity)
+        intensity = partial_doit(self.intensity, PoolSum, recursive=True)
         return intensity.xreplace(self.amplitudes)
 
     def rename_symbols(

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 import itertools
-import logging
 import re
 import sys
 import warnings
@@ -54,8 +53,6 @@ if TYPE_CHECKING:
 
     from sympy.printing.latex import LatexPrinter
     from sympy.printing.numpy import NumPyPrinter
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class NumPyPrintable(sp.Expr):

--- a/src/ampform/sympy/__init__.py
+++ b/src/ampform/sympy/__init__.py
@@ -17,7 +17,7 @@ import re
 import sys
 import warnings
 from abc import abstractmethod
-from typing import TYPE_CHECKING, SupportsFloat, TypeVar
+from typing import TYPE_CHECKING
 
 import sympy as sp
 from sympy.printing.conventions import split_super_sub
@@ -40,21 +40,22 @@ from .deprecated import (
     make_commutative,  # pyright: ignore[reportUnusedImport]  # noqa: F401
 )
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 if sys.version_info >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
 if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
     from collections.abc import Iterable, Mapping, Sequence
+    from typing import SupportsFloat, TypeVar
 
     from sympy.printing.latex import LatexPrinter
     from sympy.printing.numpy import NumPyPrinter
 
-T = TypeVar("T", bound=sp.Basic)
+    T = TypeVar("T", bound=sp.Basic)
 
 
 def partial_doit(

--- a/src/symplot/__init__.py
+++ b/src/symplot/__init__.py
@@ -22,6 +22,10 @@ import sympy as sp
 from ipywidgets.widgets import FloatSlider, IntSlider
 from sympy.printing.latex import translate
 
+from ampform.sympy import (
+    partial_doit,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+)
+
 if TYPE_CHECKING:  # pragma: no cover
     import sys
     from collections.abc import Iterator, Mapping, Sequence
@@ -309,26 +313,6 @@ def __safe_wrap_symbols(
         return (plot_symbol,)
     msg = f"Wrong plot_symbol input type {type(plot_symbol).__name__}"
     raise TypeError(msg)
-
-
-def partial_doit(
-    expression: sp.Expr,
-    doit_classes: type[sp.Basic] | tuple[type[sp.Basic], ...],
-) -> sp.Expr:
-    """Perform :meth:`~sympy.core.basic.Basic.doit` up to a certain level.
-
-    Arguments
-    ---------
-    expression: the `~sympy.core.expr.Expr` on which you want to perform a
-        :meth:`~sympy.core.basic.Basic.doit`.
-    doit_classes: types on which the :meth:`~sympy.core.basic.Basic.doit` should be
-        performed.
-    """
-    new_expression = expression
-    for node in sp.preorder_traversal(expression):
-        if isinstance(node, doit_classes):
-            new_expression = new_expression.xreplace({node: node.doit(deep=False)})
-    return new_expression
 
 
 def _indexed_to_symbol(idx: sp.Indexed) -> sp.Symbol:

--- a/tests/external/test_sympy.py
+++ b/tests/external/test_sympy.py
@@ -3,6 +3,8 @@ from functools import reduce
 
 import sympy as sp
 
+from ampform.sympy import partial_doit
+
 
 class TestFunction:
     def test_hash(self):
@@ -45,3 +47,52 @@ class TestSymbol:
             sp.Symbol("z"),
         ]
         reduce(operator.mul, symbols)
+
+
+def test_partial_doit():
+    x, m, n = sp.symbols("x m n")
+    expr = (
+        sp.Integral(sp.Sum(sp.sin(x) / n, (n, 1, 3)), x)
+        + sp.Derivative(sp.Product(sp.cos(x) * sp.exp(-x) / n, (n, 1, 3)), x)
+        + sp.Sum(sp.Integral(1 / n**2, (n, 1, 10)), (n, 1, 3))
+        + sp.Sum(sp.sin(sp.Sum(1 / (n * m), (m, 1, 5))), (n, 1, 5))
+    )
+    assert expr is partial_doit(expr, types=())
+
+    unfolded_expr = expr.doit()
+    assert unfolded_expr is not expr
+    n_ops = sp.count_ops(expr)
+    n_ops_unfolded = sp.count_ops(unfolded_expr)
+
+    n_ops_doit_sum = sp.count_ops(partial_doit(expr, sp.Sum))
+    assert n_ops_doit_sum != n_ops
+    assert n_ops_doit_sum != n_ops_unfolded
+
+    n_ops_doit_sum_recursive = sp.count_ops(partial_doit(expr, sp.Sum, recursive=True))
+    assert n_ops_doit_sum_recursive != n_ops
+    assert n_ops_doit_sum_recursive != n_ops_doit_sum
+    assert n_ops_doit_sum_recursive != n_ops_unfolded
+
+    n_ops_doit_sum_integral = sp.count_ops(partial_doit(expr, (sp.Integral, sp.Sum)))
+    assert n_ops_doit_sum_integral != n_ops
+    assert n_ops_doit_sum_integral != n_ops_doit_sum
+    assert n_ops_doit_sum_integral != n_ops_doit_sum_recursive
+    assert n_ops_doit_sum_integral != n_ops_unfolded
+
+    all_unfolded_expr = partial_doit(
+        expr,
+        types=(sp.Derivative, sp.Integral, sp.Product, sp.Sum),
+        recursive=True,
+    ).simplify()
+    assert all_unfolded_expr == unfolded_expr.simplify()
+
+    wrong_type_unfolded_expr = partial_doit(expr, sp.sin)
+    assert wrong_type_unfolded_expr == expr
+
+
+def test_partial_doit_top_node():
+    x, n = sp.symbols("x n")
+    expr = sp.Sum(sp.sin(x) / n, (n, 1, 3))
+    doit_expr = expr.doit()
+    partial_doit_expr = partial_doit(expr, sp.Sum)
+    assert doit_expr == partial_doit_expr


### PR DESCRIPTION
- Imported `partial_doit()` from `symplot` into `ampform.sympy`
- Also gave it the option to unfold recursively and added tests and documentation
- Related to https://github.com/ComPWA/ampform/issues/279