### PR TITLE
FIX: stabilize caching hashes

### DIFF
--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -213,7 +213,7 @@ def _get_cache_dir() -> Path:
 
 
 @cache
-def _warn_once(msg):
+def _warn_once(msg, /):
     _LOGGER.warning(msg)
 
 
@@ -243,7 +243,7 @@ def get_system_cache_directory() -> str:
 
 
 @cache
-def get_readable_hash(obj: Hashable) -> str:
+def get_readable_hash(obj: Hashable, /) -> str:
     """Get a human-readable hash of any hashable Python object.
 
     The hash follows from the value of the object, not from the identity of the parts it
@@ -254,7 +254,8 @@ def get_readable_hash(obj: Hashable) -> str:
     Sets and dictionaries are an exception. They are serialized in iteration order,
     which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`. The
     wrappers in :mod:`~ampform.sympy.cached` sort the substitution mappings they are
-    given, so their cache keys do not depend on the order in which the caller built them.
+    given, so their cache keys do not depend on the order in which the caller built
+    them.
 
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
@@ -262,7 +263,7 @@ def get_readable_hash(obj: Hashable) -> str:
     return hashlib.md5(to_bytes(obj), usedforsecurity=False).hexdigest()
 
 
-def to_bytes(obj) -> bytes:
+def to_bytes(obj, /) -> bytes:
     """Convert any Python object to `bytes` with :mod:`pickle`.
 
     The bytes depend on the value of the object rather than on which of its parts happen
@@ -275,7 +276,7 @@ def to_bytes(obj) -> bytes:
     return stream.getvalue()
 
 
-def _dump_deterministically(obj, stream: SupportsWrite[bytes]) -> None:
+def _dump_deterministically(obj, /, stream: SupportsWrite[bytes]) -> None:
     """Pickle an object so that the bytes depend on its value alone."""
     _DeterministicPickler(stream).dump(obj)
 
@@ -332,7 +333,7 @@ def make_hashable(*args) -> Hashable:
     return tuple(_make_hashable_impl(x) for x in args)
 
 
-def _make_hashable_impl(obj) -> Hashable:
+def _make_hashable_impl(obj, /) -> Hashable:
     if isinstance(obj, abc.Mapping):
         return frozendict({k: _make_hashable_impl(v) for k, v in obj.items()})
     if isinstance(obj, str):

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -7,10 +7,12 @@ These methods are private, but can be imported from this module:
    import ampform.sympy._cache
 """
 
+# cspell:ignore pickler
 from __future__ import annotations
 
 import hashlib
 import inspect
+import io
 import logging
 import os
 import pickle  # ruff: ignore[suspicious-pickle-import]
@@ -18,15 +20,17 @@ import re
 import sys
 import tempfile
 from collections import abc
+from contextlib import suppress
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NamedTuple, overload
 
+import sympy as sp
 from frozendict import frozendict
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Iterable
     from io import BufferedReader
 
     from _typeshed import SupportsWrite
@@ -245,16 +249,107 @@ def get_readable_hash(obj: Hashable) -> str:
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
     """
-    b = to_bytes(obj)
-    h = hashlib.md5(b, usedforsecurity=False)
-    return h.hexdigest()
+    digest = hashlib.md5(usedforsecurity=False)
+    if isinstance(obj, (bytes, bytearray)):
+        digest.update(obj)
+    else:
+        _dump_deterministically(obj, stream=_HashStream(digest))
+    return digest.hexdigest()
 
 
 def to_bytes(obj) -> bytes:
     """Convert any Python object to `bytes` using :func:`pickle.dumps`."""
     if isinstance(obj, (bytes, bytearray)):
         return obj
