### PR TITLE
ENH: use memoization on functions in `cached` module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "attrs >=20.1.0", # on_setattr and https://www.attrs.org/en/stable/api.html#next-gen
+    "frozendict",
     "qrules >=0.9.6",
     "sympy >=1.10",
 ]

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     SympyObject = TypeVar("SympyObject", bound=sp.Basic)
 
 
+@cache
 @cache_to_disk(dependencies=["sympy"])
 def doit(expr: SympyObject) -> SympyObject:
     """Perform :meth:`~sympy.core.basic.Basic.doit` and cache the result to disk.
@@ -35,9 +36,19 @@ def doit(expr: SympyObject) -> SympyObject:
     return expr.doit()
 
 
-@cache_to_disk(dependencies=["sympy"])
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
+    hashable_substitutions = tuple(
+        (k, substitutions[k]) for k in sorted(substitutions, key=str)
+    )
+    return _xreplace_impl(expr, hashable_substitutions)
+
+
+@cache
+@cache_to_disk(function_name="xreplace", dependencies=["sympy"])
+def _xreplace_impl(
+    expr: sp.Expr, substitutions: tuple[tuple[sp.Basic, sp.Basic], ...]
+) -> sp.Expr:
     return expr.xreplace(substitutions)
 
 

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from functools import cache
 from typing import TYPE_CHECKING, Protocol, overload, runtime_checkable
+
+from frozendict import frozendict
 
 from ampform.sympy._cache import cache_to_disk
 
@@ -62,7 +65,13 @@ class Model(Protocol):
 
 
 def _unfold_impl(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
-    return xreplace(
-        expr=doit(expr),
-        substitutions={k: doit(v) for k, v in substitutions.items()},
-    )
+    substitutions = _unfold_substitutions(frozendict(substitutions))
+    expr = doit(expr)
+    return xreplace(expr, substitutions)
+
+
+@cache
+def _unfold_substitutions(
+    substitutions: frozendict[sp.Basic, sp.Basic],
+) -> frozendict[sp.Basic, sp.Basic]:
+    return frozendict({k: doit(v) for k, v in substitutions.items()})

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -38,16 +38,13 @@ def doit(expr: SympyObject) -> SympyObject:
 
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
-    hashable_substitutions = tuple(
-        (k, substitutions[k]) for k in sorted(substitutions, key=str)
-    )
-    return _xreplace_impl(expr, hashable_substitutions)
+    return _xreplace_impl(expr, frozendict(substitutions))
 
 
 @cache
 @cache_to_disk(function_name="xreplace", dependencies=["sympy"])
 def _xreplace_impl(
-    expr: sp.Expr, substitutions: tuple[tuple[sp.Basic, sp.Basic], ...]
+    expr: sp.Expr, substitutions: frozendict[sp.Basic, sp.Basic]
 ) -> sp.Expr:
     return expr.xreplace(substitutions)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -48,6 +49,7 @@ name = "ampform"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
+    { name = "frozendict" },
     { name = "qrules" },
     { name = "sympy" },
 ]
@@ -187,11 +189,13 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=20.1.0" },
+    { name = "frozendict" },
     { name = "graphviz", marker = "extra == 'viz'" },
     { name = "qrules", specifier = ">=0.9.6" },
     { name = "scipy", marker = "extra == 'scipy'" },
     { name = "sympy", specifier = ">=1.10" },
 ]
+provides-extras = ["scipy", "viz"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Reduce overhead from I/O operations by caching the result of functions like `xreplace()` under `cached` to memory.