### PR TITLE
FIX: write disk cache files atomically

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -70,6 +70,7 @@
     "compwa",
     "concat",
     "conds",
+    "delenv",
     "displaystyle",
     "dlink",
     "docnb",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,6 +315,7 @@ linkcheck_ignore = [
     "https://suchung.web.cern.ch",
     "https://www.bookfinder.com",
 ]
+linkcheck_timeout = 60
 myst_enable_extensions = [
     "amsmath",
     "colon_fence",

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -126,27 +126,40 @@ def _cache_to_disk_implementation(
             msg = f"No cache file {cache_file}, performing {function_name}()..."
             _LOGGER.warning(msg)
             result = func(*args, **kwargs)
-            cache_file.parent.mkdir(exist_ok=True, parents=True)
-            temporary_file = None
             try:
-                with tempfile.NamedTemporaryFile(
-                    dir=cache_file.parent,
-                    prefix=f".{cache_file.name}.",
-                    suffix=".tmp",
-                    delete=False,
-                ) as f:
-                    temporary_file = Path(f.name)
-                    dump_function(result, f)
-                os.replace(temporary_file, cache_file)
-            except BaseException:
-                if temporary_file is not None:
-                    temporary_file.unlink(missing_ok=True)
-                raise
+                _dump_to_cache_file(result, cache_file, dump_function)
+            except OSError as exception:
+                msg = f"Could not write cache file {cache_file}: {exception}"
+                _LOGGER.warning(msg)
             return result
 
         return wrapped_function
 
     return decorator
+
+
+def _dump_to_cache_file(
+    result: Any,
+    cache_file: Path,
+    dump_function: Callable[[Any, SupportsWrite[bytes]], None],
+) -> None:
+    """Dump to a temporary file and rename, so that readers never see a partial file."""
+    cache_file.parent.mkdir(exist_ok=True, parents=True)
+    temporary_file = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=cache_file.parent,
+            prefix=f".{cache_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            temporary_file = Path(f.name)
+            dump_function(result, f)
+        os.replace(temporary_file, cache_file)
+    except BaseException:
+        if temporary_file is not None:
+            temporary_file.unlink(missing_ok=True)
+        raise
 
 
 def _get_dependency_identifiers(func: Callable, dependencies: list[str]) -> list[str]:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -16,6 +16,7 @@ import os
 import pickle  # ruff: ignore[suspicious-pickle-import]
 import re
 import sys
+import tempfile
 from collections import abc
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
@@ -117,14 +118,30 @@ def _cache_to_disk_implementation(
             h = get_readable_hash(hashable_object)
             cache_file = _get_cache_dir() / h[:2] / h[2:]
             if cache_file.exists():
-                with open(cache_file, "rb") as f:
-                    return load_function(f)
+                try:
+                    with open(cache_file, "rb") as f:
+                        return load_function(f)
+                except (EOFError, pickle.UnpicklingError):
+                    _LOGGER.warning("Ignoring corrupt cache file %s", cache_file)
             msg = f"No cache file {cache_file}, performing {function_name}()..."
             _LOGGER.warning(msg)
             result = func(*args, **kwargs)
             cache_file.parent.mkdir(exist_ok=True, parents=True)
-            with open(cache_file, "wb") as f:
-                dump_function(result, f)
+            temporary_file = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    dir=cache_file.parent,
+                    prefix=f".{cache_file.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as f:
+                    temporary_file = Path(f.name)
+                    dump_function(result, f)
+                os.replace(temporary_file, cache_file)
+            except BaseException:
+                if temporary_file is not None:
+                    temporary_file.unlink(missing_ok=True)
+                raise
             return result
 
         return wrapped_function

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+import pickle  # ruff: ignore[suspicious-pickle-import]
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from typing import TYPE_CHECKING, ClassVar
 
 import pytest
@@ -13,11 +16,77 @@ import ampform
 from ampform._qrules import get_qrules_version
 from ampform.dynamics import EnergyDependentWidth
 from ampform.dynamics.builder import RelativisticBreitWignerBuilder
-from ampform.sympy._cache import get_readable_hash
+from ampform.sympy import _cache
+from ampform.sympy._cache import cache_to_disk, get_readable_hash
 
 if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
     from _pytest.logging import LogCaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+    from _typeshed import SupportsWrite
     from qrules.transition import SpinFormalism
+
+
+def test_cache_to_disk_writes_atomically(tmp_path: Path, monkeypatch: MonkeyPatch):
+    monkeypatch.setattr(_cache, "_get_cache_dir", lambda: tmp_path)
+    first_write_started = Event()
+    continue_first_write = Event()
+    dump_calls = 0
+
+    def dump_in_two_steps(value: Any, stream: SupportsWrite[bytes]) -> None:
+        nonlocal dump_calls
+        dump_calls += 1
+        data = pickle.dumps(value)
+        if dump_calls == 1:
+            stream.write(data[:1])
+            first_write_started.set()
+            continue_first_write.wait(timeout=5)
+            stream.write(data[1:])
+        else:
+            stream.write(data)
+
+    @cache_to_disk(dump_function=dump_in_two_steps)
+    def cached_function():
+        return "result"
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_result = executor.submit(cached_function)
+        try:
+            assert first_write_started.wait(timeout=5)
+            assert cached_function() == "result"
+        finally:
+            continue_first_write.set()
+        assert first_result.result(timeout=5) == "result"
+
+    assert not list(tmp_path.rglob("*.tmp"))
+    cache_files = [path for path in tmp_path.rglob("*") if path.is_file()]
+    assert len(cache_files) == 1
+    assert pickle.loads(cache_files[0].read_bytes()) == "result"  # ruff: ignore[suspicious-pickle-usage]
+
+
+@pytest.mark.parametrize("corrupt_data", [b"", b"not a pickle"])
+def test_cache_to_disk_repairs_corrupt_file(
+    corrupt_data: bytes, tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    monkeypatch.setattr(_cache, "_get_cache_dir", lambda: tmp_path)
+    call_count = 0
+
+    @cache_to_disk
+    def cached_function():
+        nonlocal call_count
+        call_count += 1
+        return "result"
+
+    assert cached_function() == "result"
+    cache_files = [path for path in tmp_path.rglob("*") if path.is_file()]
+    assert len(cache_files) == 1
+    cache_files[0].write_bytes(corrupt_data)
+
+    assert cached_function() == "result"
+    assert cached_function() == "result"
+    assert call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 def test_cache_to_disk_writes_atomically(tmp_path: Path, monkeypatch: MonkeyPatch):
     monkeypatch.setattr(_cache, "_get_cache_dir", lambda: tmp_path)
+    monkeypatch.delenv("NO_CACHE", raising=False)
     first_write_started = Event()
     continue_first_write = Event()
     dump_calls = 0
@@ -71,6 +72,7 @@ def test_cache_to_disk_repairs_corrupt_file(
     corrupt_data: bytes, tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     monkeypatch.setattr(_cache, "_get_cache_dir", lambda: tmp_path)
+    monkeypatch.delenv("NO_CACHE", raising=False)
     call_count = 0
 
     @cache_to_disk


### PR DESCRIPTION
Closes #506 

## 🐛 Bug fixes

- Cache files are now written to a temporary file in the same directory and moved into place with `os.replace()`, so a concurrent reader never observes a half-written file.
- A cache file that is empty or otherwise unreadable is now ignored with a warning and recomputed, instead of raising from `pickle.load()`.
- A failing cache write (full or read-only cache directory, or a locked destination file) no longer discards an already-computed result: it is logged as a warning and the result is returned uncached.

## 🖱️ Developer experience

- The Sphinx `linkcheck` builder now allows 60 seconds per link instead of the 30-second default, which was causing spurious CI failures on slow-responding hosts such as `zenodo.org`.

## Squash commit messages

```text
* DX: increase Sphinx linkcheck timeout
* FIX: keep computed result when cache write fails
```