-    return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    stream = io.BytesIO()
+    _dump_deterministically(obj, stream)
+    return stream.getvalue()
+
+
+def _dump_deterministically(obj, stream: SupportsWrite[bytes]) -> None:
+    """Pickle an object so that the bytes depend on its value alone."""
+    _DeterministicPickler(stream).dump(obj)
+
+
+class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-access]
+    """Pickler whose output does not depend on object identity or iteration order.
+
+    A pickle stores a repeated object as a back-reference to the first time it was
+    written, keyed on identity. SymPy hands out a cached instance for equal expressions,
+    but its cache is a bounded LRU (:code:`SYMPY_CACHE_SIZE`), so which sub-expressions
+    are the *same* instance depends on what was constructed before and in which order.
+    Equal expressions are therefore mapped to one representative here, which makes the
+    back-references depend on the expression rather than on the cache state.
+
+    Two SymPy objects that compare equal always carry the same
+    :code:`_hashable_content()`, which for `.unevaluated` classes includes the arguments
+    that are not sympified, so equal objects also pickle to the same bytes.
+
+    Only those canonicalized SymPy objects are memoized. Anything else is written out in
+    full on each occurrence, because whether two equal non-SymPy objects are one shared
+    instance depends on caches and string interning elsewhere.
+
+    Sets and dictionaries are written in a sorted order, because their iteration order
+    depends on :code:`PYTHONHASHSEED` for `str` keys.
+
+    The pure-Python pickler is subclassed because the C accelerator does not dispatch to
+    these overrides.
+    """
+
+    dispatch = pickle._Pickler.dispatch.copy()  # ruff: ignore[private-member-access]
+
+    def __init__(self, stream: SupportsWrite[bytes]) -> None:
+        super().__init__(stream, protocol=pickle.HIGHEST_PROTOCOL)
+        self._representatives: dict[tuple[type, Any], Any] = {}
+
+    def save(self, obj, *args, **kwargs) -> None:
+        if isinstance(obj, sp.Basic):
+            with suppress(TypeError):
+                obj = self._representatives.setdefault((type(obj), obj), obj)
+        super().save(obj, *args, **kwargs)
+
+    def memoize(self, obj) -> None:
+        if isinstance(obj, sp.Basic):
+            super().memoize(obj)
+
+    def save_set(self, obj) -> None:
+        self.save(_SortedContainer("set", _sorted_deterministically(obj)))
+
+    def save_frozenset(self, obj) -> None:
+        self.save(_SortedContainer("frozenset", _sorted_deterministically(obj)))
+
+    def _batch_setitems(self, items, *args) -> None:
+        # Python 3.14 passes an additional argument
+        super()._batch_setitems(iter(_sorted_deterministically(items)), *args)
+
+    dispatch[set] = save_set  # ty: ignore[invalid-assignment]
+    dispatch[frozenset] = save_frozenset  # ty: ignore[invalid-assignment]
+
+
+class _SortedContainer(NamedTuple):
+    """Sorted stand-in for a set, tagged so that it cannot collide with a `tuple`."""
+
+    kind: str
+    items: list
+
+
+def _sorted_deterministically(items: Iterable) -> list:
+    """Sort items, falling back to their serialization when they are not orderable."""
+    try:
+        return sorted(items)
+    except TypeError:
+        return sorted(items, key=to_bytes)
+
+
+class _HashStream:
+    """Minimal write-only stream that feeds everything written to it into a hash."""
+
+    def __init__(self, digest) -> None:
+        self.digest = digest
+
+    def write(self, data: bytes) -> int:
+        self.digest.update(data)
+        return len(data)
 
 
 def make_hashable(*args) -> Hashable:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -249,12 +249,7 @@ def get_readable_hash(obj: Hashable) -> str:
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
     """
-    digest = hashlib.md5(usedforsecurity=False)
-    if isinstance(obj, (bytes, bytearray)):
-        digest.update(obj)
-    else:
-        _dump_deterministically(obj, stream=_HashStream(digest))
-    return digest.hexdigest()
+    return hashlib.md5(to_bytes(obj), usedforsecurity=False).hexdigest()
 
 
 def to_bytes(obj) -> bytes:
@@ -339,17 +334,6 @@ def _sorted_deterministically(items: Iterable) -> list:
         return sorted(items)
     except TypeError:
         return sorted(items, key=to_bytes)
-
-
-class _HashStream:
-    """Minimal write-only stream that feeds everything written to it into a hash."""
-
-    def __init__(self, digest) -> None:
-        self.digest = digest
-
-    def write(self, data: bytes) -> int:
-        self.digest.update(data)
-        return len(data)
 
 
 def make_hashable(*args) -> Hashable:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -284,8 +284,11 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     full on each occurrence, because whether two equal non-SymPy objects are one shared
     instance depends on caches and string interning elsewhere.
 
-    Sets and dictionaries are written in a sorted order, because their iteration order
-    depends on :code:`PYTHONHASHSEED` for `str` keys.
+    Sets and dictionaries are written in a sorted order. A `set` iterates in an order
+    that depends on :code:`PYTHONHASHSEED` for `str` elements. A `dict` iterates in
+    insertion order, which is not seed-dependent in itself, but two dictionaries that
+    compare equal can have been built in a different order, and a dictionary built by
+    iterating a `set` inherits that seed-dependent order.
 
     The pure-Python pickler is subclassed because the C accelerator does not dispatch to
     these overrides.

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -24,13 +24,13 @@ from contextlib import suppress
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NamedTuple, overload
 
 import sympy as sp
 from frozendict import frozendict
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Iterable
     from io import BufferedReader
 
     from _typeshed import SupportsWrite
@@ -251,8 +251,9 @@ def get_readable_hash(obj: Hashable) -> str:
     matter what was constructed before them or in which process, which is what makes the
     hash usable as a cache key in :func:`.cache_to_disk`.
 
-    Sets and dictionaries are an exception. They are serialized in iteration order,
-    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`.
+    Sets and dictionaries hash the same whatever order they are iterated or built in, so
+    that a substitution mapping built from something like
+    :attr:`~sympy.core.basic.Basic.free_symbols` gets the same hash in every process.
 
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
@@ -279,7 +280,7 @@ def _dump_deterministically(obj, stream: SupportsWrite[bytes]) -> None:
 
 
 class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-access]
-    """Pickler whose output does not depend on object identity.
+    """Pickler whose output does not depend on object identity or iteration order.
 
     A pickle stores a repeated object as a back-reference to the first time it was
     written, keyed on identity. SymPy hands out a cached instance for equal expressions,
@@ -296,9 +297,17 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     full on each occurrence, because whether two equal non-SymPy objects are one shared
     instance depends on caches and string interning elsewhere.
 
+    Sets and dictionaries are written in a sorted order. A `set` iterates in an order
+    that depends on :code:`PYTHONHASHSEED` for `str` elements. A `dict` iterates in
+    insertion order, which is not seed-dependent in itself, but two dictionaries that
+    compare equal can have been built in a different order, and a dictionary built by
+    iterating a `set` inherits that seed-dependent order.
+
     The pure-Python pickler is subclassed because the C accelerator does not dispatch to
     these overrides.
     """
+
+    dispatch = pickle._Pickler.dispatch.copy()  # ruff: ignore[private-member-access]
 
     def __init__(self, stream: SupportsWrite[bytes]) -> None:
         super().__init__(stream, protocol=pickle.HIGHEST_PROTOCOL)
@@ -313,6 +322,34 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     def memoize(self, obj) -> None:
         if isinstance(obj, sp.Basic):
             super().memoize(obj)
+
+    def save_set(self, obj) -> None:
+        self.save(_SortedContainer("set", _sorted_deterministically(obj)))
+
+    def save_frozenset(self, obj) -> None:
+        self.save(_SortedContainer("frozenset", _sorted_deterministically(obj)))
+
+    def _batch_setitems(self, items, *args) -> None:
+        # Python 3.14 passes an additional argument
+        super()._batch_setitems(iter(_sorted_deterministically(items)), *args)
+
+    dispatch[set] = save_set  # ty: ignore[invalid-assignment]
+    dispatch[frozenset] = save_frozenset  # ty: ignore[invalid-assignment]
+
+
+class _SortedContainer(NamedTuple):
+    """Sorted stand-in for a set, tagged so that it cannot collide with a `tuple`."""
+
+    kind: str
+    items: list
+
+
+def _sorted_deterministically(items: Iterable) -> list:
+    """Sort items, falling back to their serialization when they are not orderable."""
+    try:
+        return sorted(items)
+    except TypeError:
+        return sorted(items, key=to_bytes)
 
 
 def make_hashable(*args) -> Hashable:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -252,7 +252,9 @@ def get_readable_hash(obj: Hashable) -> str:
     hash usable as a cache key in :func:`.cache_to_disk`.
 
     Sets and dictionaries are an exception. They are serialized in iteration order,
-    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`.
+    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`. The
+    wrappers in :mod:`~ampform.sympy.cached` sort the substitution mappings they are
+    given, so their cache keys do not depend on the order in which the caller built them.
 
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -24,13 +24,13 @@ from contextlib import suppress
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NamedTuple, overload
 
 import sympy as sp
 from frozendict import frozendict
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Iterable
     from io import BufferedReader
 
     from _typeshed import SupportsWrite
@@ -251,11 +251,10 @@ def get_readable_hash(obj: Hashable, /) -> str:
     matter what was constructed before them or in which process, which is what makes the
     hash usable as a cache key in :func:`.cache_to_disk`.
 
