### PR TITLE
DX: host benchmark results on separate repository

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,17 +46,6 @@ jobs:
               --benchmark-json output.json \
               --durations=0
         working-directory: benchmarks
-      - name: Store result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: AmpForm benchmark results
-          tool: pytest
-          output-file-path: benchmarks/output.json
-          github-token: ${{ secrets.PAT }}
-          gh-pages-branch: main
-          gh-repository: github.com/ComPWA/ampform-benchmark-results
-          benchmark-data-dir-path: ""
-          auto-push: true
       - name: Warn on performance decrease
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -69,3 +58,14 @@ jobs:
           benchmark-data-dir-path: ""
           comment-on-alert: true
           fail-on-alert: true
+      - name: Store result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: AmpForm benchmark results
+          tool: pytest
+          output-file-path: benchmarks/output.json
+          github-token: ${{ secrets.PAT }}
+          gh-pages-branch: main
+          gh-repository: github.com/ComPWA/ampform-benchmark-results
+          benchmark-data-dir-path: ""
+          auto-push: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,5 +60,5 @@ jobs:
           fail-on-alert: true
       - name: Store result
         if: github.event_name == 'push'
-        run: git push https://ComPWA:${{ secrets.GITHUB_TOKEN }}@github.com/ComPWA/ampform-benchmark-results main:main
+        run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' main:main
         working-directory: benchmark-data-repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
           name: AmpForm benchmark results
           tool: pytest
           output-file-path: benchmarks/output.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
@@ -63,7 +63,7 @@ jobs:
           name: AmpForm benchmark results
           tool: pytest
           output-file-path: benchmarks/output.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,12 +53,11 @@ jobs:
           tool: pytest
           output-file-path: benchmarks/output.json
           github-token: ${{ secrets.PAT }}
-          gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           comment-on-alert: true
           fail-on-alert: true
       - name: Store result
         if: github.event_name == 'push'
-        run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' main:gh-pages
+        run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' gh-pages
         working-directory: benchmark-data-repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,8 +2,6 @@ name: Benchmark
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -49,7 +47,6 @@ jobs:
               --durations=0
         working-directory: benchmarks
       - name: Store result
-        if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: AmpForm benchmark results
@@ -61,7 +58,6 @@ jobs:
           benchmark-data-dir-path: ""
           auto-push: true
       - name: Warn on performance decrease
-        if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: AmpForm benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,6 +58,7 @@ jobs:
           benchmark-data-dir-path: ""
           comment-on-alert: true
           fail-on-alert: true
+          auto-push: false
       - name: Store result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,5 +60,5 @@ jobs:
           fail-on-alert: true
       - name: Store result
         if: github.event_name == 'push'
-        run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' main:main
+        run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' main:gh-pages
         working-directory: benchmark-data-repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,6 @@ jobs:
           benchmark-data-dir-path: ""
           comment-on-alert: true
           fail-on-alert: true
-          auto-push: false
       - name: Store result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,6 +71,5 @@ jobs:
           gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
-          auto-push: false
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
           tool: pytest
           output-file-path: benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: benchmark-results
+          gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           auto-push: true
@@ -68,7 +68,7 @@ jobs:
           tool: pytest
           output-file-path: benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: benchmark-results
+          gh-pages-branch: main
           gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           auto-push: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,13 +59,6 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
       - name: Store result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: AmpForm benchmark results
-          tool: pytest
-          output-file-path: benchmarks/output.json
-          github-token: ${{ secrets.PAT }}
-          gh-pages-branch: main
-          gh-repository: github.com/ComPWA/ampform-benchmark-results
-          benchmark-data-dir-path: ""
-          auto-push: true
+        if: github.event_name == 'push'
+        run: git push https://ComPWA:${{ secrets.GITHUB_TOKEN }}@github.com/ComPWA/ampform-benchmark-results main:main
+        working-directory: benchmark-data-repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,8 @@ env:
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -50,6 +52,7 @@ jobs:
               --durations=0
         working-directory: benchmarks
       - name: Warn on performance decrease
+        if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: AmpForm benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,6 +57,7 @@ jobs:
           output-file-path: benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: benchmark-results
+          gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           auto-push: true
       - name: Warn on performance decrease
@@ -68,6 +69,7 @@ jobs:
           output-file-path: benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: benchmark-results
+          gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           auto-push: false
           comment-on-alert: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
           name: AmpForm benchmark results
           output-file-path: benchmarks/output.json
           tool: pytest
-      - name: Store result
+      - name: Push results to GitHub Pages
         if: github.event_name == 'push'
         run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' gh-pages
         working-directory: benchmark-data-repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,14 +55,14 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: AmpForm benchmark results
-          tool: pytest
-          output-file-path: benchmarks/output.json
-          github-token: ${{ secrets.PAT }}
-          gh-repository: github.com/ComPWA/ampform-benchmark-results
           benchmark-data-dir-path: ""
           comment-on-alert: true
           fail-on-alert: true
+          gh-repository: github.com/ComPWA/ampform-benchmark-results
+          github-token: ${{ secrets.PAT }}
+          name: AmpForm benchmark results
+          output-file-path: benchmarks/output.json
+          tool: pytest
       - name: Store result
         if: github.event_name == 'push'
         run: git push 'https://ComPWA:${{ secrets.PAT }}@github.com/ComPWA/ampform-benchmark-results' gh-pages

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: Benchmark
 
+env:
+  FORCE_COLOR: "1"
+
 on:
   push:
   pull_request:

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ hidden:
 maxdepth: 2
 ---
 API <api/ampform>
-Continuous benchmarks <https://compwa.github.io/ampform>
+Continuous benchmarks <https://compwa.github.io/ampform-benchmark-results>
 Changelog <https://github.com/ComPWA/ampform/releases>
 Upcoming features <https://github.com/ComPWA/ampform/milestones?direction=asc&sort=title&state=open>
 Help developing <https://compwa.github.io/develop>


### PR DESCRIPTION
See https://github.com/ComPWA/policy/issues/514

> [!WARNING]
> This changes the URL for the benchmark results from compwa.github.io/ampform to **[compwa.github.io/ampform-benchmark-results](https://compwa.github.io/ampform-benchmark-results)**.