### PR TITLE
FIX: make values in mapping hashable

### DIFF
--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -10,6 +10,7 @@ These methods are private, but can be imported from this module:
 from __future__ import annotations
 
 import hashlib
+import inspect
 import logging
 import os
 import pickle  # noqa: S403
@@ -95,6 +96,7 @@ def _cache_to_disk_implementation(
             _warn_once("AmpForm cache disabled by NO_CACHE environment variable.")
             return func
         function_identifier = f"{func.__module__}.{func.__name__}"
+        src = inspect.getsource(func)
         dependency_identifiers = _get_dependency_identifiers(func, dependencies or [])
         nonlocal function_name
         if function_name is None:
@@ -103,7 +105,7 @@ def _cache_to_disk_implementation(
         @wraps(func)
         def wrapped_function(*args: P.args, **kwargs: P.kwargs) -> T:
             hashable_object = make_hashable(
-                function_identifier, *dependency_identifiers, args, kwargs
+                function_identifier, src, *dependency_identifiers, args, kwargs
             )
             h = get_readable_hash(hashable_object)
             cache_file = _get_cache_dir() / h[:2] / h[2:]

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -221,6 +221,8 @@ def to_bytes(obj) -> bytes:
 
 
 def make_hashable(*args) -> Hashable:
+    if len(args) == 1:
+        return _make_hashable_impl(args[0])
     return tuple(_make_hashable_impl(x) for x in args)
 
 

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -228,9 +228,7 @@ def make_hashable(*args) -> Hashable:
 
 def _make_hashable_impl(obj) -> Hashable:
     if isinstance(obj, abc.Mapping):
-        return frozendict({
-            _make_hashable_impl(k): _make_hashable_impl(v) for k, v in obj.items()
-        })
+        return frozendict({k: _make_hashable_impl(v) for k, v in obj.items()})
     if isinstance(obj, str):
         return obj
     if isinstance(obj, abc.Iterable):

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -112,9 +112,9 @@ def _cache_to_disk_implementation(
             if cache_file.exists():
                 with open(cache_file, "rb") as f:
                     return load_function(f)
-            result = func(*args, **kwargs)
             msg = f"No cache file {cache_file}, performing {function_name}()..."
             _LOGGER.warning(msg)
+            result = func(*args, **kwargs)
             cache_file.parent.mkdir(exist_ok=True, parents=True)
             with open(cache_file, "wb") as f:
                 dump_function(result, f)

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -226,7 +226,7 @@ def make_hashable(*args) -> Hashable:
 
 def _make_hashable_impl(obj) -> Hashable:
     if isinstance(obj, abc.Mapping):
-        return frozendict(obj)
+        return frozendict({make_hashable(k): make_hashable(v) for k, v in obj.items()})
     if isinstance(obj, str):
         return obj
     if isinstance(obj, abc.Iterable):

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -226,11 +226,13 @@ def make_hashable(*args) -> Hashable:
 
 def _make_hashable_impl(obj) -> Hashable:
     if isinstance(obj, abc.Mapping):
-        return frozendict({make_hashable(k): make_hashable(v) for k, v in obj.items()})
+        return frozendict({
+            _make_hashable_impl(k): _make_hashable_impl(v) for k, v in obj.items()
+        })
     if isinstance(obj, str):
         return obj
     if isinstance(obj, abc.Iterable):
-        hashable_items = (make_hashable(x) for x in obj)
+        hashable_items = (_make_hashable_impl(x) for x in obj)
         if isinstance(obj, abc.Sequence):
             return tuple(hashable_items)
         if isinstance(obj, set):

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -95,6 +95,7 @@ def _cache_to_disk_implementation(
         if "NO_CACHE" in os.environ:
             _warn_once("AmpForm cache disabled by NO_CACHE environment variable.")
             return func
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         function_identifier = f"{func.__module__}.{func.__name__}"
         src = inspect.getsource(func)
         dependency_identifiers = _get_dependency_identifiers(func, dependencies or [])
@@ -105,7 +106,12 @@ def _cache_to_disk_implementation(
         @wraps(func)
         def wrapped_function(*args: P.args, **kwargs: P.kwargs) -> T:
             hashable_object = make_hashable(
-                function_identifier, src, *dependency_identifiers, args, kwargs
+                function_identifier,
+                src,
+                python_version,
+                *dependency_identifiers,
+                args,
+                kwargs,
             )
             h = get_readable_hash(hashable_object)
             cache_file = _get_cache_dir() / h[:2] / h[2:]

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -221,6 +221,15 @@ def to_bytes(obj) -> bytes:
 
 
 def make_hashable(*args) -> Hashable:
+    """Make a hashable object from any Python object.
+
+    >>> make_hashable("a", 1, {"b": 2}, {3, 4})
+    ('a', 1, frozendict.frozendict({'b': 2}), frozenset({3, 4}))
+    >>> make_hashable({"a": {"sub-key": {1, 2, 3}, "b": [4, 5]}})
+    frozendict.frozendict({'a': frozendict.frozendict({'sub-key': frozenset({1, 2, 3}), 'b': (4, 5)})})
+    >>> make_hashable("already-hashable")
+    'already-hashable'
+    """
     if len(args) == 1:
         return _make_hashable_impl(args[0])
     return tuple(_make_hashable_impl(x) for x in args)


### PR DESCRIPTION
This is a fix-up to #459. The values of mappings were not made hashable. Some other improvements can be found in the [commits](https://github.com/ComPWA/ampform/commits).