-    Sets and dictionaries are an exception. They are serialized in iteration order,
-    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`. The
-    wrappers in :mod:`~ampform.sympy.cached` sort the substitution mappings they are
-    given, so their cache keys do not depend on the order in which the caller built
-    them.
+    A `set` or `dict` handed to this function directly is serialized in iteration order,
+    which depends on :code:`PYTHONHASHSEED` when its elements or keys are `str`. Pass it
+    through :func:`.make_hashable` first, as :func:`.cache_to_disk` does, to put it in a
+    fixed order.
 
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
@@ -321,10 +320,15 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
 def make_hashable(*args) -> Hashable:
     """Make a hashable object from any Python object.
 
+    Sets and dictionaries are put in a fixed order, because a `set` iterates in an order
+    that depends on :code:`PYTHONHASHSEED` for `str` elements, and a `dict` built by
+    iterating one inherits that order. A cache key built from them would otherwise
+    differ in every process.
+
     >>> make_hashable("a", 1, {"b": 2}, {3, 4})
-    ('a', 1, frozendict.frozendict({'b': 2}), frozenset({3, 4}))
+    ('a', 1, frozendict.frozendict({'b': 2}), _SortedSet(items=(3, 4)))
     >>> make_hashable({"a": {"sub-key": {1, 2, 3}, "b": [4, 5]}})
-    frozendict.frozendict({'a': frozendict.frozendict({'sub-key': frozenset({1, 2, 3}), 'b': (4, 5)})})
+    frozendict.frozendict({'a': frozendict.frozendict({'b': (4, 5), 'sub-key': _SortedSet(items=(1, 2, 3))})})
     >>> make_hashable("already-hashable")
     'already-hashable'
     """
@@ -335,7 +339,8 @@ def make_hashable(*args) -> Hashable:
 
 def _make_hashable_impl(obj, /) -> Hashable:
     if isinstance(obj, abc.Mapping):
-        return frozendict({k: _make_hashable_impl(v) for k, v in obj.items()})
+        keys = _sorted_deterministically(obj.keys())
+        return frozendict({k: _make_hashable_impl(obj[k]) for k in keys})
     if isinstance(obj, str):
         return obj
     if isinstance(obj, abc.Iterable):
@@ -343,5 +348,19 @@ def _make_hashable_impl(obj, /) -> Hashable:
         if isinstance(obj, abc.Sequence):
             return tuple(hashable_items)
         if isinstance(obj, set):
-            return frozenset(hashable_items)
+            return _SortedSet(_sorted_deterministically(hashable_items))
     return obj
+
+
+class _SortedSet(NamedTuple):
+    """Order-normalized stand-in for a `set`, tagged so it cannot pass for a `tuple`."""
+
+    items: tuple
+
+
+def _sorted_deterministically(items: Iterable[T], /) -> tuple[T, ...]:
+    """Sort items, falling back to their serialization when they cannot be compared."""
+    try:
+        return tuple(sorted(items))
+    except TypeError:
+        return tuple(sorted(items, key=to_bytes))

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -24,13 +24,13 @@ from contextlib import suppress
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, overload
+from typing import TYPE_CHECKING, overload
 
 import sympy as sp
 from frozendict import frozendict
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable
+    from collections.abc import Hashable
     from io import BufferedReader
 
     from _typeshed import SupportsWrite
@@ -267,7 +267,7 @@ def _dump_deterministically(obj, stream: SupportsWrite[bytes]) -> None:
 
 
 class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-access]
-    """Pickler whose output does not depend on object identity or iteration order.
+    """Pickler whose output does not depend on object identity.
 
     A pickle stores a repeated object as a back-reference to the first time it was
     written, keyed on identity. SymPy hands out a cached instance for equal expressions,
@@ -284,17 +284,9 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     full on each occurrence, because whether two equal non-SymPy objects are one shared
     instance depends on caches and string interning elsewhere.
 
-    Sets and dictionaries are written in a sorted order. A `set` iterates in an order
-    that depends on :code:`PYTHONHASHSEED` for `str` elements. A `dict` iterates in
-    insertion order, which is not seed-dependent in itself, but two dictionaries that
-    compare equal can have been built in a different order, and a dictionary built by
-    iterating a `set` inherits that seed-dependent order.
-
     The pure-Python pickler is subclassed because the C accelerator does not dispatch to
     these overrides.
     """
-
-    dispatch = pickle._Pickler.dispatch.copy()  # ruff: ignore[private-member-access]
 
     def __init__(self, stream: SupportsWrite[bytes]) -> None:
         super().__init__(stream, protocol=pickle.HIGHEST_PROTOCOL)
@@ -309,34 +301,6 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     def memoize(self, obj) -> None:
         if isinstance(obj, sp.Basic):
             super().memoize(obj)
-
-    def save_set(self, obj) -> None:
-        self.save(_SortedContainer("set", _sorted_deterministically(obj)))
-
-    def save_frozenset(self, obj) -> None:
-        self.save(_SortedContainer("frozenset", _sorted_deterministically(obj)))
-
-    def _batch_setitems(self, items, *args) -> None:
-        # Python 3.14 passes an additional argument
-        super()._batch_setitems(iter(_sorted_deterministically(items)), *args)
-
-    dispatch[set] = save_set  # ty: ignore[invalid-assignment]
-    dispatch[frozenset] = save_frozenset  # ty: ignore[invalid-assignment]
-
-
-class _SortedContainer(NamedTuple):
-    """Sorted stand-in for a set, tagged so that it cannot collide with a `tuple`."""
-
-    kind: str
-    items: list
-
-
-def _sorted_deterministically(items: Iterable) -> list:
-    """Sort items, falling back to their serialization when they are not orderable."""
-    try:
-        return sorted(items)
-    except TypeError:
-        return sorted(items, key=to_bytes)
 
 
 def make_hashable(*args) -> Hashable:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -24,13 +24,13 @@ from contextlib import suppress
 from functools import cache, wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, overload
+from typing import TYPE_CHECKING, overload
 
 import sympy as sp
 from frozendict import frozendict
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable
+    from collections.abc import Hashable
     from io import BufferedReader
 
     from _typeshed import SupportsWrite
@@ -251,9 +251,8 @@ def get_readable_hash(obj: Hashable) -> str:
     matter what was constructed before them or in which process, which is what makes the
     hash usable as a cache key in :func:`.cache_to_disk`.
 
-    Sets and dictionaries hash the same whatever order they are iterated or built in, so
-    that a substitution mapping built from something like
-    :attr:`~sympy.core.basic.Basic.free_symbols` gets the same hash in every process.
+    Sets and dictionaries are an exception. They are serialized in iteration order,
+    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`.
 
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
@@ -280,7 +279,7 @@ def _dump_deterministically(obj, stream: SupportsWrite[bytes]) -> None:
 
 
 class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-access]
-    """Pickler whose output does not depend on object identity or iteration order.
+    """Pickler whose output does not depend on object identity.
 
     A pickle stores a repeated object as a back-reference to the first time it was
     written, keyed on identity. SymPy hands out a cached instance for equal expressions,
@@ -297,17 +296,9 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     full on each occurrence, because whether two equal non-SymPy objects are one shared
     instance depends on caches and string interning elsewhere.
 
