### PR TITLE
ENH: memoize `get_readable_hash()`

### DIFF
--- a/docs/_extend_docstrings.py
+++ b/docs/_extend_docstrings.py
@@ -23,7 +23,7 @@ from sympy.printing.numpy import NumPyPrinter
 from ampform.io import aslatex
 from ampform.kinematics.lorentz import ArraySize, FourMomentumSymbol
 from ampform.sympy._array_expressions import ArrayMultiplication
-from ampform.sympy._cache import get_readable_hash
+from ampform.sympy._cache import get_readable_hash, make_hashable
 
 if TYPE_CHECKING:
     from qrules.transition import ReactionInfo, SpinFormalism
@@ -726,7 +726,7 @@ def __generate_transitions_cached(
     formalism: SpinFormalism,
 ) -> ReactionInfo:
     version = get_package_version("qrules")
-    obj = (initial_state, final_state, formalism)
+    obj = make_hashable(initial_state, final_state, formalism)
     h = get_readable_hash(obj)
     docs_dir = Path(__file__).parent
     file_name = docs_dir / ".cache" / f"reaction-qrules-v{version}-{h}.pickle"

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -200,7 +200,7 @@ def get_readable_hash(obj: Hashable) -> str:
         obj: Any hashable object, mutable or immutable, to be hashed.
     """
     b = to_bytes(obj)
-    h = hashlib.md5(b)  # noqa: S324
+    h = hashlib.md5(b, usedforsecurity=False)
     return h.hexdigest()
 
 

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         from typing import ParamSpec
     else:
         from typing_extensions import ParamSpec
+    from collections.abc import Hashable
     from typing import Any, Callable, ParamSpec, TypeVar
 
     P = ParamSpec("P")
@@ -197,7 +198,8 @@ def get_system_cache_directory() -> str:
     return os.path.expanduser("~/.cache")
 
 
-def get_readable_hash(obj) -> str:
+@cache
+def get_readable_hash(obj: Hashable) -> str:
     """Get a human-readable hash of any hashable Python object.
 
     Args:

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -90,8 +90,8 @@ class TestLargeHash:
     @pytest.mark.parametrize(
         ("expected_hashes", "formalism"),
         [
-            ({"4765e78", "8bf5459"}, "canonical-helicity"),
-            ({"c141fbb"}, "helicity"),
+            ({"4765e78", "8bf5459", "88393a4"}, "canonical-helicity"),
+            ({"be45e3f", "c141fbb"}, "helicity"),
         ],
         ids=["canonical-helicity", "helicity"],
     )


### PR DESCRIPTION
This speeds up `get_readable_hash()` by enforcing objects to be hashable.