### PR TITLE
FEAT: implement `cached.simplify` etc

### DIFF
--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -55,6 +55,17 @@ def trigsimp(expr: sp.Expr, *args, **kwargs) -> sp.Expr:
     return sp.trigsimp(expr, *args, **kwargs)
 
 
+def subs(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
+    """Call :meth:`~sympy.core.basic.Basic.subs` and cache the result to disk."""
+    return _subs_impl(expr, frozendict(substitutions))
+
+
+@cache
+@cache_to_disk(function_name="subs", dependencies=["sympy"])
+def _subs_impl(expr: sp.Expr, substitutions: frozendict[sp.Basic, sp.Basic]) -> sp.Expr:
+    return expr.xreplace(substitutions)
+
+
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
     return _xreplace_impl(expr, frozendict(substitutions))

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -35,6 +35,26 @@ def doit(expr: SympyObject) -> SympyObject:
     return expr.doit()
 
 
+@cache
+@cache_to_disk
+def simplify(expr: sp.Expr, *args, **kwargs) -> sp.Expr:
+    """Perform :func:`~sympy.simplify.simplify.simplify` and cache the result to disk.
+
+    .. versionadded:: 0.15.7
+    """
+    return sp.simplify(expr, *args, **kwargs)
+
+
+@cache
+@cache_to_disk
+def trigsimp(expr: sp.Expr, *args, **kwargs) -> sp.Expr:
+    """Perform :func:`~sympy.simplify.trigsimp.trigsimp` and cache the result to disk.
+
+    .. versionadded:: 0.15.7
+    """
+    return sp.trigsimp(expr, *args, **kwargs)
+
+
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, sp.Basic]) -> sp.Expr:
     """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
     return _xreplace_impl(expr, frozendict(substitutions))

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -69,19 +69,23 @@ def test_trigsimp():
     assert simplified == cached_simplified
 
 
+@pytest.mark.parametrize("substitute", ["subs", "xreplace"])
 @pytest.mark.parametrize(
     "substitution_name", ["parameter_defaults", "kinematic_variables"]
 )
-def test_xreplace(amplitude_model: tuple[str, HelicityModel], substitution_name: str):
+def test_xreplace(
+    amplitude_model: tuple[str, HelicityModel], substitute: str, substitution_name: str
+):
+    cached_func = getattr(cached, substitute)
     _, model = amplitude_model
     full_expression = model.expression.doit()
     substitutions: dict[sp.Symbol, sp.Basic] = getattr(model, substitution_name)
     expected_expr = full_expression.xreplace(substitutions)
     assert expected_expr != full_expression
 
-    substituted_expr_1 = cached.xreplace(full_expression, substitutions)
+    substituted_expr_1 = cached_func(full_expression, substitutions)
     assert substituted_expr_1 == expected_expr
-    substituted_expr_2 = cached.xreplace(full_expression, substitutions)
+    substituted_expr_2 = cached_func(full_expression, substitutions)
     assert substituted_expr_2 == expected_expr
 
 

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -1,14 +1,14 @@
+# cspell:ignore pbarksigma
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 import pytest
+import sympy as sp
 
 from ampform.sympy import cached
 
 if TYPE_CHECKING:
-    import sympy as sp
-
     from ampform.helicity import HelicityModel
 
 
@@ -21,6 +21,52 @@ def test_doit(amplitude_model: tuple[str, HelicityModel]):
     assert unfolded_expr_1 == expected_expr
     unfolded_expr_2 = cached.doit(model.expression)
     assert unfolded_expr_2 == expected_expr
+
+
+def test_simplify():
+    a, b, c, d, x, y, z = sp.symbols("a b c d x y z")
+    expr = (
+        (a * x + b * y + c * z + d) ** 2
+        - (a * x) ** 2
+        - (b * y) ** 2
+        - (c * z) ** 2
+        - 2 * a * b * x * y
+        - 2 * a * c * x * z
+        - 2 * b * c * y * z
+        - 2 * d * (a * x + b * y + c * z)
+    )
+
+    simplified = expr.simplify()
+    assert simplified != expr
+    assert simplified == d**2
+
+    cached_simplified = cached.simplify(expr)
+    assert simplified == cached_simplified
+
+
+@pytest.mark.parametrize("amplitude_idx", list(range(4)))
+def test_simplify_model(amplitude_model: tuple[str, HelicityModel], amplitude_idx: int):
+    _, model = amplitude_model
+    amplitudes = [model.amplitudes[k] for k in sorted(model.amplitudes, key=str)]
+    amplitude_expr = amplitudes[amplitude_idx]
+
+    simplified = amplitude_expr.simplify()
+    assert simplified != amplitude_expr
+
+    cached_simplified = cached.simplify(amplitude_expr)
+    assert simplified == cached_simplified
+
+
+def test_trigsimp():
+    x, y = sp.symbols("x y")
+    expr = (sp.sin(x) * sp.cos(y) + sp.cos(x) * sp.sin(y)) ** 2 + (
+        sp.cos(x) * sp.cos(y) - sp.sin(x) * sp.sin(y)
+    ) ** 2
+    simplified = sp.trigsimp(expr)
+    assert expr != simplified
+    assert simplified == 1
+    cached_simplified = cached.trigsimp(expr)
+    assert simplified == cached_simplified
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements the cached equivalents for `subs()`, `trigsimp()`, and `simplify()`.