-    Sets and dictionaries are written in a sorted order. A `set` iterates in an order
-    that depends on :code:`PYTHONHASHSEED` for `str` elements. A `dict` iterates in
-    insertion order, which is not seed-dependent in itself, but two dictionaries that
-    compare equal can have been built in a different order, and a dictionary built by
-    iterating a `set` inherits that seed-dependent order.
-
     The pure-Python pickler is subclassed because the C accelerator does not dispatch to
     these overrides.
     """
-
-    dispatch = pickle._Pickler.dispatch.copy()  # ruff: ignore[private-member-access]
 
     def __init__(self, stream: SupportsWrite[bytes]) -> None:
         super().__init__(stream, protocol=pickle.HIGHEST_PROTOCOL)
@@ -322,34 +313,6 @@ class _DeterministicPickler(pickle._Pickler):  # ruff: ignore[private-member-acc
     def memoize(self, obj) -> None:
         if isinstance(obj, sp.Basic):
             super().memoize(obj)
-
-    def save_set(self, obj) -> None:
-        self.save(_SortedContainer("set", _sorted_deterministically(obj)))
-
-    def save_frozenset(self, obj) -> None:
-        self.save(_SortedContainer("frozenset", _sorted_deterministically(obj)))
-
-    def _batch_setitems(self, items, *args) -> None:
-        # Python 3.14 passes an additional argument
-        super()._batch_setitems(iter(_sorted_deterministically(items)), *args)
-
-    dispatch[set] = save_set  # ty: ignore[invalid-assignment]
-    dispatch[frozenset] = save_frozenset  # ty: ignore[invalid-assignment]
-
-
-class _SortedContainer(NamedTuple):
-    """Sorted stand-in for a set, tagged so that it cannot collide with a `tuple`."""
-
-    kind: str
-    items: list
-
-
-def _sorted_deterministically(items: Iterable) -> list:
-    """Sort items, falling back to their serialization when they are not orderable."""
-    try:
-        return sorted(items)
-    except TypeError:
-        return sorted(items, key=to_bytes)
 
 
 def make_hashable(*args) -> Hashable:

--- a/src/ampform/sympy/_cache.py
+++ b/src/ampform/sympy/_cache.py
@@ -246,6 +246,14 @@ def get_system_cache_directory() -> str:
 def get_readable_hash(obj: Hashable) -> str:
     """Get a human-readable hash of any hashable Python object.
 
+    The hash follows from the value of the object, not from the identity of the parts it
+    is built from. Two SymPy expressions that compare equal therefore hash the same, no
+    matter what was constructed before them or in which process, which is what makes the
+    hash usable as a cache key in :func:`.cache_to_disk`.
+
+    Sets and dictionaries are an exception. They are serialized in iteration order,
+    which depends on :code:`PYTHONHASHSEED` when their elements or keys are `str`.
+
     Args:
         obj: Any hashable object, mutable or immutable, to be hashed.
     """
@@ -253,7 +261,11 @@ def get_readable_hash(obj: Hashable) -> str:
 
 
 def to_bytes(obj) -> bytes:
-    """Convert any Python object to `bytes` using :func:`pickle.dumps`."""
+    """Convert any Python object to `bytes` with :mod:`pickle`.
+
+    The bytes depend on the value of the object rather than on which of its parts happen
+    to be the same instance. See :func:`.get_readable_hash` for what that guarantees.
+    """
     if isinstance(obj, (bytes, bytearray)):
         return obj
     stream = io.BytesIO()

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from typing import TypeVar
 
     SympyObject = TypeVar("SympyObject", bound=sp.Basic)
+    V = TypeVar("V")
 
 
 @cache
@@ -124,8 +125,8 @@ def _unfold_substitutions(
 
 
 def _sorted_frozendict(
-    substitutions: Mapping[sp.Basic, Any],
-) -> frozendict[sp.Basic, Any]:
+    substitutions: Mapping[SympyObject, V], /
+) -> frozendict[SympyObject, V]:
     """Freeze a substitution mapping in an order that does not depend on the caller.
 
     The disk cache is keyed on a pickle of the mapping, and a pickled mapping is written

