### PR TITLE
ENH: use `aligned` environment instead of `array`

### DIFF
--- a/docs/usage/helicity/spin-alignment.ipynb
+++ b/docs/usage/helicity/spin-alignment.ipynb
@@ -183,7 +183,7 @@
     "        if i % 5 == 0\n",
     "    }\n",
     "    src = aslatex(selected_amplitudes, terms_per_line=1)\n",
-    "    src = src.replace(R\"\\end{array}\", R\"\\dots \\\\ \\end{array}\")\n",
+    "    src = src.replace(R\"\\end{aligned}\", R\"\\dots \\\\ \\end{aligned}\")\n",
     "    return Math(src)\n",
     "\n",
     "\n",

--- a/src/ampform/io/__init__.py
+++ b/src/ampform/io/__init__.py
@@ -80,11 +80,11 @@ def _render_broken_expression(
 ) -> str:
     n = terms_per_line
     groups = [sp.Add(*terms[i : i + n]) for i in range(0, len(terms), n)]
-    latex = R"\begin{array}{l}" + "\n"
-    latex += Rf"  {aslatex(groups[0], **kwargs)} \\" + "\n"
+    latex = R"\begin{aligned}" + "\n"
+    latex += Rf"& {aslatex(groups[0], **kwargs)} \\" + "\n"
     for term in groups[1:]:
-        latex += Rf"  \; + \; {aslatex(term, **kwargs)} \\" + "\n"
-    latex += R"\end{array}"
+        latex += Rf"& \;+\; {aslatex(term, **kwargs)} \\" + "\n"
+    latex += R"\end{aligned}"
     return latex
 
 
@@ -93,10 +93,10 @@ def _(obj: Mapping, *, terms_per_line: int = 0, **kwargs) -> str:
     if len(obj) == 0:
         msg = "Need at least one dictionary item"
         raise ValueError(msg)
-    latex = R"\begin{array}{rcl}" + "\n"
+    latex = R"\begin{aligned}" + "\n"
     for lhs, rhs in obj.items():
         latex += _render_row(lhs, rhs, terms_per_line, **kwargs)
-    latex += R"\end{array}"
+    latex += R"\end{aligned}"
     return latex
 
 
@@ -107,9 +107,9 @@ def _render_row(lhs, rhs, terms_per_line: int, **kwargs) -> str:
         terms = [sum(terms[i : i + n]) for i in range(0, len(terms), n)]
         row = _render_row(lhs, terms[0], terms_per_line=False)
         for term in terms[1:]:
-            row += Rf"    &+& {aslatex(term, **kwargs)} \\" + "\n"
+            row += Rf"    \;&+\; {aslatex(term, **kwargs)} \\" + "\n"
         return row
-    return Rf"  {aslatex(lhs)} &=& {aslatex(rhs, **kwargs)} \\" + "\n"
+    return Rf"  {aslatex(lhs)} \;&=\; {aslatex(rhs, **kwargs)} \\" + "\n"
 
 
 @aslatex.register(abc.Iterable)

--- a/tests/io/test_latex.py
+++ b/tests/io/test_latex.py
@@ -22,19 +22,19 @@ def test_expr():
     assert aslatex(expr, terms_per_line=3) == "x + y + z"
 
     expected = dedent(R"""
-    \begin{array}{l}
-      x \\
-      \; + \; y \\
-      \; + \; z \\
-    \end{array}
+    \begin{aligned}
+    & x \\
+    & \;+\; y \\
+    & \;+\; z \\
+    \end{aligned}
     """)
-
     assert aslatex(expr, terms_per_line=1) == expected.strip()
+
     expected = dedent(R"""
-    \begin{array}{l}
-      x + y \\
-      \; + \; z \\
-    \end{array}
+    \begin{aligned}
+    & x + y \\
+    & \;+\; z \\
+    \end{aligned}
     """)
     assert aslatex(expr, terms_per_line=2) == expected.strip()
 
@@ -66,21 +66,21 @@ def test_mapping(terms_per_line: int):
     }
     latex = aslatex(definitions, terms_per_line=terms_per_line)
     expected = R"""
-    \begin{array}{rcl}
-      y &=& a x^{2} + b \\
-      a &=& 3.0 \\
-      b &=& 2-1.3i \\
-    \end{array}
+    \begin{aligned}
+      y \;&=\; a x^{2} + b \\
+      a \;&=\; 3.0 \\
+      b \;&=\; 2-1.3i \\
+    \end{aligned}
     """
     assert latex == dedent(expected).strip()
 
     latex = aslatex(definitions, terms_per_line=1)
     expected = R"""
-    \begin{array}{rcl}
-      y &=& a x^{2} \\
-        &+& b \\
-      a &=& 3.0 \\
-      b &=& 2-1.3i \\
-    \end{array}
+    \begin{aligned}
+      y \;&=\; a x^{2} \\
+        \;&+\; b \\
+      a \;&=\; 3.0 \\
+      b \;&=\; 2-1.3i \\
+    \end{aligned}
     """
     assert latex == dedent(expected).strip()


### PR DESCRIPTION
The LaTeX `array` environment is not meant for aligning items in equations. For instance, in some renderings, the `array` environment renders equations in `\textstyle` rather than `\displaystyle`. Better to use `aligned`, which also is also supported by MathJax.