### PR TITLE
FEAT: implement `cached.unfold` for amplitude models

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -195,11 +195,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A {class}`.HelicityModel` has a few attributes. The expression for the total intensity is given by {attr}`.intensity`:\n",
+    "A {class}`.HelicityModel` has a few attributes. The expression for the total intensity is given by {attr}`~.HelicityModel.intensity`:\n",
     "\n",
     ":::{margin}\n",
     "\n",
-    "As can be seen in {ref}`usage/amplitude:Generate transitions`, the transition that this {class}`.HelicityModel` describes features only one decay topology. This means that the main {attr}`~.intensity` expression is relatively simple. In case there are more decay topologies, AmpForm {doc}`aligns spin </usage/helicity/spin-alignment>`, which makes the main intensity expression more complicated.\n",
+    "As can be seen in {ref}`usage/amplitude:Generate transitions`, the transition that this {class}`.HelicityModel` describes features only one decay topology. This means that the main {attr}`~.HelicityModel.intensity` expression is relatively simple. In case there are more decay topologies, AmpForm {doc}`aligns spin </usage/helicity/spin-alignment>`, which makes the main intensity expression more complicated.\n",
     "\n",
     ":::"
    ]
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This shows that the main intensity is an **incoherent** sum of the amplitude for each spin projection combination of the initial and final states. The expressions for each of these amplitudes are provided with the {attr}`~.amplitudes` attribute. This is an {class}`~collections.OrderedDict`, so we can inspect the first of these amplitudes as follows:"
+    "This shows that the main intensity is an **incoherent** sum of the amplitude for each spin projection combination of the initial and final states. The expressions for each of these amplitudes are provided with the {attr}`~.HelicityModel.amplitudes` attribute. This is an {class}`~collections.OrderedDict`, so we can inspect the first of these amplitudes as follows:"
    ]
   },
   {
@@ -674,6 +674,23 @@
    "source": [
     "substituted_expression = cached.xreplace(full_expression, model.parameter_defaults)\n",
     "substituted_expression.free_symbols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, to 'unfold' the intensity expression, you can use the {func}`.cached.unfold` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unfolded_intensity_expr = cached.unfold(model)\n",
+    "sp.count_ops(unfolded_intensity_expr)"
    ]
   },
   {

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -689,7 +689,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unfolded_intensity_expr = cached.unfold(model)\n",
+    "unfolded_intensity_expr = cached.unfold(model.intensity, model.amplitudes)\n",
     "sp.count_ops(unfolded_intensity_expr)"
    ]
   },

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from ampform.sympy._cache import cache_to_disk
 
@@ -36,3 +36,17 @@ def doit(expr: SympyObject) -> SympyObject:
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
     return expr.xreplace(substitutions)
+
+
+def unfold(model: Model) -> sp.Expr:
+    """Insert the amplitude definitions into the intensity and unfold the expression."""
+    return doit(xreplace(doit(model.intensity), model.amplitudes))
+
+
+class Model(Protocol):
+    """Protocol for amplitude models of the form `.HelicityModel`."""
+
+    @property
+    def intensity(self) -> sp.Expr: ...
+    @property
+    def amplitudes(self) -> Mapping[sp.Basic, sp.Expr]: ...

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -40,7 +40,11 @@ def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Ex
 
 def unfold(model: Model) -> sp.Expr:
     """Insert the amplitude definitions into the intensity and unfold the expression."""
-    return doit(xreplace(doit(model.intensity), model.amplitudes))
+    unfolded_amplitudes = {
+        symbol: doit(model.amplitudes[symbol])
+        for symbol in sorted(model.amplitudes, key=str)
+    }
+    return doit(xreplace(model.intensity.doit(), unfolded_amplitudes))
 
 
 class Model(Protocol):

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 from ampform.sympy._cache import cache_to_disk
 
@@ -38,19 +38,9 @@ def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Ex
     return expr.xreplace(substitutions)
 
 
-def unfold(model: Model) -> sp.Expr:
-    """Insert the amplitude definitions into the intensity and unfold the expression."""
-    unfolded_amplitudes = {
-        symbol: doit(model.amplitudes[symbol])
-        for symbol in sorted(model.amplitudes, key=str)
-    }
-    return doit(xreplace(model.intensity.doit(), unfolded_amplitudes))
-
-
-class Model(Protocol):
-    """Protocol for amplitude models of the form `.HelicityModel`."""
-
-    @property
-    def intensity(self) -> sp.Expr: ...
-    @property
-    def amplitudes(self) -> Mapping[sp.Basic, sp.Expr]: ...
+def unfold(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
+    """Efficiently perform both substitutions and :code:`doit()`."""
+    return xreplace(
+        expr=doit(expr),
+        substitutions={k: doit(v) for k, v in substitutions.items()},
+    )

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -41,6 +41,7 @@ def test_xreplace(amplitude_model: tuple[str, HelicityModel], substitution_name:
 
 def test_unfold(amplitude_model: tuple[str, HelicityModel]):
     _, model = amplitude_model
-    intensity_expr_direct = model.intensity.doit().xreplace(model.amplitudes).doit()
+    amplitudes = {k: v.doit() for k, v in model.amplitudes.items()}
+    intensity_expr_direct = model.intensity.doit().xreplace(amplitudes)
     intensity_expr_unfold = cached.unfold(model)
     assert intensity_expr_direct == intensity_expr_unfold

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -37,3 +37,10 @@ def test_xreplace(amplitude_model: tuple[str, HelicityModel], substitution_name:
     assert substituted_expr_1 == expected_expr
     substituted_expr_2 = cached.xreplace(full_expression, substitutions)
     assert substituted_expr_2 == expected_expr
+
+
+def test_unfold(amplitude_model: tuple[str, HelicityModel]):
+    _, model = amplitude_model
+    intensity_expr_direct = model.intensity.doit().xreplace(model.amplitudes).doit()
+    intensity_expr_unfold = cached.unfold(model)
+    assert intensity_expr_direct == intensity_expr_unfold

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -43,5 +43,5 @@ def test_unfold(amplitude_model: tuple[str, HelicityModel]):
     _, model = amplitude_model
     amplitudes = {k: v.doit() for k, v in model.amplitudes.items()}
     intensity_expr_direct = model.intensity.doit().xreplace(amplitudes)
-    intensity_expr_unfold = cached.unfold(model)
+    intensity_expr_unfold = cached.unfold(model.intensity, model.amplitudes)
     assert intensity_expr_direct == intensity_expr_unfold


### PR DESCRIPTION
Implemented a convenience function, `cached.unfold()`, which does two things:
1. It combines and 'unfolds' (evaluates) the `model.intensity` and its `model.amplitudes` in one go.
1. It unfolds and combines a top expression (like `model.intensity`) and its definitions (like `model.amplitudes`) efficiently by first calling `doit` on the top expression, then calling `doit` on all the expressions in the definitions, and finally combining them with `xreplace`. This is more efficient than using `xreplace` and then `doit` on the whole result. The function also uses caching internally.

Note that `cached.unfold` takes either a single amplitude model or a top expression and a list of definitions. This is motivated by [ComPWA/polarimetry](https://github.com/ComPWA/polarimetry), where instead of using `model.intensity` as the top expression, you use the polarimeter field definition $\vec\alpha$.

See also this test
https://github.com/ComPWA/ampform/blob/8bb9c07763c92a2d9ac3391a2482eff9232cf7d0/tests/sympy/test_cached.py#L44-L47