--- a/src/ampform/sympy/cached.py
+++ b/src/ampform/sympy/cached.py
@@ -3,6 +3,7 @@
 .. autofunction:: doit
 """
 
+# cspell:ignore srepr
 from __future__ import annotations
 
 from functools import cache
@@ -59,8 +60,11 @@ def trigsimp(expr: sp.Expr, *args, **kwargs) -> sp.Expr:
 
 
 def subs(expr: sp.Expr, substitutions: Mapping[sp.Basic, Any]) -> sp.Expr:
-    """Call :meth:`~sympy.core.basic.Basic.subs` and cache the result to disk."""
-    return _subs_impl(expr, frozendict(substitutions))
+    """Call :meth:`~sympy.core.basic.Basic.subs` and cache the result to disk.
+
+    The order of the substitutions does not affect the cache key.
+    """
+    return _subs_impl(expr, _sorted_frozendict(substitutions))
 
 
 @cache
@@ -70,8 +74,11 @@ def _subs_impl(expr: sp.Expr, substitutions: frozendict[sp.Basic, Any]) -> sp.Ex
 
 
 def xreplace(expr: sp.Expr, substitutions: Mapping[sp.Basic, Any]) -> sp.Expr:
-    """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk."""
-    return _xreplace_impl(expr, frozendict(substitutions))
+    """Call :meth:`~sympy.core.basic.Basic.xreplace` and cache the result to disk.
+
+    The order of the substitutions does not affect the cache key.
+    """
+    return _xreplace_impl(expr, _sorted_frozendict(substitutions))
 
 
 @cache
@@ -104,7 +111,7 @@ class Model(Protocol):
 
 
 def _unfold_impl(expr: sp.Expr, substitutions: Mapping[sp.Basic, Any]) -> sp.Expr:
-    substitutions = _unfold_substitutions(frozendict(substitutions))
+    substitutions = _unfold_substitutions(_sorted_frozendict(substitutions))
     expr = doit(expr)
     return xreplace(expr, substitutions)
 
@@ -114,3 +121,25 @@ def _unfold_substitutions(
     substitutions: frozendict[sp.Basic, Any],
 ) -> frozendict[sp.Basic, Any]:
     return frozendict({k: doit(v) for k, v in substitutions.items()})
+
+
+def _sorted_frozendict(
+    substitutions: Mapping[sp.Basic, Any],
+) -> frozendict[sp.Basic, Any]:
+    """Freeze a substitution mapping in an order that does not depend on the caller.
+
+    The disk cache is keyed on a pickle of the mapping, and a pickled mapping is written
+    in iteration order. A mapping built by iterating over
+    :attr:`~sympy.core.basic.Basic.free_symbols` inherits the order of that `set`, which
+    depends on :code:`PYTHONHASHSEED`, so the same substitutions would otherwise get a
+    different cache key in every process.
+
+    `~sympy.core.sorting.default_sort_key` does not distinguish assumptions, which would
+    leave the order of two otherwise identical symbols to the caller again, so
+    :func:`~sympy.printing.repr.srepr` breaks those ties.
+    """
+    return frozendict(sorted(substitutions.items(), key=lambda kv: _sort_key(kv[0])))
+
+
+def _sort_key(obj: Any) -> tuple[Any, str]:
+    return sp.default_sort_key(obj), sp.srepr(obj)

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import logging
-import os
 import pickle
-import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from textwrap import dedent
 from threading import Event
 from typing import TYPE_CHECKING, ClassVar
 
@@ -140,11 +137,11 @@ class TestLargeHash:
         ("expected_hash", "formalism"),
         [
             (
-                "004ae36" if sys.version_info >= (3, 11) else "b1bd1af",
+                "627ee45" if sys.version_info >= (3, 11) else "206587e",
                 "canonical-helicity",
             ),
             (
-                "37510e8" if sys.version_info >= (3, 11) else "953baa2",
+                "422ec6b" if sys.version_info >= (3, 11) else "4c37f61",
                 "helicity",
             ),
         ],
@@ -213,46 +210,11 @@ class TestLargeHash:
         ("a36cb47", b"raw bytes"),
         ("cb5e378", "a string"),
         ("dc0dafb", (1, "a", (2, 3))),
-        ("aeee3a6", frozenset({"a", "b", "c"})),
-        ("792a355", frozendict({"b": 2, "a": 1})),
-        ("1d60963", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
+        ("af94f10", frozendict({"b": 2, "a": 1})),
+        ("d7210d2", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
     ],
-    ids=["bytes", "str", "tuple", "frozenset", "frozendict", "nested"],
+    ids=["bytes", "str", "tuple", "frozendict", "nested"],
 )
 def test_get_readable_hash_containers(expected_hash: str, obj: Any):
-    """Pin the hashes of the containers that :func:`.to_bytes` sorts deterministically."""
+    """Pin the hashes of the container types that :func:`.to_bytes` is used on."""
     assert get_readable_hash(obj)[:7] == expected_hash
-
-
-@pytest.mark.parametrize("seed", ["0", "1", "12345"])
-def test_get_readable_hash_independent_of_hash_seed(seed: str):
-    """Sets and dicts must hash the same under any :code:`PYTHONHASHSEED`."""
-    source = dedent("""
-        from frozendict import frozendict
-
-        from ampform.sympy._cache import get_readable_hash
-
-        obj = frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
-        print(get_readable_hash(obj))
-    """)
-    env = {**os.environ, "PYTHONHASHSEED": seed}
-    output = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
-        [sys.executable, "-c", source],
-        capture_output=True,
-        check=True,
-        env=env,
-        text=True,
-    )
-    assert output.stdout.strip() == get_readable_hash(
-        frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
-    )
-
-
-def test_get_readable_hash_ignores_dict_insertion_order():
-    """Dictionaries that compare equal must hash the same, whatever their build order."""
-    keys = ("alpha", "beta", "gamma", "delta")
-    forward = frozendict({k: len(k) for k in keys})
-    backward = frozendict({k: len(k) for k in reversed(keys)})
-    assert forward == backward
-    assert tuple(forward) != tuple(backward)
-    assert get_readable_hash(forward) == get_readable_hash(backward)

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import logging
-import os
 import pickle
-import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from textwrap import dedent
 from threading import Event
 from typing import TYPE_CHECKING
 
@@ -135,47 +132,14 @@ def describe_get_readable_hash():
             ("a36cb47", b"raw bytes"),
             ("cb5e378", "a string"),
             ("dc0dafb", (1, "a", (2, 3))),
-            ("aeee3a6", frozenset({"a", "b", "c"})),
-            ("792a355", frozendict({"b": 2, "a": 1})),
-            ("1d60963", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
+            ("af94f10", frozendict({"b": 2, "a": 1})),
+            ("d7210d2", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
         ],
-        ids=["bytes", "str", "tuple", "frozenset", "frozendict", "nested"],
+        ids=["bytes", "str", "tuple", "frozendict", "nested"],
     )
     def it_hashes_containers(expected_hash: str, obj: Any):
-        """Pin the hashes of the containers that :func:`.to_bytes` sorts deterministically."""
+        """Pin the hashes of the container types that :func:`.to_bytes` is used on."""
         assert get_readable_hash(obj)[:7] == expected_hash
-
-    @pytest.mark.parametrize("seed", ["0", "1", "12345"])
-    def it_hashes_sets_identically_across_hash_seeds(seed: str):
-        """Sets and dicts must hash the same under any :code:`PYTHONHASHSEED`."""
-        source = dedent("""
-            from frozendict import frozendict
-
-            from ampform.sympy._cache import get_readable_hash
-
-            obj = frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
-            print(get_readable_hash(obj))
-        """)
-        env = {**os.environ, "PYTHONHASHSEED": seed}
-        output = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
-            [sys.executable, "-c", source],
-            capture_output=True,
-            check=True,
-            env=env,
-            text=True,
-        )
-        assert output.stdout.strip() == get_readable_hash(
-            frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
-        )
-
-    def it_ignores_dict_insertion_order():
-        """Dictionaries that compare equal must hash the same, whatever their build order."""
-        keys = ("alpha", "beta", "gamma", "delta")
-        forward = frozendict({k: len(k) for k in keys})
-        backward = frozendict({k: len(k) for k in reversed(keys)})
-        assert forward == backward
-        assert tuple(forward) != tuple(backward)
-        assert get_readable_hash(forward) == get_readable_hash(backward)
 
 
 def describe_large_hash():
@@ -188,11 +152,11 @@ def describe_large_hash():
         ("expected_hash", "formalism"),
         [
             (
-                "004ae36" if sys.version_info >= (3, 11) else "b1bd1af",
+                "627ee45" if sys.version_info >= (3, 11) else "206587e",
                 "canonical-helicity",
             ),
             (
-                "37510e8" if sys.version_info >= (3, 11) else "953baa2",
+                "422ec6b" if sys.version_info >= (3, 11) else "4c37f61",
                 "helicity",
             ),
         ],

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -94,9 +94,9 @@ def test_cache_to_disk_repairs_corrupt_file(
 @pytest.mark.parametrize(
     ("expected_hash", "assumptions"),
     [
-        ("a7559ca", dict()),
-        ("278bcee", dict(real=True)),
-        ("bc417f2", dict(rational=True)),
+        ("238baa6", dict()),
+        ("72a46dd", dict(real=True)),
+        ("f34cac7", dict(rational=True)),
     ],
     ids=["symbol", "symbol-real", "symbol-rational"],
 )
@@ -124,7 +124,7 @@ def test_get_readable_hash_energy_dependent_width():
         meson_radius=d,
     )
     h = get_readable_hash(expr)[:7]
-    assert h == "3d076c6"
+    assert h == "1b63a45"
 
 
 class TestLargeHash:
@@ -137,11 +137,11 @@ class TestLargeHash:
         ("expected_hash", "formalism"),
         [
             (
-                "762cc00" if sys.version_info >= (3, 11) else "1f5ac33",
+                "004ae36" if sys.version_info >= (3, 11) else "b1bd1af",
                 "canonical-helicity",
             ),
             (
-                "17fefe5" if sys.version_info >= (3, 11) else "7b5fad1",
+                "37510e8" if sys.version_info >= (3, 11) else "953baa2",
                 "helicity",
             ),
         ],
@@ -161,15 +161,15 @@ class TestLargeHash:
         assert h == expected_hash
 
     @pytest.mark.parametrize(
-        ("expected_hashes", "formalism"),
+        ("expected_hash", "formalism"),
         [
-            ({"2b77221", "8397450", "dc1ee0e"}, "canonical-helicity"),
-            ({"aced899", "cbd5ff0", "ceecb32"}, "helicity"),
+            ("6165ac0", "canonical-helicity"),
+            ("8f6174c", "helicity"),
         ],
         ids=["canonical-helicity", "helicity"],
     )
     @pytest.mark.slow
-    def test_amplitude_model(self, expected_hashes: set[str], formalism: SpinFormalism):
+    def test_amplitude_model(self, expected_hash: str, formalism: SpinFormalism):
         reaction = qrules.generate_transitions(
             initial_state=[("J/psi(1S)", [-1, 1])],
             final_state=["p~", "K0", "Sigma+"],
@@ -196,10 +196,9 @@ class TestLargeHash:
         assert any(isinstance(s, sp.Indexed) for s in intensity.free_symbols)
 
         intensity_hash = get_readable_hash(intensity)[:7]
-        assert intensity_hash in {"c83b853", "d113a38"}
+        assert intensity_hash == "1cd3567"
 
         amplitudes = frozendict({k: v.doit() for k, v in model.amplitudes.items()})
         unfolded_intensity = intensity.xreplace(amplitudes)
         unfolded_intensity_hash = get_readable_hash(unfolded_intensity)[:7]
-        assert unfolded_intensity_hash in expected_hashes
-        # Hash is not fully stable yet! See https://github.com/ComPWA/ampform-dpd/discussions/163
+        assert unfolded_intensity_hash == expected_hash

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -153,8 +153,8 @@ def describe_get_readable_hash():
         """Equal expressions must hash the same, however SymPy shared their parts.
 
         SymPy returns a cached instance for an equal expression, but its cache is a
