### PR TITLE
ENH: improve cache invalidation of `@cache_to_disk`

### DIFF
--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -76,7 +76,7 @@ def _cache_to_disk_implementation(
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def decorator(func: Callable[P, T]) -> Callable[P, T]:
         if "NO_CACHE" in os.environ:
-            _warn_once("Cache disabled by NO_CACHE environment variable.")
+            _warn_once("AmpForm cache disabled by NO_CACHE environment variable.")
             return func
         function_identifier = [f"{func.__module__}.{func.__name__}"]
         if (package_version := _get_package_version(func)) is not None:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -93,13 +93,14 @@ def _cache_to_disk_implementation(
                 tuple((k, _sort_dict(kwargs[k])) for k in sorted(kwargs)),
             )
             h = get_readable_hash(hashable_object)
-            cache_file = _get_cache_dir() / f"{h}.pkl"
+            cache_file = _get_cache_dir() / h[:2] / h[2:]
             if cache_file.exists():
                 with open(cache_file, "rb") as f:
                     return load_function(f)
             result = func(*args, **kwargs)
             msg = f"No cache file {cache_file}, performing {function_name}()..."
             _LOGGER.warning(msg)
+            cache_file.parent.mkdir(exist_ok=True, parents=True)
             with open(cache_file, "wb") as f:
                 dump_function(result, f)
             return result
@@ -132,9 +133,7 @@ def _get_cache_dir() -> Path:
     else:
         system_cache_dir = get_system_cache_directory()
     sympy_version = version("sympy")
-    cache_directory = Path(system_cache_dir) / "ampform" / f"sympy-v{sympy_version}"
-    cache_directory.mkdir(exist_ok=True, parents=True)
-    return cache_directory
+    return Path(system_cache_dir) / "ampform" / f"sympy-v{sympy_version}"
 
 
 @cache

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -146,8 +146,10 @@ def _remove_dev(version: str) -> str:
     '0.15.7'
     >>> _remove_dev("0.15.7")
     '0.15.7'
+    >>> _remove_dev("0.15.7.post1")
+    '0.15.7'
     """
-    return re.sub(r"(\.dev.*)?$", "", version)
+    return re.sub(r"(\.(dev|post).*)?$", "", version)
 
 
 def _sort_dict(obj) -> tuple[tuple[Any, Any], ...]:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -77,7 +77,7 @@ def _cache_to_disk_implementation(
         @wraps(func)
         def wrapped_function(*args: P.args, **kwargs: P.kwargs) -> T:
             hashable_object = (
-                args,
+                tuple(_sort_dict(x) for x in args),
                 tuple((k, _sort_dict(kwargs[k])) for k in sorted(kwargs)),
             )
             h = get_readable_hash(hashable_object)

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import pickle  # noqa: S403
+import re
 import sys
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
@@ -131,9 +132,22 @@ def _get_package(func: Callable) -> str | None:
 @cache
 def _package_with_version(distribution_name: str) -> str:
     try:
-        return f"{distribution_name}-v{version(distribution_name)}"
+        v = _remove_dev(version(distribution_name))
     except PackageNotFoundError:
         return distribution_name
+    else:
+        return f"{distribution_name}-{v}"
+
+
+def _remove_dev(version: str) -> str:
+    """Remove the ".dev" suffix from a version string.
+
+    >>> _remove_dev("0.15.7.dev15+g3c1b3cec.d20250301")
+    '0.15.7'
+    >>> _remove_dev("0.15.7")
+    '0.15.7'
+    """
+    return re.sub(r"(\.dev.*)?$", "", version)
 
 
 def _sort_dict(obj) -> tuple[tuple[Any, Any], ...]:

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     SympyObject = TypeVar("SympyObject", bound=sp.Basic)
 
 
-@cache_to_disk
+@cache_to_disk(dependencies=["sympy"])
 def doit(expr: SympyObject) -> SympyObject:
     """Perform :meth:`~sympy.core.basic.Basic.doit` and cache the result to disk.
 
@@ -32,7 +32,7 @@ def doit(expr: SympyObject) -> SympyObject:
     return expr.doit()
 
 
-@cache_to_disk
+@cache_to_disk(dependencies=["sympy"])
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
     return expr.xreplace(substitutions)


### PR DESCRIPTION
The `@cache_to_disk` decorator got some major improvements:
- It embeds the model name and its own name into the hash.
- It got a `dependencies` keyword that allows specifying which dependencies the function has. The distribution names plus their version (minus any `dev` identifiers) are then included into the hash as well to improve cache invalidation.
- Hash files are now organised like objects in a `.git` folder (e.g. `83/c88eef607e4ff33e11bf626c784d73`).
- The `dump` and `load` methods can be overwritten. This is useful for `perform_cache_lambdify()` in AmpForm-DPD.
- Hashes should be more stable now: any `dict`s in function arguments are sorted now.
- Warning messages for missing caches or `NO_CACHE` are improved.