-        bounded LRU, so an expression can end up with either one shared sub-expression or
-        two equal ones depending on what was built before it.
+        bounded LRU, so an expression can end up with either one shared sub-expression
+        or two equal ones depending on what was built before it.
         """
         x, y = sp.symbols("x y")
         shared = sp.sqrt(x**2 + y**2)

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import pickle
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from textwrap import dedent
 from threading import Event
 from typing import TYPE_CHECKING
 
@@ -132,14 +135,47 @@ def describe_get_readable_hash():
             ("a36cb47", b"raw bytes"),
             ("cb5e378", "a string"),
             ("dc0dafb", (1, "a", (2, 3))),
-            ("af94f10", frozendict({"b": 2, "a": 1})),
-            ("d7210d2", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
+            ("aeee3a6", frozenset({"a", "b", "c"})),
+            ("792a355", frozendict({"b": 2, "a": 1})),
+            ("1d60963", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
         ],
-        ids=["bytes", "str", "tuple", "frozendict", "nested"],
+        ids=["bytes", "str", "tuple", "frozenset", "frozendict", "nested"],
     )
     def it_hashes_containers(expected_hash: str, obj: Any):
-        """Pin the hashes of the container types that :func:`.to_bytes` is used on."""
+        """Pin the hashes of the containers that :func:`.to_bytes` sorts deterministically."""
         assert get_readable_hash(obj)[:7] == expected_hash
+
+    @pytest.mark.parametrize("seed", ["0", "1", "12345"])
+    def it_hashes_sets_identically_across_hash_seeds(seed: str):
+        """Sets and dicts must hash the same under any :code:`PYTHONHASHSEED`."""
+        source = dedent("""
+            from frozendict import frozendict
+
+            from ampform.sympy._cache import get_readable_hash
+
+            obj = frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
+            print(get_readable_hash(obj))
+        """)
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        output = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+            [sys.executable, "-c", source],
+            capture_output=True,
+            check=True,
+            env=env,
+            text=True,
+        )
+        assert output.stdout.strip() == get_readable_hash(
+            frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
+        )
+
+    def it_ignores_dict_insertion_order():
+        """Dictionaries that compare equal must hash the same, whatever their build order."""
+        keys = ("alpha", "beta", "gamma", "delta")
+        forward = frozendict({k: len(k) for k in keys})
+        backward = frozendict({k: len(k) for k in reversed(keys)})
+        assert forward == backward
+        assert tuple(forward) != tuple(backward)
+        assert get_readable_hash(forward) == get_readable_hash(backward)
 
 
 def describe_large_hash():
@@ -152,11 +188,11 @@ def describe_large_hash():
         ("expected_hash", "formalism"),
         [
             (
-                "627ee45" if sys.version_info >= (3, 11) else "206587e",
+                "004ae36" if sys.version_info >= (3, 11) else "b1bd1af",
                 "canonical-helicity",
             ),
             (
-                "422ec6b" if sys.version_info >= (3, 11) else "4c37f61",
+                "37510e8" if sys.version_info >= (3, 11) else "953baa2",
                 "helicity",
             ),
         ],

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import pickle
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from textwrap import dedent
 from threading import Event
 from typing import TYPE_CHECKING, ClassVar
 
@@ -202,3 +205,44 @@ class TestLargeHash:
         unfolded_intensity = intensity.xreplace(amplitudes)
         unfolded_intensity_hash = get_readable_hash(unfolded_intensity)[:7]
         assert unfolded_intensity_hash == expected_hash
+
+
+@pytest.mark.parametrize(
+    ("expected_hash", "obj"),
+    [
+        ("a36cb47", b"raw bytes"),
+        ("cb5e378", "a string"),
+        ("dc0dafb", (1, "a", (2, 3))),
+        ("aeee3a6", frozenset({"a", "b", "c"})),
+        ("792a355", frozendict({"b": 2, "a": 1})),
+        ("1d60963", frozendict({"x": frozenset({1, 2, 3}), "y": (4, 5)})),
+    ],
+    ids=["bytes", "str", "tuple", "frozenset", "frozendict", "nested"],
+)
+def test_get_readable_hash_containers(expected_hash: str, obj: Any):
+    """Pin the hashes of the containers that :func:`.to_bytes` sorts deterministically."""
+    assert get_readable_hash(obj)[:7] == expected_hash
+
+
+@pytest.mark.parametrize("seed", ["0", "1", "12345"])
+def test_get_readable_hash_independent_of_hash_seed(seed: str):
+    """Sets and dicts must hash the same under any :code:`PYTHONHASHSEED`."""
+    source = dedent("""
+        from frozendict import frozendict
+
+        from ampform.sympy._cache import get_readable_hash
+
+        obj = frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
+        print(get_readable_hash(obj))
+    """)
+    env = {**os.environ, "PYTHONHASHSEED": seed}
+    output = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+        [sys.executable, "-c", source],
+        capture_output=True,
+        check=True,
+        env=env,
+        text=True,
+    )
+    assert output.stdout.strip() == get_readable_hash(
+        frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
+    )

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -246,3 +246,13 @@ def test_get_readable_hash_independent_of_hash_seed(seed: str):
     assert output.stdout.strip() == get_readable_hash(
         frozendict({"x": frozenset({"a", "b", "c"}), "y": ("d", "e")})
     )
+
+
+def test_get_readable_hash_ignores_dict_insertion_order():
+    """Dictionaries that compare equal must hash the same, whatever their build order."""
+    keys = ("alpha", "beta", "gamma", "delta")
+    forward = frozendict({k: len(k) for k in keys})
+    backward = frozendict({k: len(k) for k in reversed(keys)})
+    assert forward == backward
+    assert tuple(forward) != tuple(backward)
+    assert get_readable_hash(forward) == get_readable_hash(backward)

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -11,13 +11,19 @@ import pytest
 import qrules
 import sympy as sp
 from frozendict import frozendict
+from sympy.core.cache import clear_cache
 
 import ampform
 from ampform._qrules import get_qrules_version
 from ampform.dynamics import EnergyDependentWidth
 from ampform.dynamics.builder import RelativisticBreitWignerBuilder
+from ampform.dynamics.phasespace import (
+    PhaseSpaceFactor,
+    PhaseSpaceFactorAbs,
+    PhaseSpaceFactorComplex,
+)
 from ampform.sympy import _cache
-from ampform.sympy._cache import cache_to_disk, get_readable_hash
+from ampform.sympy._cache import cache_to_disk, get_readable_hash, to_bytes
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,6 +33,8 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
     from _typeshed import SupportsWrite
     from qrules.transition import SpinFormalism
+
+    from ampform.dynamics.phasespace import PhaseSpaceFactorProtocol
 
 
 def describe_cache_to_disk():
@@ -140,6 +148,50 @@ def describe_get_readable_hash():
     def it_hashes_containers(expected_hash: str, obj: Any):
         """Pin the hashes of the container types that :func:`.to_bytes` is used on."""
         assert get_readable_hash(obj)[:7] == expected_hash
+
+    def it_ignores_how_sub_expressions_are_shared():
+        """Equal expressions must hash the same, however SymPy shared their parts.
+
+        SymPy returns a cached instance for an equal expression, but its cache is a
+        bounded LRU, so an expression can end up with either one shared sub-expression or
+        two equal ones depending on what was built before it.
+        """
+        x, y = sp.symbols("x y")
+        shared = sp.sqrt(x**2 + y**2)
+        with_one_instance = shared + y * shared
+        clear_cache()
+        duplicate = sp.sqrt(x**2 + y**2)
+        with_two_instances = shared + y * duplicate
+
+        assert with_one_instance == with_two_instances
+        assert to_bytes(with_one_instance) == to_bytes(with_two_instances)
+
+    def it_distinguishes_phase_space_factors():
+        """Arguments that are not sympified must still reach the hash."""
+        s, m0, w0, m_a, m_b, d = sp.symbols("s m0 Gamma0 m_a m_b d", nonnegative=True)
+        angular_momentum = sp.Symbol("L", integer=True)
+
+        def make_width(phsp_factor: PhaseSpaceFactorProtocol) -> EnergyDependentWidth:
+            return EnergyDependentWidth(
+                s=s,
+                mass0=m0,
+                gamma0=w0,
+                m_a=m_a,
+                m_b=m_b,
+                angular_momentum=angular_momentum,
+                meson_radius=d,
+                phsp_factor=phsp_factor,
+            )
+
+        hashes = {
+            get_readable_hash(make_width(phsp_factor))
+            for phsp_factor in (
+                PhaseSpaceFactor,
+                PhaseSpaceFactorAbs,
+                PhaseSpaceFactorComplex,
+            )
+        }
+        assert len(hashes) == 3
 
 
 def describe_large_hash():

--- a/tests/sympy/test_cache_helpers.py
+++ b/tests/sympy/test_cache_helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import pickle
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from textwrap import dedent
 from threading import Event
 from typing import TYPE_CHECKING
 
@@ -23,7 +26,12 @@ from ampform.dynamics.phasespace import (
     PhaseSpaceFactorComplex,
 )
 from ampform.sympy import _cache
-from ampform.sympy._cache import cache_to_disk, get_readable_hash, to_bytes
+from ampform.sympy._cache import (
+    cache_to_disk,
+    get_readable_hash,
+    make_hashable,
+    to_bytes,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -99,6 +107,39 @@ def describe_cache_to_disk():
         assert call_count == 2
 
 
+def describe_make_hashable():
+    def it_ignores_set_and_dict_order():
+        forward = make_hashable({"beta": {"b", "a"}, "alpha": {2, 1}})
+        backward = make_hashable({"alpha": {1, 2}, "beta": {"a", "b"}})
+        assert to_bytes(forward) == to_bytes(backward)
+
+    def it_sorts_items_of_mixed_types():
+        forward = make_hashable({1, "a", (2, 3)})
+        backward = make_hashable({(2, 3), "a", 1})
+        assert to_bytes(forward) == to_bytes(backward)
+
+    def it_distinguishes_a_set_from_a_sequence():
+        assert to_bytes(make_hashable({1, 2})) != to_bytes(make_hashable((1, 2)))
+
+    @pytest.mark.parametrize("seed", ["0", "1", "12345"])
+    def it_hashes_string_sets_identically_across_hash_seeds(seed: str):
+        obj = {"x": {"a", "b", "c"}, "y": ("d", "e")}
+        source = dedent("""
+            from ampform.sympy._cache import get_readable_hash, make_hashable
+
+            obj = {"x": {"a", "b", "c"}, "y": ("d", "e")}
+            print(get_readable_hash(make_hashable(obj)))
+        """)
+        output = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+            [sys.executable, "-c", source],
+            capture_output=True,
+            check=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+            text=True,
+        )
+        assert output.stdout.strip() == get_readable_hash(make_hashable(obj))
+
+
 def describe_get_readable_hash():
     @pytest.mark.parametrize(
         ("expected_hash", "assumptions"),
@@ -146,7 +187,6 @@ def describe_get_readable_hash():
         ids=["bytes", "str", "tuple", "frozendict", "nested"],
     )
     def it_hashes_containers(expected_hash: str, obj: Any):
-        """Pin the hashes of the container types that :func:`.to_bytes` is used on."""
         assert get_readable_hash(obj)[:7] == expected_hash
 
     def it_ignores_how_sub_expressions_are_shared():

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -105,7 +105,6 @@ def test_xreplace(
 
 def describe_sorted_frozendict():
     def it_ignores_substitution_order():
-        """Substitutions built in a different order must map to the same cache key."""
         expr = sp.sympify("a*sin(b) + c**2 + d/e + f")
         forward = {s: sp.Symbol(f"{s}_new") for s in sorted(expr.free_symbols, key=str)}
         backward = dict(reversed(list(forward.items())))
@@ -116,7 +115,6 @@ def describe_sorted_frozendict():
         )
 
     def it_orders_symbols_with_equal_sort_key():
-        """Symbols that differ only in their assumptions must still get a fixed order."""
         x = sp.Symbol("x")
         x_real = sp.Symbol("x", real=True)
         assert sp.default_sort_key(x) == sp.default_sort_key(x_real)

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -103,25 +103,25 @@ def test_xreplace(
     assert substituted_expr_2 == expected_expr
 
 
-def test_xreplace_ignores_substitution_order():
-    """Substitutions built in a different order must map to the same cache key."""
-    expr = sp.sympify("a*sin(b) + c**2 + d/e + f")
-    forward = {s: sp.Symbol(f"{s}_new") for s in sorted(expr.free_symbols, key=str)}
-    backward = dict(reversed(list(forward.items())))
-    assert tuple(forward) != tuple(backward)
-    assert to_bytes(frozendict(forward)) != to_bytes(frozendict(backward))
-    assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
-        _sorted_frozendict(backward)
-    )
+def describe_sorted_frozendict():
+    def it_ignores_substitution_order():
+        """Substitutions built in a different order must map to the same cache key."""
+        expr = sp.sympify("a*sin(b) + c**2 + d/e + f")
+        forward = {s: sp.Symbol(f"{s}_new") for s in sorted(expr.free_symbols, key=str)}
+        backward = dict(reversed(list(forward.items())))
+        assert tuple(forward) != tuple(backward)
+        assert to_bytes(frozendict(forward)) != to_bytes(frozendict(backward))
+        assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
+            _sorted_frozendict(backward)
+        )
 
-
-def test_xreplace_orders_symbols_with_equal_sort_key():
-    """Symbols that differ only in their assumptions must still get a fixed order."""
-    x = sp.Symbol("x")
-    x_real = sp.Symbol("x", real=True)
-    assert sp.default_sort_key(x) == sp.default_sort_key(x_real)
-    forward = {x: 1, x_real: 2}
-    backward = {x_real: 2, x: 1}
-    assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
-        _sorted_frozendict(backward)
-    )
+    def it_orders_symbols_with_equal_sort_key():
+        """Symbols that differ only in their assumptions must still get a fixed order."""
+        x = sp.Symbol("x")
+        x_real = sp.Symbol("x", real=True)
+        assert sp.default_sort_key(x) == sp.default_sort_key(x_real)
+        forward = {x: 1, x_real: 2}
+        backward = {x_real: 2, x: 1}
+        assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
+            _sorted_frozendict(backward)
+        )

--- a/tests/sympy/test_cached.py
+++ b/tests/sympy/test_cached.py
@@ -5,8 +5,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 import sympy as sp
+from frozendict import frozendict
 
 from ampform.sympy import cached
+from ampform.sympy._cache import to_bytes
+from ampform.sympy.cached import _sorted_frozendict
 
 if TYPE_CHECKING:
     from ampform.helicity import HelicityModel
@@ -98,3 +101,27 @@ def test_xreplace(
     assert substituted_expr_1 == expected_expr
     substituted_expr_2 = cached_func(full_expression, substitutions)
     assert substituted_expr_2 == expected_expr
+
+
+def test_xreplace_ignores_substitution_order():
+    """Substitutions built in a different order must map to the same cache key."""
+    expr = sp.sympify("a*sin(b) + c**2 + d/e + f")
+    forward = {s: sp.Symbol(f"{s}_new") for s in sorted(expr.free_symbols, key=str)}
+    backward = dict(reversed(list(forward.items())))
+    assert tuple(forward) != tuple(backward)
+    assert to_bytes(frozendict(forward)) != to_bytes(frozendict(backward))
+    assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
+        _sorted_frozendict(backward)
+    )
+
+
+def test_xreplace_orders_symbols_with_equal_sort_key():
+    """Symbols that differ only in their assumptions must still get a fixed order."""
+    x = sp.Symbol("x")
+    x_real = sp.Symbol("x", real=True)
+    assert sp.default_sort_key(x) == sp.default_sort_key(x_real)
+    forward = {x: 1, x_real: 2}
+    backward = {x_real: 2, x: 1}
+    assert to_bytes(_sorted_frozendict(forward)) == to_bytes(
+        _sorted_frozendict(backward)
+    )


### PR DESCRIPTION
Closes #514 

## 🐛 Bug fixes

- Expression hashes no longer depend on SymPy cache state. A pickle stores a repeated object as a back-reference keyed on identity, and SymPy's instance cache is a bounded LRU, so whether two equal sub-expressions were the *same* instance used to leak into the hash. `to_bytes` now pickles through a `_DeterministicPickler` that maps equal `sympy.Basic` objects onto one representative and memoizes only those, so equal expressions hash identically regardless of what was constructed before them or in which process.
- `cached.subs`, `cached.xreplace` and `cached.unfold` sort the substitution mapping they are given before building the cache key. A mapping built by iterating over `free_symbols` inherits the order of a `set`, which depends on `PYTHONHASHSEED`, so the same substitutions previously produced a different cache key in every process. Symbols that differ only in their assumptions share a `default_sort_key`, so `srepr` breaks those ties.
- `make_hashable` puts sets and dictionaries in a fixed order instead of relying on iteration order. A `frozenset` pickles in iteration order, which depends on `PYTHONHASHSEED` for `str` elements, so a cache key built from one differed in every process. Sets now become a `_SortedSet` (a named tuple, so it cannot pass for a plain `tuple`) and dictionary keys are sorted, with a fallback to sorting on the serialized items when the elements cannot be compared to each other.

## ❗ Behavioral changes

- All readable hashes change, since the pickled bytes changed. Disk caches written by earlier versions are invalidated and will be recomputed on first use.
- Amplitude-model hashes are now stable across processes and Python invocations, so the tests that previously accepted a set of possible hashes now pin a single value per formalism.

## Squash commit messages

```text
* DOC: document hash stability on the public interface
* FIX: make expression hashes independent of SymPy cache state
* FIX: put sets and dicts in a fixed order in make_hashable
* FIX: sort substitution mappings in cached wrappers
* MAINT: hash pickled bytes directly into the digest
* MAINT: use positional-only arguments and type variables
```
